### PR TITLE
fix(data/mmcif/input): hide pydantic dataclasses from type checkers

### DIFF
--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -5,12 +5,12 @@ import logging
 from collections.abc import Set
 from dataclasses import InitVar, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import networkx as nx
 import numpy as np
 from numpy.typing import NDArray
 from pydantic import ConfigDict, TypeAdapter
-from pydantic.dataclasses import dataclass
 from rdkit import Chem
 from scipy.spatial import distance as D
 
@@ -38,6 +38,11 @@ from .smiles import (
     reference_from_mmcif,
     unique_atom_id,
 )
+
+if TYPE_CHECKING:
+    from dataclasses import dataclass
+else:
+    from pydantic.dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +193,7 @@ class BondClass(enum.IntEnum):
         return mapping.get(conn_type.lower(), cls.unknown)
 
 
-@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+@dataclass
 class PolymerChain:
     mol_type: MolType
 
@@ -209,11 +214,13 @@ class PolymerChain:
     # [N_res]
     residue_ids: list[ResidueId | None]
 
+    __pydantic_config__ = ConfigDict(arbitrary_types_allowed=True)
+
     def __len__(self):
         return len(self.restype)
 
 
-@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+@dataclass
 class NonPolymerLigand:
     entity_id: str
     chain_id: str
@@ -224,6 +231,8 @@ class NonPolymerLigand:
     atom_ids: NDArray[np.str_]
     # [N_atom, 3]
     atom_coords: NDArray[np.float64]
+
+    __pydantic_config__ = ConfigDict(arbitrary_types_allowed=True)
 
 
 @dataclass(order=True, frozen=True)


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to dataclass imports and pydantic configuration; main risk is subtle differences in pydantic dataclass config handling at runtime.
> 
> **Overview**
> Updates `mmcif/input.py` to conditionally import `dataclass` from stdlib during `TYPE_CHECKING`, avoiding exposing `pydantic.dataclasses` to type checkers.
> 
> Refactors `PolymerChain` and `NonPolymerLigand` to move `ConfigDict(arbitrary_types_allowed=True)` from the decorator into `__pydantic_config__`, preserving runtime behavior while improving typing/tooling compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7109c4ad731538ef3998b11d714a095de046c751. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->