### PR TITLE
fix(assembly): add DNA/RNA support to to_fasta method

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -11,7 +11,12 @@ from typing import ClassVar, Protocol
 import numpy as np
 from numpy.typing import NDArray
 
-from gmol.base.const import aa_restype_3to1, modres
+from gmol.base.const import (
+    aa_restype_3to1,
+    dna_restype_3to1,
+    modres,
+    rna_restype_3to1,
+)
 from .parse import (
     AtomSite,
     BioAssembly,
@@ -1275,12 +1280,21 @@ class Assembly:
     def to_fasta(self, name: str) -> str:
         fastas: list[str] = []
         for chain_id, chain in self.chains.items():
-            if chain.type != MolType.Protein:
+            if not chain.type.is_polymer:
                 continue
+
             seq_list = []
             for seqres in chain.seqres:
-                comp_id = modres.get(seqres.comp_id, seqres.comp_id)
-                seq_list.append(aa_restype_3to1.get(comp_id, "X"))
+                comp_id = seqres.comp_id
+
+                if chain.type == MolType.Protein:
+                    comp_id = modres.get(comp_id, comp_id)
+                    seq_list.append(aa_restype_3to1.get(comp_id, "X"))
+                elif chain.type == MolType.DNA:
+                    seq_list.append(dna_restype_3to1.get(comp_id, "N"))
+                elif chain.type == MolType.RNA:
+                    seq_list.append(rna_restype_3to1.get(comp_id, "N"))
+
             seq = "".join(seq_list)
             fastas.append(f">{name}_{chain_id}\n{seq}\n")
         return "".join(fastas)


### PR DESCRIPTION
casp data 만들 때 assembly.to_fasta() method 쓰는데 
DNA, RNA 지원 안 되어서 추가합니다!

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to sequence export plus additive tests/fixtures; low risk aside from potential edge cases in residue ID mapping for nucleic acids.
> 
> **Overview**
> `Assembly.to_fasta()` now generates FASTA output for **all polymer chains** (`Protein`, `DNA`, `RNA`) instead of protein-only, using new `dna_restype_3to1`/`rna_restype_3to1` mappings (defaulting unknown bases to `N`) while preserving protein `modres` handling.
> 
> Adds pytest coverage for protein/DNA/RNA FASTA generation and introduces new mmCIF/CCD test fixtures (notably `tests/test_data/mmcif/1bna.cif` and additional nucleotide components in `components_stdres.cif`) to support the new cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fb02ed172cfa15325135f78f240f983aa5443ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->