### PR TITLE
refactor(data/mmcif): avoid mmcif metadata

### DIFF
--- a/src/gmol/base/data/mmcif/filter.py
+++ b/src/gmol/base/data/mmcif/filter.py
@@ -13,7 +13,7 @@ from gmol.base.const import (
     aa_restype_3to1,
 )
 from .assembly import Assembly, AssemblyAtom, MolType, Residue
-from .parse import ChemComp, Mmcif
+from .parse import ChemComp
 
 __all__ = ["filter_mmcif", "filter_structure"]
 
@@ -311,7 +311,6 @@ def filter_structure(
 
 
 def filter_mmcif(
-    metadata: Mmcif,
     assembly: Assembly,
     chem_comp_dict: dict[str, ChemComp],
     cutoff_date: dt.date = dt.date(2021, 9, 30),
@@ -320,15 +319,15 @@ def filter_mmcif(
     is_test: bool = False,
 ) -> Assembly | None:
     if not (
-        metadata.revision_date < cutoff_date
-        and metadata.resolution < max_resolution
+        assembly.metadata.revision_date < cutoff_date
+        and assembly.metadata.resolution < max_resolution
         and assembly.count_polymer_chains() <= max_chains
     ):
         return None
 
     mask = filter_structure(
         assembly,
-        metadata.exptl_method,
+        assembly.metadata.exptl_method,
         chem_comp_dict,
         is_test,
     )

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -28,7 +28,6 @@ from .parse import (
     ChemComp,
     ChemCompAtom,
     ChemCompBond,
-    Mmcif,
     load_mmcif_single,
 )
 from .smiles import (
@@ -807,7 +806,6 @@ def _bond_as_key(bond: ExtraBond):
 
 def build_input(
     assembly: Assembly,
-    metadata: Mmcif,
     ccd: dict[str, ChemComp],
     split_modified: bool = False,
     well_known_atoms: Set[str] = frozenset({"OXT", "HXT"}),
@@ -848,8 +846,8 @@ def build_input(
         polymers=polymers_all,
         ligands=non_polymers_all,
         extra_bonds=explicit_bonds,
-        release_date=metadata.revision_date,
-        resolution=metadata.resolution,
+        release_date=assembly.metadata.revision_date,
+        resolution=assembly.metadata.resolution,
         is_distillation=False,
     )
 
@@ -860,14 +858,11 @@ def build_input_from_mmcif(
 ) -> Input | None:
     metadata = load_mmcif_single(Path(mmcif_path))
     assemblies = mmcif_assemblies(metadata, ccd_comp)
-    filtered_assembly = filter_mmcif(metadata, assemblies[0], ccd_comp)
+    filtered_assembly = filter_mmcif(assemblies[0], ccd_comp)
+
     if filtered_assembly is not None:
-        try:
-            return build_input(
-                filtered_assembly, metadata, ccd_comp, split_modified=False
-            )
-        except Exception as e:
-            raise e
+        return build_input(filtered_assembly, ccd_comp, split_modified=False)
+
     return None
 
 

--- a/tests/data/mmcif/conftest.py
+++ b/tests/data/mmcif/conftest.py
@@ -22,4 +22,4 @@ def sample_assembly(test_data: Path, ccd_components: dict[str, ChemComp]):
     data = load_mmcif_single(mmcif)
     assemblies = mmcif_assemblies(data, ccd_components)
     assert len(assemblies) == 1
-    return data, assemblies[0]
+    return assemblies[0]

--- a/tests/data/mmcif/filter_test.py
+++ b/tests/data/mmcif/filter_test.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pytest
 
-from gmol.base.data.mmcif import Assembly, ChemComp, Mmcif, filter_mmcif
+from gmol.base.data.mmcif import Assembly, ChemComp, filter_mmcif
 
 
 def test_filter_mmcif(
     ccd_components: dict[str, ChemComp],
-    sample_assembly: tuple[Mmcif, Assembly],
+    sample_assembly: Assembly,
 ):
-    result = filter_mmcif(*sample_assembly, ccd_components)
+    result = filter_mmcif(sample_assembly, ccd_components)
     if result is None:
         pytest.skip("target did not pass pre-filter")
 

--- a/tests/data/mmcif/input_test.py
+++ b/tests/data/mmcif/input_test.py
@@ -39,11 +39,11 @@ def _load_input(
     assert len(assemblies) == 1
 
     result = filter_mmcif(
-        data, assemblies[0], ccd, cutoff_date=dt.date(9999, 12, 31)
+        assemblies[0], ccd, cutoff_date=dt.date(9999, 12, 31)
     )
     assert result is not None
 
-    input_data = build_input(result, data, ccd, split_modified=split)
+    input_data = build_input(result, ccd, split_modified=split)
     return input_data
 
 

--- a/tests/data/mmcif/pdb_test.py
+++ b/tests/data/mmcif/pdb_test.py
@@ -1,14 +1,13 @@
 import nuri
 
-from gmol.base.data.mmcif import Assembly, Mmcif
+from gmol.base.data.mmcif import Assembly
 
 
-def test_to_pdb(sample_assembly: tuple[Mmcif, Assembly]):
-    _, assembly = sample_assembly
-    result = assembly.to_pdb()
+def test_to_pdb(sample_assembly: Assembly):
+    result = sample_assembly.to_pdb()
 
     mols = list(nuri.readstring("pdb", result, sanitize=False))
     assert len(mols) == 1
 
     mol = mols[0]
-    assert len(mol) == len(assembly.atoms)
+    assert len(mol) == len(sample_assembly.atoms)

--- a/tests/data/mmcif/save_test.py
+++ b/tests/data/mmcif/save_test.py
@@ -1,10 +1,8 @@
-from gmol.base.data.mmcif import Assembly, Mmcif
+from gmol.base.data.mmcif import Assembly
 
 
-def test_save_load(sample_assembly: tuple[Mmcif, Assembly]):
-    _, assembly = sample_assembly
-
-    j1 = assembly.model_dump_json(indent=2)
+def test_save_load(sample_assembly: Assembly):
+    j1 = sample_assembly.model_dump_json(indent=2)
     data = Assembly.model_validate_json(j1)
 
     j2 = data.model_dump_json(indent=2)


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to public API signature changes (`filter_mmcif`/`build_input`) that can break downstream callers and subtly alter behavior if `Assembly.metadata` diverges from the original `Mmcif` metadata.
> 
> **Overview**
> Refactors mmCIF processing to stop passing around raw `Mmcif` metadata: `filter_mmcif` and `build_input` now read `revision_date`, `resolution`, and `exptl_method` from `assembly.metadata` instead of separate `Mmcif` arguments.
> 
> Updates `build_input_from_mmcif` and test fixtures/call sites to match the new function signatures, removing redundant metadata threading and simplifying the input build path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4dcdde60fba7bd4f943e168b1cde1d245fdfdce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->