### PR TITLE
feat(data/seq/mmseqs): allow temp directory customization

### DIFF
--- a/src/gmol/base/data/seq/mmseqs_search.py
+++ b/src/gmol/base/data/seq/mmseqs_search.py
@@ -600,6 +600,7 @@ def mmseqs_search_monomer(
     qdb: Path,
     output_dir: Path,
     params: MMseqsMonomerSearchParams,
+    temp_base: Path | None = None,
 ):
     """
     Run mmseqs with a local colabfold database set
@@ -612,7 +613,7 @@ def mmseqs_search_monomer(
 
     output_dir.mkdir(exist_ok=True, parents=True)
 
-    with TemporaryDirectory() as tmpd:
+    with TemporaryDirectory(dir=temp_base) as tmpd:
         base = Path(tmpd)
 
         mmseqs.search(
@@ -778,10 +779,11 @@ def mmseqs_search_pair(
     output_dir: Path,
     params: MMseqsPairSearchParams,
     unpack_suffix: str,
+    temp_base: Path | None = None,
 ) -> None:
     p = params
 
-    with TemporaryDirectory() as tmpd:
+    with TemporaryDirectory(dir=temp_base) as tmpd:
         base = Path(tmpd)
 
         mmseqs.search(
@@ -862,6 +864,7 @@ def run_search_from_path(
     output_dir: Path,
     threads: int = 1,
     mmseqs: str | Path = "mmseqs",
+    temp_base: Path | None = None,
     *,
     monomer_params: MMseqsMonomerSearchParams,
     pair_params: MMseqsPairSearchParams,
@@ -911,6 +914,7 @@ def run_search_from_path(
         output_dir / "qdb",
         output_dir,
         monomer_params,
+        temp_base,
     )
 
     if any(q.heteromer for q in queries_unique):
@@ -920,6 +924,7 @@ def run_search_from_path(
             output_dir,
             pair_params,
             ".paired.a3m",
+            temp_base,
         )
         if env_pair_params is not None:
             mmseqs_search_pair(
@@ -928,6 +933,7 @@ def run_search_from_path(
                 output_dir,
                 env_pair_params,
                 ".env.paired.a3m",
+                temp_base,
             )
 
     for q, sids in zip(queries_unique, sid_by_query):


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: the change only threads an optional `temp_base` path into `TemporaryDirectory` creation, affecting where intermediate files are written but not the MMseqs search logic itself.
> 
> **Overview**
> Adds an optional `temp_base: Path | None` parameter to the MMseqs search entrypoints and passes it through to `TemporaryDirectory(dir=...)` so callers can control where intermediate MMseqs working directories are created.
> 
> Updates `run_search_from_path` to propagate this option to both monomer and paired searches, enabling customization of temp location without changing outputs or search parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c4aca8096d5cd8e2d4a9a8ad4ef63f42ee36401. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->