### PR TITLE
feat(data/mmcif): filter deuterium (D) alongside hydrogen (H) in mmCIF pipeline

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -1680,7 +1680,7 @@ def _prepare_initial_assemblies(
 ) -> list[Assembly]:
     atom_sites_model: dict[int, list[AtomSite]] = defaultdict(list)
     for atom_site in metadata.atom_site:
-        if atom_site.type_symbol == "H":
+        if atom_site.type_symbol in ("H", "D"):
             continue
 
         atom_sites_model[atom_site.pdbx_PDB_model_num].append(atom_site)

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -1680,7 +1680,7 @@ def _prepare_initial_assemblies(
 ) -> list[Assembly]:
     atom_sites_model: dict[int, list[AtomSite]] = defaultdict(list)
     for atom_site in metadata.atom_site:
-        if atom_site.type_symbol in ("H", "D"):
+        if atom_site.type_symbol in "HD":
             continue
 
         atom_sites_model[atom_site.pdbx_PDB_model_num].append(atom_site)

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -485,7 +485,7 @@ def _split_modified_residue(
     for aid in chain_consts.backbone:
         for n in graph[aid]:
             atom: ChemCompAtom = graph.nodes[n]["data"]
-            if atom.type_symbol in ("H", "D"):
+            if atom.type_symbol in "HD":
                 bb_all.add(n)
 
     only_sc = graph.copy(as_view=False)

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -485,7 +485,7 @@ def _split_modified_residue(
     for aid in chain_consts.backbone:
         for n in graph[aid]:
             atom: ChemCompAtom = graph.nodes[n]["data"]
-            if atom.type_symbol == "H":
+            if atom.type_symbol in ("H", "D"):
                 bb_all.add(n)
 
     only_sc = graph.copy(as_view=False)

--- a/src/gmol/base/data/mmcif/parse.py
+++ b/src/gmol/base/data/mmcif/parse.py
@@ -185,7 +185,7 @@ class AtomSite(LooseModel):
 
     @property
     def is_hydrogen(self):
-        return self.type_symbol == "H"
+        return self.type_symbol in ("H", "D")
 
     @field_validator("b_iso_or_equiv", mode="before")
     @staticmethod

--- a/src/gmol/base/data/mmcif/parse.py
+++ b/src/gmol/base/data/mmcif/parse.py
@@ -185,7 +185,7 @@ class AtomSite(LooseModel):
 
     @property
     def is_hydrogen(self):
-        return self.type_symbol in ("H", "D")
+        return self.type_symbol in "HD"
 
     @field_validator("b_iso_or_equiv", mode="before")
     @staticmethod

--- a/src/gmol/base/data/mmcif/smiles.py
+++ b/src/gmol/base/data/mmcif/smiles.py
@@ -47,7 +47,10 @@ def mol_from_chem_comp(
         # RemoveHs() cannot delete degree-0 H atoms and emits warnings, so
         # drop them here when the bond/heavy-atom partner is missing.
         # Ref: seoklab/gmol-base#9.
-        if atom_data.type_symbol == "H" and atom_data.atom_id not in bond_ids:
+        if (
+            atom_data.type_symbol in ("H", "D")
+            and atom_data.atom_id not in bond_ids
+        ):
             continue
 
         atom = Chem.Atom(atom_data.type_symbol)

--- a/src/gmol/base/data/mmcif/smiles.py
+++ b/src/gmol/base/data/mmcif/smiles.py
@@ -47,10 +47,7 @@ def mol_from_chem_comp(
         # RemoveHs() cannot delete degree-0 H atoms and emits warnings, so
         # drop them here when the bond/heavy-atom partner is missing.
         # Ref: seoklab/gmol-base#9.
-        if (
-            atom_data.type_symbol in ("H", "D")
-            and atom_data.atom_id not in bond_ids
-        ):
+        if atom_data.type_symbol in "HD" and atom_data.atom_id not in bond_ids:
             continue
 
         atom = Chem.Atom(atom_data.type_symbol)


### PR DESCRIPTION
…F pipeline

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [x] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #35 

---

gmol-base mmCIF pipepline에서 hydrogen filtering이 포함된 코드에 deuterium도 같이 filtering되도록 코드를 수정한다.
