### PR TITLE
feat(b-factor): add b-factor feat to Assembly, NonPolymerLigand, Poly…

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -1,5 +1,6 @@
 import enum
 import itertools
+import math
 from collections import defaultdict
 from collections.abc import Iterable
 from copy import deepcopy
@@ -260,7 +261,7 @@ class AssemblyAtom:
     comp_id: str
 
     occupancy: float
-    b_factor: float | None = None
+    b_factor: float
 
     @property
     def chain_id(self) -> str:
@@ -371,7 +372,7 @@ class _PdbAtom:
         assert len(self.element) <= 2
 
     def to_pdb_line(self, serial: int):
-        b = 0.0 if self.b_factor is None else float(self.b_factor)
+        b = self.b_factor if math.isfinite(self.b_factor) else 0.0
         return (
             # 1-21
             f"{self.record}{serial:>5} {self.name} {self.res_name:>3} "
@@ -1363,7 +1364,7 @@ class Assembly(LooseModel):
                     coords=self.coords[atom.atom_idx],
                     element=atom.type_symbol,
                     occupancy=atom.occupancy,
-                    b_factor=atom.b_factor or 0.0,
+                    b_factor=atom.b_factor,
                 )
             )
 

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -260,6 +260,7 @@ class AssemblyAtom:
     comp_id: str
 
     occupancy: float
+    b_factor: float | None = None
 
     @property
     def chain_id(self) -> str:
@@ -273,6 +274,7 @@ class AssemblyAtom:
             atom_id=self.atom_id,
             comp_id=self.comp_id,
             occupancy=self.occupancy,
+            b_factor=self.b_factor,
         )
 
     def with_updates(self, idx: int, chain_suffix: str):
@@ -283,6 +285,7 @@ class AssemblyAtom:
             atom_id=self.atom_id,
             comp_id=self.comp_id,
             occupancy=self.occupancy,
+            b_factor=self.b_factor,
         )
 
 
@@ -357,6 +360,7 @@ class _PdbAtom:
     coords: NDArray[np.float64]
     element: str
     occupancy: float
+    b_factor: float
 
     def __post_init__(self):
         assert len(self.record) == 6
@@ -367,6 +371,7 @@ class _PdbAtom:
         assert len(self.element) <= 2
 
     def to_pdb_line(self, serial: int):
+        b = 0.0 if self.b_factor is None else float(self.b_factor)
         return (
             # 1-21
             f"{self.record}{serial:>5} {self.name} {self.res_name:>3} "
@@ -376,7 +381,7 @@ class _PdbAtom:
             f"   {self.coords[0]:>8.3f}{self.coords[1]:>8.3f}{self.coords[2]:>8.3f}"
             #                       6         7
             #                       12345678901234567
-            f"{self.occupancy:>6.2f}  0.00          {self.element.upper():>2}  "
+            f"{self.occupancy:>6.2f}{b:>6.2f}          {self.element.upper():>2}  "
         )
 
 
@@ -1358,6 +1363,7 @@ class Assembly(LooseModel):
                     coords=self.coords[atom.atom_idx],
                     element=atom.type_symbol,
                     occupancy=atom.occupancy,
+                    b_factor=atom.b_factor or 0.0,
                 )
             )
 
@@ -1607,6 +1613,7 @@ def _model_assembly(
             atom_id=atom_site.label_atom_id,
             comp_id=atom_site.label_comp_id,
             occupancy=atom_site.occupancy,
+            b_factor=atom_site.b_iso_or_equiv,
         )
         for i, atom_site in enumerate(atom_sites)
     ]

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -237,7 +237,7 @@ class NonPolymerLigand:
 
     # [N_atom]
     # Temperature factor (B-factor) aligned with atom_ids. Missing values are NaN.
-    atom_b_factors: NDArray[np.float64] | None = None
+    atom_b_factors: NDArray[np.float64]
 
     __pydantic_config__ = ConfigDict(arbitrary_types_allowed=True)
 
@@ -299,39 +299,12 @@ class Input:
     is_distillation: bool
 
 
-def build_atom_coords_from_ref(
+def _build_atom_data_from_ref(
     assembly: Assembly,
     residues: list[Residue],
     ref_ligand: RefLigandInput,
-) -> NDArray[np.float64]:
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     coords = np.full((len(ref_ligand.atom_ids), 3), np.nan, dtype=np.float64)
-
-    if len(residues) == 1:
-
-        def resolve_atom_id(residue_id: ResidueId, atom_id: str):
-            return atom_id
-    else:
-
-        def resolve_atom_id(residue_id: ResidueId, atom_id: str):
-            return unique_atom_id(residue_id, atom_id)
-
-    aid_to_index = {aid: i for i, aid in enumerate(ref_ligand.atom_ids)}
-    for residue in residues:
-        for atom in assembly.atoms_of_residue(residue):
-            atom_id = resolve_atom_id(residue.residue_id, atom.atom_id)
-            if atom_id not in aid_to_index:
-                continue
-
-            coords[aid_to_index[atom_id]] = assembly.coords[atom.atom_idx]
-
-    return coords
-
-
-def build_atom_b_factors_from_ref(
-    assembly: Assembly,
-    residues: list[Residue],
-    ref_ligand: RefLigandInput,
-) -> NDArray[np.float64]:
     b_factors = np.full((len(ref_ligand.atom_ids),), np.nan, dtype=np.float64)
 
     if len(residues) == 1:
@@ -350,17 +323,16 @@ def build_atom_b_factors_from_ref(
             if atom_id not in aid_to_index:
                 continue
 
-            val = atom.b_factor
-            b_factors[aid_to_index[atom_id]] = (
-                np.nan if val is None else float(val)
-            )
+            idx = aid_to_index[atom_id]
+            coords[idx] = assembly.coords[atom.atom_idx]
+            b_factors[idx] = atom.b_factor
 
-    return b_factors
+    return coords, b_factors
 
 
 def _update_polymer_residue_coords(
     coords: NDArray[np.float64],
-    b_factors: NDArray[np.float64] | None,
+    b_factors: NDArray[np.float64],
     assembly: Assembly,
     residue: Residue,
     polymer_consts: PolymerConstants,
@@ -379,12 +351,9 @@ def _update_polymer_residue_coords(
 
     for atom in assembly.atoms_of_residue(residue):
         try:
-            coords[atom_idxs[atom.atom_id]] = assembly.coords[atom.atom_idx]
-            if b_factors is not None:
-                val = atom.b_factor
-                b_factors[atom_idxs[atom.atom_id]] = (
-                    np.nan if val is None else float(val)
-                )
+            idx = atom_idxs[atom.atom_id]
+            coords[idx] = assembly.coords[atom.atom_idx]
+            b_factors[idx] = atom.b_factor
         except KeyError:
             if atom.atom_id not in well_known_atoms:
                 logger.warning(
@@ -407,8 +376,7 @@ def _update_polymer_residue_coords(
     dsq_nh2 = D.sqeuclidean(cd_nh1_nh2[0], cd_nh1_nh2[2])
     if dsq_nh1 > dsq_nh2:
         coords[[j, i]] = cd_nh1_nh2[1:]
-        if b_factors is not None:
-            b_factors[[j, i]] = b_factors[[i, j]]
+        b_factors[[j, i]] = b_factors[[i, j]]
 
 
 def _add_implicit_bb_bonds(
@@ -472,12 +440,7 @@ def _modres_as_ligand(
 ):
     ref_mmcif = MmcifRefLigand(chem_comp.atoms, chem_comp.bonds)
     ref_ligand = input_from_reference(ref_mmcif)
-    crd = build_atom_coords_from_ref(
-        assembly,
-        [] if resid is None else [assembly.residues[resid]],
-        ref_ligand,
-    )
-    bfs = build_atom_b_factors_from_ref(
+    crd, bfs = _build_atom_data_from_ref(
         assembly,
         [] if resid is None else [assembly.residues[resid]],
         ref_ligand,
@@ -599,12 +562,7 @@ def _build_sc_ligand(
 ) -> NonPolymerLigand:
     ref_mmcif = MmcifRefLigand(sc_frag.atoms, sc_frag.bonds)
     ref_ligand = input_from_reference(ref_mmcif)
-    crd = build_atom_coords_from_ref(
-        assembly,
-        [] if resid is None else [assembly.residues[resid]],
-        ref_ligand,
-    )
-    bfs = build_atom_b_factors_from_ref(
+    crd, bfs = _build_atom_data_from_ref(
         assembly,
         [] if resid is None else [assembly.residues[resid]],
         ref_ligand,
@@ -777,8 +735,7 @@ def process_ligand_chain(assembly: Assembly, chain: Chain):
     ]
     lig = input_from_reference(reference_from_mmcif(ccs, chain.branches))
     residues = [assembly.residues[rid] for rid, _ in ccs]
-    coords = build_atom_coords_from_ref(assembly, residues, lig)
-    b_factors = build_atom_b_factors_from_ref(assembly, residues, lig)
+    coords, b_factors = _build_atom_data_from_ref(assembly, residues, lig)
 
     return NonPolymerLigand(
         chain_id=chain.chain_id,

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -209,6 +209,10 @@ class PolymerChain:
     # [N_res, N_atom_type, 3]
     atom_coords: NDArray[np.float64]
 
+    # [N_res, N_atom_type]
+    # Temperature factor (B-factor) aligned with atom_coords. Missing values are NaN.
+    atom_b_factors: NDArray[np.float64]
+
     # Below is for reference, not used in input
     # [N_res]
     residue_ids: list[ResidueId | None]
@@ -230,6 +234,10 @@ class NonPolymerLigand:
     atom_ids: NDArray[np.str_]
     # [N_atom, 3]
     atom_coords: NDArray[np.float64]
+
+    # [N_atom]
+    # Temperature factor (B-factor) aligned with atom_ids. Missing values are NaN.
+    atom_b_factors: NDArray[np.float64] | None = None
 
     __pydantic_config__ = ConfigDict(arbitrary_types_allowed=True)
 
@@ -319,8 +327,40 @@ def build_atom_coords_from_ref(
     return coords
 
 
+def build_atom_b_factors_from_ref(
+    assembly: Assembly,
+    residues: list[Residue],
+    ref_ligand: RefLigandInput,
+) -> NDArray[np.float64]:
+    b_factors = np.full((len(ref_ligand.atom_ids),), np.nan, dtype=np.float64)
+
+    if len(residues) == 1:
+
+        def resolve_atom_id(residue_id: ResidueId, atom_id: str):
+            return atom_id
+    else:
+
+        def resolve_atom_id(residue_id: ResidueId, atom_id: str):
+            return unique_atom_id(residue_id, atom_id)
+
+    aid_to_index = {aid: i for i, aid in enumerate(ref_ligand.atom_ids)}
+    for residue in residues:
+        for atom in assembly.atoms_of_residue(residue):
+            atom_id = resolve_atom_id(residue.residue_id, atom.atom_id)
+            if atom_id not in aid_to_index:
+                continue
+
+            val = atom.b_factor
+            b_factors[aid_to_index[atom_id]] = (
+                np.nan if val is None else float(val)
+            )
+
+    return b_factors
+
+
 def _update_polymer_residue_coords(
     coords: NDArray[np.float64],
+    b_factors: NDArray[np.float64] | None,
     assembly: Assembly,
     residue: Residue,
     polymer_consts: PolymerConstants,
@@ -340,6 +380,11 @@ def _update_polymer_residue_coords(
     for atom in assembly.atoms_of_residue(residue):
         try:
             coords[atom_idxs[atom.atom_id]] = assembly.coords[atom.atom_idx]
+            if b_factors is not None:
+                val = atom.b_factor
+                b_factors[atom_idxs[atom.atom_id]] = (
+                    np.nan if val is None else float(val)
+                )
         except KeyError:
             if atom.atom_id not in well_known_atoms:
                 logger.warning(
@@ -362,6 +407,8 @@ def _update_polymer_residue_coords(
     dsq_nh2 = D.sqeuclidean(cd_nh1_nh2[0], cd_nh1_nh2[2])
     if dsq_nh1 > dsq_nh2:
         coords[[j, i]] = cd_nh1_nh2[1:]
+        if b_factors is not None:
+            b_factors[[j, i]] = b_factors[[i, j]]
 
 
 def _add_implicit_bb_bonds(
@@ -430,6 +477,11 @@ def _modres_as_ligand(
         [] if resid is None else [assembly.residues[resid]],
         ref_ligand,
     )
+    bfs = build_atom_b_factors_from_ref(
+        assembly,
+        [] if resid is None else [assembly.residues[resid]],
+        ref_ligand,
+    )
 
     ligand = NonPolymerLigand(
         entity_id=mod_entity,
@@ -437,6 +489,7 @@ def _modres_as_ligand(
         smiles=ref_ligand.smiles,
         atom_ids=np.array(ref_ligand.atom_ids, dtype=np.str_),
         atom_coords=crd,
+        atom_b_factors=bfs,
     )
     bonds = _add_implicit_bb_bonds(polymer, polymer_consts, mod_chain, res_idx)
 
@@ -551,6 +604,11 @@ def _build_sc_ligand(
         [] if resid is None else [assembly.residues[resid]],
         ref_ligand,
     )
+    bfs = build_atom_b_factors_from_ref(
+        assembly,
+        [] if resid is None else [assembly.residues[resid]],
+        ref_ligand,
+    )
 
     ligand = NonPolymerLigand(
         entity_id=mod_entity,
@@ -558,6 +616,7 @@ def _build_sc_ligand(
         smiles=ref_ligand.smiles,
         atom_ids=np.array(ref_ligand.atom_ids, dtype=np.str_),
         atom_coords=crd,
+        atom_b_factors=bfs,
     )
     return ligand
 
@@ -633,6 +692,11 @@ def process_polymer_chain(
             np.nan,
             dtype=np.float64,
         ),
+        atom_b_factors=np.full(
+            (len(chain.seqres), polymer_consts.max_res_atoms),
+            np.nan,
+            dtype=np.float64,
+        ),
         residue_ids=[seq.res_id for seq in chain.seqres],
     )
 
@@ -647,6 +711,7 @@ def process_polymer_chain(
             if seq.res_id is not None:
                 _update_polymer_residue_coords(
                     polymer.atom_coords[i],
+                    polymer.atom_b_factors[i],
                     assembly,
                     assembly.residues[seq.res_id],
                     polymer_consts,
@@ -681,6 +746,7 @@ def process_polymer_chain(
         if seq.res_id is not None:
             _update_polymer_residue_coords(
                 polymer.atom_coords[i],
+                polymer.atom_b_factors[i],
                 assembly,
                 assembly.residues[seq.res_id],
                 polymer_consts,
@@ -712,6 +778,7 @@ def process_ligand_chain(assembly: Assembly, chain: Chain):
     lig = input_from_reference(reference_from_mmcif(ccs, chain.branches))
     residues = [assembly.residues[rid] for rid, _ in ccs]
     coords = build_atom_coords_from_ref(assembly, residues, lig)
+    b_factors = build_atom_b_factors_from_ref(assembly, residues, lig)
 
     return NonPolymerLigand(
         chain_id=chain.chain_id,
@@ -719,6 +786,7 @@ def process_ligand_chain(assembly: Assembly, chain: Chain):
         smiles=lig.smiles,
         atom_ids=np.array(lig.atom_ids, dtype=np.str_),
         atom_coords=coords,
+        atom_b_factors=b_factors,
     )
 
 

--- a/src/gmol/base/data/mmcif/parse.py
+++ b/src/gmol/base/data/mmcif/parse.py
@@ -178,15 +178,9 @@ class AtomSite(LooseModel):
     cartn: NDArray[np.float64]
     occupancy: float
 
-    # Temperature factor (aka B-factor) from mmCIF: _atom_site.B_iso_or_equiv
-    b_iso_or_equiv: float | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "B_iso_or_equiv",
-            "B_iso",
-            "b_iso_or_equiv",
-            "b_iso",
-        ),
+    b_iso_or_equiv: float = Field(
+        default=float("nan"),
+        validation_alias="B_iso_or_equiv",
     )
 
     @property
@@ -197,7 +191,7 @@ class AtomSite(LooseModel):
     @staticmethod
     def _coerce_b_iso_or_equiv(v: Any) -> Any:
         if v in (".", "?", "", None):
-            return None
+            return float("nan")
         return v
 
     @model_validator(mode="before")

--- a/src/gmol/base/data/mmcif/parse.py
+++ b/src/gmol/base/data/mmcif/parse.py
@@ -178,9 +178,27 @@ class AtomSite(LooseModel):
     cartn: NDArray[np.float64]
     occupancy: float
 
+    # Temperature factor (aka B-factor) from mmCIF: _atom_site.B_iso_or_equiv
+    b_iso_or_equiv: float | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "B_iso_or_equiv",
+            "B_iso",
+            "b_iso_or_equiv",
+            "b_iso",
+        ),
+    )
+
     @property
     def is_hydrogen(self):
         return self.type_symbol == "H"
+
+    @field_validator("b_iso_or_equiv", mode="before")
+    @staticmethod
+    def _coerce_b_iso_or_equiv(v: Any) -> Any:
+        if v in (".", "?", "", None):
+            return None
+        return v
 
     @model_validator(mode="before")
     @staticmethod

--- a/tests/data/mmcif/bfactor_test.py
+++ b/tests/data/mmcif/bfactor_test.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import math
 from pathlib import Path
 
 import numpy as np
@@ -49,7 +50,7 @@ def test_atom_site_bfactor_is_parsed(test_data: Path):
     bvals = [a.b_iso_or_equiv for a in data.atom_site[:50]]
     assert any(v is not None for v in bvals), "B-factor should be present"
 
-    non_null = [v for v in bvals if v is not None]
+    non_null = [v for v in bvals if math.isfinite(v)]
     assert all(float(v) >= 0.0 for v in non_null)
 
 
@@ -75,9 +76,7 @@ def test_ligand_chain_bfactor_vector(
     input_data = _build_input_for_pdb("7qgw", test_data, ccd_min)
     assert len(input_data.ligands) > 0
 
-    lig = next(
-        (l for l in input_data.ligands if l.atom_b_factors is not None), None
-    )
+    lig = next((l for l in input_data.ligands), None)
     assert lig is not None
 
     b_factors = lig.atom_b_factors

--- a/tests/data/mmcif/bfactor_test.py
+++ b/tests/data/mmcif/bfactor_test.py
@@ -1,0 +1,87 @@
+import datetime as dt
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pydantic import TypeAdapter
+
+from gmol.base.data.mmcif import (
+    ChemComp,
+    filter_mmcif,
+    load_mmcif_single,
+    mmcif_assemblies,
+)
+from gmol.base.data.mmcif.input import build_input
+
+
+@pytest.fixture(scope="session")
+def ccd_min(test_data: Path) -> dict[str, ChemComp]:
+    return TypeAdapter(dict[str, ChemComp]).validate_json(
+        test_data.joinpath("ccd", "components_min.json").read_bytes()
+    )
+
+
+def _build_input_for_pdb(
+    pdb_id: str,
+    test_data: Path,
+    ccd: dict[str, ChemComp],
+):
+    mmcif = test_data / "mmcif" / f"{pdb_id}.cif"
+    data = load_mmcif_single(mmcif)
+
+    assemblies = mmcif_assemblies(data, ccd)
+    assert len(assemblies) == 1
+
+    filtered = filter_mmcif(
+        assemblies[0], ccd, cutoff_date=dt.date(9999, 12, 31)
+    )
+    assert filtered is not None
+
+    return build_input(filtered, ccd, split_modified=False)
+
+
+def test_atom_site_bfactor_is_parsed(test_data: Path):
+    mmcif = test_data / "mmcif" / "1ubq.cif"
+    data = load_mmcif_single(mmcif)
+
+    assert len(data.atom_site) > 0
+
+    bvals = [a.b_iso_or_equiv for a in data.atom_site[:50]]
+    assert any(v is not None for v in bvals), "B-factor should be present"
+
+    non_null = [v for v in bvals if v is not None]
+    assert all(float(v) >= 0.0 for v in non_null)
+
+
+def test_polymer_chain_bfactor_tensor(
+    test_data: Path, ccd_min: dict[str, ChemComp]
+):
+    input_data = _build_input_for_pdb("4hf7", test_data, ccd_min)
+    assert len(input_data.polymers) > 0
+
+    poly = input_data.polymers[0]
+    assert poly.atom_coords.shape[:2] == poly.atom_b_factors.shape
+
+    # If a coordinate exists for an atom type, B-factor should also be set
+    # (at least for some atoms; missing values are NaN)
+    present = ~np.isnan(poly.atom_coords[..., 0])
+    b_present = ~np.isnan(poly.atom_b_factors)
+    assert int(np.sum(present & b_present)) > 0
+
+
+def test_ligand_chain_bfactor_vector(
+    test_data: Path, ccd_min: dict[str, ChemComp]
+):
+    input_data = _build_input_for_pdb("7qgw", test_data, ccd_min)
+    assert len(input_data.ligands) > 0
+
+    lig = next(
+        (l for l in input_data.ligands if l.atom_b_factors is not None), None
+    )
+    assert lig is not None
+
+    b_factors = lig.atom_b_factors
+    assert b_factors is not None
+
+    assert b_factors.shape == (len(lig.atom_ids),)
+    assert int(np.sum(~np.isnan(b_factors))) > 0


### PR DESCRIPTION
…merChain

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [x] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #...

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mmCIF parsing and input-building data models by adding new per-atom fields, which can break downstream assumptions about shapes/serialization and requires correct NaN/format handling. Changes are straightforward but broadly propagated across assembly, PDB export, and input generation.
> 
> **Overview**
> Adds B-factor support end-to-end: `AtomSite` now parses `B_iso_or_equiv` (coercing missing values to `NaN`), `AssemblyAtom` carries `b_factor`, and `Assembly.to_pdb()` writes the B-factor column (falling back to `0.0` for non-finite values).
> 
> Extends `PolymerChain` and `NonPolymerLigand` with `atom_b_factors` aligned to existing coordinate arrays, updates coordinate-mapping helpers to return both coords and B-factors, and preserves B-factors during ARG `NH1/NH2` swapping. Adds `tests/data/mmcif/bfactor_test.py` to validate parsing and that built inputs contain non-`NaN` B-factors for both polymers and ligands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5043391acc07cb4cb2054d5ee854dc0bd83e142d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->