### PR TITLE
feat(data/mmcif): downgrade duplicate bond warning to debug message

### DIFF
--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -839,7 +839,8 @@ def build_input(
     mmcif_bond_index = {_bond_as_key(bond): bond for bond in explicit_bonds}
     for bond in new_bonds_for_modres:
         if _bond_as_key(bond) in mmcif_bond_index:
-            logger.warning("Duplicate bond: %s", bond)
+            # See seoklab/gmol-base#9 for context.
+            logger.debug("Duplicate bond: %s", bond)
         else:
             explicit_bonds.append(bond)
 


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Resolves (partially) #9.

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; does not alter bond merging behavior or data output, but may hide a potentially useful warning in default logs.
> 
> **Overview**
> Reduces log noise during mmCIF input construction by downgrading the "Duplicate bond" message (when merging modified-residue bonds with explicit `process_connections` bonds) from `logger.warning` to `logger.debug`, with an added comment referencing issue context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7246696018b4bb05cc9587c030ff1995a187eae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->