### PR TITLE
fix(data/mmcif): omit label_seq_id if chain is non-polymer

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -646,8 +646,8 @@ class Assembly(LooseModel):
                 if scheme not in br_schemes:
                     np_schemes.add(scheme)
 
-        label_seqs: dict[ResidueId, int | None] = {
-            seqres.res_id: seqres.seq_id if chain.type.is_polymer else None
+        label_seqs: dict[ResidueId, int | str] = {
+            seqres.res_id: seqres.seq_id if chain.type.is_polymer else "."
             for chain in self.chains.values()
             for seqres in chain.seqres
             if seqres.res_id is not None
@@ -719,9 +719,7 @@ class Assembly(LooseModel):
                         ".",
                         atom.comp_id,
                         atom.chain_id,
-                        label_seqs[atom.residue_id]
-                        if label_seqs[atom.residue_id] is not None
-                        else ".",
+                        label_seqs[atom.residue_id],
                         atom.residue_id.seq_id,
                         atom.comp_id,
                         atom.chain_id,
@@ -828,9 +826,7 @@ class Assembly(LooseModel):
                         (ptnr1 := self.atoms[conn.src_idx]).atom_id,
                         ptnr1.comp_id,
                         ptnr1.chain_id,
-                        label_seqs[ptnr1.residue_id]
-                        if label_seqs[ptnr1.residue_id] is not None
-                        else ".",
+                        label_seqs[ptnr1.residue_id],
                         ptnr1.residue_id.seq_id,
                         ptnr1.comp_id,
                         ptnr1.chain_id,
@@ -839,9 +835,7 @@ class Assembly(LooseModel):
                         (ptnr2 := self.atoms[conn.dst_idx]).atom_id,
                         ptnr2.comp_id,
                         ptnr2.chain_id,
-                        label_seqs[ptnr2.residue_id]
-                        if label_seqs[ptnr2.residue_id] is not None
-                        else ".",
+                        label_seqs[ptnr2.residue_id],
                         ptnr2.residue_id.seq_id,
                         ptnr2.comp_id,
                         ptnr2.chain_id,
@@ -995,8 +989,8 @@ class Assembly(LooseModel):
                 if scheme not in branch_scheme:
                     nonpoly_scheme.add(scheme)
 
-        label_seqs: dict[ResidueId, int | None] = {
-            seqres.res_id: seqres.seq_id if chain.type.is_polymer else None
+        label_seqs: dict[ResidueId, int | str] = {
+            seqres.res_id: seqres.seq_id if chain.type.is_polymer else "."
             for seqres in chain.seqres
             if seqres.res_id is not None
         }
@@ -1041,9 +1035,7 @@ class Assembly(LooseModel):
                         atom.atom_id,
                         atom.comp_id,
                         atom.chain_id,
-                        label_seqs[atom.residue_id]
-                        if label_seqs[atom.residue_id] is not None
-                        else ".",
+                        label_seqs[atom.residue_id],
                         atom.residue_id.seq_id,
                         atom.residue_id.ins_code or ".",
                         f"{crd[0]:.3f}",
@@ -1142,17 +1134,13 @@ class Assembly(LooseModel):
                         (ptnr1 := self.atoms[conn.src_idx]).chain_id,
                         ptnr1.comp_id,
                         ptnr1.atom_id,
-                        label_seqs[ptnr1.residue_id]
-                        if label_seqs[ptnr1.residue_id] is not None
-                        else ".",
+                        label_seqs[ptnr1.residue_id],
                         ptnr1.residue_id.seq_id,
                         ptnr1.residue_id.ins_code or ".",
                         (ptnr2 := self.atoms[conn.dst_idx]).chain_id,
                         ptnr2.comp_id,
                         ptnr2.atom_id,
-                        label_seqs[ptnr2.residue_id]
-                        if label_seqs[ptnr2.residue_id] is not None
-                        else ".",
+                        label_seqs[ptnr2.residue_id],
                         ptnr2.residue_id.seq_id,
                         ptnr2.residue_id.ins_code or ".",
                     )

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -646,8 +646,8 @@ class Assembly(LooseModel):
                 if scheme not in br_schemes:
                     np_schemes.add(scheme)
 
-        label_seqs: dict[ResidueId, int] = {
-            seqres.res_id: seqres.seq_id
+        label_seqs: dict[ResidueId, int | None] = {
+            seqres.res_id: seqres.seq_id if chain.type.is_polymer else None
             for chain in self.chains.values()
             for seqres in chain.seqres
             if seqres.res_id is not None
@@ -719,7 +719,9 @@ class Assembly(LooseModel):
                         ".",
                         atom.comp_id,
                         atom.chain_id,
-                        label_seqs[atom.residue_id],
+                        label_seqs[atom.residue_id]
+                        if label_seqs[atom.residue_id] is not None
+                        else ".",
                         atom.residue_id.seq_id,
                         atom.comp_id,
                         atom.chain_id,
@@ -826,7 +828,9 @@ class Assembly(LooseModel):
                         (ptnr1 := self.atoms[conn.src_idx]).atom_id,
                         ptnr1.comp_id,
                         ptnr1.chain_id,
-                        label_seqs[ptnr1.residue_id],
+                        label_seqs[ptnr1.residue_id]
+                        if label_seqs[ptnr1.residue_id] is not None
+                        else ".",
                         ptnr1.residue_id.seq_id,
                         ptnr1.comp_id,
                         ptnr1.chain_id,
@@ -835,7 +839,9 @@ class Assembly(LooseModel):
                         (ptnr2 := self.atoms[conn.dst_idx]).atom_id,
                         ptnr2.comp_id,
                         ptnr2.chain_id,
-                        label_seqs[ptnr2.residue_id],
+                        label_seqs[ptnr2.residue_id]
+                        if label_seqs[ptnr2.residue_id] is not None
+                        else ".",
                         ptnr2.residue_id.seq_id,
                         ptnr2.comp_id,
                         ptnr2.chain_id,
@@ -989,8 +995,8 @@ class Assembly(LooseModel):
                 if scheme not in branch_scheme:
                     nonpoly_scheme.add(scheme)
 
-        label_seqs = {
-            seqres.res_id: seqres.seq_id
+        label_seqs: dict[ResidueId, int | None] = {
+            seqres.res_id: seqres.seq_id if chain.type.is_polymer else None
             for seqres in chain.seqres
             if seqres.res_id is not None
         }
@@ -1035,7 +1041,9 @@ class Assembly(LooseModel):
                         atom.atom_id,
                         atom.comp_id,
                         atom.chain_id,
-                        label_seqs[atom.residue_id],
+                        label_seqs[atom.residue_id]
+                        if label_seqs[atom.residue_id] is not None
+                        else ".",
                         atom.residue_id.seq_id,
                         atom.residue_id.ins_code or ".",
                         f"{crd[0]:.3f}",
@@ -1134,13 +1142,17 @@ class Assembly(LooseModel):
                         (ptnr1 := self.atoms[conn.src_idx]).chain_id,
                         ptnr1.comp_id,
                         ptnr1.atom_id,
-                        label_seqs[ptnr1.residue_id],
+                        label_seqs[ptnr1.residue_id]
+                        if label_seqs[ptnr1.residue_id] is not None
+                        else ".",
                         ptnr1.residue_id.seq_id,
                         ptnr1.residue_id.ins_code or ".",
                         (ptnr2 := self.atoms[conn.dst_idx]).chain_id,
                         ptnr2.comp_id,
                         ptnr2.atom_id,
-                        label_seqs[ptnr2.residue_id],
+                        label_seqs[ptnr2.residue_id]
+                        if label_seqs[ptnr2.residue_id] is not None
+                        else ".",
                         ptnr2.residue_id.seq_id,
                         ptnr2.residue_id.ins_code or ".",
                     )

--- a/tests/data/mmcif/label_seq_id_test.py
+++ b/tests/data/mmcif/label_seq_id_test.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+
+import pytest
+from pydantic import TypeAdapter
+
+from gmol.base.data.mmcif import (
+    Assembly,
+    ChemComp,
+    MolType,
+    load_components,
+    load_mmcif_single,
+    mmcif_assemblies,
+)
+
+
+@pytest.fixture(scope="module")
+def ccd_with_ligands(test_data: Path) -> dict[str, ChemComp]:
+    ccd = load_components(test_data / "ccd" / "components_stdres.cif")
+    extra = TypeAdapter(dict[str, ChemComp]).validate_json(
+        (test_data / "ccd" / "components_5m7m.json").read_bytes()
+    )
+    ccd.update(extra)
+    return ccd
+
+
+@pytest.fixture(scope="module")
+def assembly_with_ligands(
+    test_data: Path, ccd_with_ligands: dict[str, ChemComp]
+) -> Assembly:
+    data = load_mmcif_single(test_data / "mmcif" / "5m7m.cif")
+    assemblies = mmcif_assemblies(data, ccd_with_ligands)
+    assert len(assemblies) == 1
+    return assemblies[0]
+
+
+def test_ligand_label_seq_id_is_dot(assembly_with_ligands: Assembly):
+    """Non-polymer (ligand) chains should have '.' for label_seq_id in mmCIF output."""
+    mmcif_str = assembly_with_ligands.to_mmcif("test")
+
+    # Parse atom_site lines from the mmCIF output
+    in_atom_site = False
+    field_names: list[str] = []
+    label_seq_id_col = -1
+    label_asym_id_col = -1
+
+    ligand_chain_ids = {
+        cid
+        for cid, chain in assembly_with_ligands.chains.items()
+        if chain.type == MolType.Ligand
+    }
+    polymer_chain_ids = {
+        cid
+        for cid, chain in assembly_with_ligands.chains.items()
+        if chain.type.is_polymer
+    }
+
+    assert len(ligand_chain_ids) > 0, "Test requires ligand chains"
+    assert len(polymer_chain_ids) > 0, "Test requires polymer chains"
+
+    ligand_label_seq_ids: set[str] = set()
+    polymer_label_seq_ids: set[str] = set()
+
+    for line in mmcif_str.splitlines():
+        line = line.strip()
+
+        if line == "loop_":
+            in_atom_site = False
+            field_names = []
+            continue
+
+        if line.startswith("_atom_site."):
+            field_names.append(line.split(".")[1])
+            if field_names[-1] == "label_seq_id":
+                label_seq_id_col = len(field_names) - 1
+            if field_names[-1] == "label_asym_id":
+                label_asym_id_col = len(field_names) - 1
+            in_atom_site = True
+            continue
+
+        if (
+            in_atom_site
+            and label_seq_id_col >= 0
+            and line
+            and not line.startswith("_")
+            and not line.startswith("#")
+        ):
+            tokens = line.split()
+            if len(tokens) >= len(field_names):
+                asym_id = tokens[label_asym_id_col]
+                seq_id = tokens[label_seq_id_col]
+
+                if asym_id in ligand_chain_ids:
+                    ligand_label_seq_ids.add(seq_id)
+                elif asym_id in polymer_chain_ids:
+                    polymer_label_seq_ids.add(seq_id)
+
+        if line.startswith("#") and in_atom_site:
+            in_atom_site = False
+
+    # Ligand label_seq_id must all be "."
+    assert ligand_label_seq_ids == {"."}, (
+        f"Ligand label_seq_id should be '.', got {ligand_label_seq_ids}"
+    )
+
+    # Polymer label_seq_id must be numeric (not ".")
+    assert "." not in polymer_label_seq_ids, (
+        "Polymer label_seq_id should not contain '.'"
+    )
+    assert len(polymer_label_seq_ids) > 0


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [ ] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Fixes #36.

---

<!-- Start the description of the PR here -->
non-polymer chain일 경우 label_seq_id를 비워놓아야 해서, non-polymer의 경우 to_mmcif로 작성할 때 "."으로 작성되도록 수정했습니다.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to mmCIF serialization that only affects `label_seq_id` for ligand/non-polymer chains, with a new regression test covering the expected output.
> 
> **Overview**
> Updates mmCIF export so `label_seq_id` is written as `.` for non-polymer (ligand) chains (while keeping numeric `label_seq_id` for polymer chains) in both `Assembly.to_mmcif` and `Assembly.to_mmcif_chain`.
> 
> Adds a regression test that generates mmCIF for a structure containing ligands and asserts ligand `_atom_site.label_seq_id` values are all `.` and polymer values are not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a55f3855165513def601b7175811287b5fb80f66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->