### PR TITLE
fix(data/mmcif/assembly): avoid numpy types

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -298,6 +298,11 @@ class AssemblyConnection:
     conn_type: str
     leaving_atom_count: int
 
+    def __post_init__(self):
+        self.src_idx = int(self.src_idx)
+        self.dst_idx = int(self.dst_idx)
+        self.leaving_atom_count = int(self.leaving_atom_count)
+
     def remap(self, idx_map: _IndexMapper):
         return AssemblyConnection(
             src_idx=idx_map[self.src_idx],


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny, localized type-coercion change in a dataclass; behavior should only differ when inputs are numpy scalars or other int-like types.
> 
> **Overview**
> Ensures `AssemblyConnection` fields (`src_idx`, `dst_idx`, `leaving_atom_count`) are coerced to built-in `int` via `__post_init__`, avoiding propagation of numpy scalar types into connection objects (and downstream serialization/mapping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd0b97c106845bb272cb0fa700160f97354f6370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->