### PR TITLE
fix(data/mmcif/smiles): don't select bond partner as `StereoAtom`

### DIFF
--- a/src/gmol/base/data/mmcif/smiles.py
+++ b/src/gmol/base/data/mmcif/smiles.py
@@ -86,12 +86,22 @@ def mol_from_chem_comp(
             continue
         if bond.GetBondType() != Chem.BondType.DOUBLE:
             continue
-        # Select any configuration and neighbors, will be corrected below
+
+        # Skip stereo bonds with insufficient substituent neighbors
+        a = bond.GetBeginAtom()
+        b = bond.GetEndAtom()
+        a_subs = [
+            n.GetIdx() for n in a.GetNeighbors() if n.GetIdx() != b.GetIdx()
+        ]
+        b_subs = [
+            n.GetIdx() for n in b.GetNeighbors() if n.GetIdx() != a.GetIdx()
+        ]
+        if not a_subs or not b_subs:
+            continue
+
         bond.SetStereo(Chem.BondStereo.STEREOE)
-        ni = bond.GetBeginAtom().GetNeighbors()[0].GetIdx()
-        nj = bond.GetEndAtom().GetNeighbors()[0].GetIdx()
         # Required, set which neighbor is the "stereo atom".
-        bond.SetStereoAtoms(ni, nj)
+        bond.SetStereoAtoms(a_subs[0], b_subs[0])
 
     # Required, if not specified, resulting smiles omits E/Z stereochemistry
     Chem.AssignStereochemistry(mol, force=True)

--- a/src/gmol/base/data/mmcif/smiles.py
+++ b/src/gmol/base/data/mmcif/smiles.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 
 import networkx as nx
@@ -8,6 +9,8 @@ from rdkit import Chem
 from gmol.base.wrapper.rdkit import smi2mol
 from .assembly import Branch, ResidueId
 from .parse import ChemComp, ChemCompAtom, ChemCompBond
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -97,6 +100,15 @@ def mol_from_chem_comp(
             n.GetIdx() for n in b.GetNeighbors() if n.GetIdx() != a.GetIdx()
         ]
         if not a_subs or not b_subs:
+            _logger.warning(
+                (
+                    "Invalid bond stereo config: bond %d (%d-%d) has "
+                    "absolute_config but insufficient neighbors"
+                ),
+                bond.GetIdx(),
+                a.GetIdx(),
+                b.GetIdx(),
+            )
             continue
 
         bond.SetStereo(Chem.BondStereo.STEREOE)


### PR DESCRIPTION
…nt neighbors

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Resolves seoklab/casp-pipe#7.

---

<!-- Start the description of the PR here -->
Covalent 리간드이면서 공유결합 부분 때문에 말단 이중결합이 생기면, 여기서 (`Chem.AssignStereochemistry(mol, force=True)`) 그냥 넘어가고, `Chem.AssignCIPLabels(mol, chiral_atoms, configured_bonds)` 에서 segfault 되는 것 같습니다.

https://github.com/seoklab/gmol-base/blob/31dd926f1831244c93d3a3113b4f33b03fb62b65/src/gmol/base/data/mmcif/smiles.py#L82-L109