### PR TITLE
feat(data/mmcif/smiles): filter out isolated hydrogen atoms during molecule processing

### DIFF
--- a/src/gmol/base/data/mmcif/smiles.py
+++ b/src/gmol/base/data/mmcif/smiles.py
@@ -35,8 +35,16 @@ def mol_from_chem_comp(
 
     rw_mol = Chem.RWMol()
 
+    bond_ids = {b.atom_id_1 for b in bonds} | {b.atom_id_2 for b in bonds}
+
     atom_id_to_index: dict[str, int] = {}
     for atom_data in atoms:
+        # Some entries produce isolated explicit H atoms during processing.
+        # RemoveHs() cannot delete degree-0 H atoms and emits warnings, so
+        # drop them here when the bond/heavy-atom partner is missing.
+        if atom_data.type_symbol == "H" and atom_data.atom_id not in bond_ids:
+            continue
+
         atom = Chem.Atom(atom_data.type_symbol)
         atom.SetProp("atom_id", atom_data.atom_id)
         atom.SetIsAromatic(atom_data.pdbx_aromatic_flag)


### PR DESCRIPTION
…lecule processing

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->
몇몇 case에서 (e.g. 5hvh.cif) Ligand 합쳐지면서 bond 없는 hydrogen 생기는데, casp-pipe에서 따로 처리했다가 warning 때문에 수정했습니다. 좀 아쉬운건 더 위에서 (atoms: list[ChemCompAtom], bonds: list[ChemCompBond]) 처리해야하나 싶긴 하네요. (input.py 건드려야하나 싶은데, 완전히 구조를 이해하진 못했습니다)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to ligand molecule construction; risk is limited to potentially dropping legitimate unbonded H atoms in edge-case mmCIF entries.
> 
> **Overview**
> Filters out explicit hydrogen atoms that have no corresponding bond entries when building RDKit molecules in `mol_from_chem_comp`, by precomputing bonded atom IDs and skipping degree-0 H atoms.
> 
> This avoids RDKit `RemoveHs()` warnings/errors caused by isolated hydrogens produced during ligand assembly, without changing handling of bonded atoms/bonds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d331eaf44e70be509aa8bc6d208682dfd1b4383. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->