### PR TITLE
fix(assembly): fix branch scheme overwrite when duplicate seq_id

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -1548,16 +1548,16 @@ def _map_branches(
     br_links: list[BranchLink],
     residues: dict[ResidueId, Residue],
 ):
-    schemes = {scheme.seq_id: scheme for scheme in br_schemes}
+    schemes = {(scheme.seq_id, scheme.mon_id): scheme for scheme in br_schemes}
 
     branches = []
     for link in br_links:
         ptnr1 = BranchPartner.from_branch_scheme(
-            schemes[link.ptnr1.entity_branch_list_num],
+            schemes[(link.ptnr1.entity_branch_list_num, link.ptnr1.comp_id)],
             link.ptnr1,
         )
         ptnr2 = BranchPartner.from_branch_scheme(
-            schemes[link.ptnr2.entity_branch_list_num],
+            schemes[(link.ptnr2.entity_branch_list_num, link.ptnr2.comp_id)],
             link.ptnr2,
         )
         if (

--- a/src/gmol/base/data/mmcif/parse.py
+++ b/src/gmol/base/data/mmcif/parse.py
@@ -145,16 +145,24 @@ class Scheme(LooseModel):
         if not isinstance(other, Scheme):
             return False
 
-        return self.asym_id == other.asym_id and self.seq_id == other.seq_id
+        return (
+            self.asym_id == other.asym_id
+            and self.seq_id == other.seq_id
+            and self.mon_id == other.mon_id
+        )
 
     def __lt__(self, other):
         if not isinstance(other, Scheme):
             return NotImplemented
 
-        return (self.asym_id, self.seq_id) < (other.asym_id, other.seq_id)
+        return (self.asym_id, self.seq_id, self.mon_id) < (
+            other.asym_id,
+            other.seq_id,
+            other.mon_id,
+        )
 
     def __hash__(self):
-        return hash((self.asym_id, self.seq_id))
+        return hash((self.asym_id, self.seq_id, self.mon_id))
 
 
 class AtomSite(LooseModel):

--- a/tests/data/mmcif/branch_test.py
+++ b/tests/data/mmcif/branch_test.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from gmol.base.data.mmcif import (
+    ChemComp,
+    load_mmcif_single,
+    mmcif_assemblies,
+)
+
+
+def test_load_heterogeneous_half_occupancy_branch(
+    test_data: Path,
+    ccd_components: dict[str, ChemComp],
+):
+    data = load_mmcif_single(test_data / "mmcif" / "4mb4.cif")
+
+    ccd = ccd_components.copy()
+    ccd.update(
+        TypeAdapter(dict[str, ChemComp]).validate_json(
+            (test_data / "ccd" / "components_4mb4.json").read_bytes()
+        )
+    )
+
+    assemblies = mmcif_assemblies(data, ccd)
+    asm = assemblies[0]
+
+    chain_b = asm.chains["B"]
+
+    # NDG discarded by altloc selection logic. Should not overwrite NAG
+    assert len(chain_b.branches) == 3
+    for branch in chain_b.branches:
+        assert branch.ptnr1.comp_id == "NAG"
+        assert branch.ptnr2.comp_id == "NAG"
+
+    mmcif_out = asm.to_mmcif("4MB4")
+    in_branch_scheme = False
+    branch_scheme_lines: list[str] = []
+
+    for line in mmcif_out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("_pdbx_branch_scheme."):
+            in_branch_scheme = True
+            continue
+        if (
+            in_branch_scheme
+            and stripped
+            and not stripped.startswith(("_", "#"))
+        ):
+            branch_scheme_lines.append(stripped)
+        elif in_branch_scheme and (stripped.startswith("#") or stripped == ""):
+            if branch_scheme_lines:
+                break
+
+    assert len(branch_scheme_lines) == 4
+    for bsl in branch_scheme_lines:
+        tokens = bsl.split()
+        mon_id = tokens[3]
+        assert mon_id == "NAG"

--- a/tests/test_data/ccd/components_4mb4.json
+++ b/tests/test_data/ccd/components_4mb4.json
@@ -1,0 +1,1290 @@
+{
+  "GOL": {
+    "id": "GOL",
+    "name": "GLYCEROL",
+    "type": "non-polymer",
+    "formula": "C3 H8 O3",
+    "formula_weight": 92.094,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "C1",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O1",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C2",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O2",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C3",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O3",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H11",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H12",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H31",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H32",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO3",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": [
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "O1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "C2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "H11",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "H12",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O1",
+        "atom_id_2": "HO1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "O2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "C3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "H2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O2",
+        "atom_id_2": "HO2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "O3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "H31",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "H32",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O3",
+        "atom_id_2": "HO3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ]
+  },
+  "HOH": {
+    "id": "HOH",
+    "name": "WATER",
+    "type": "non-polymer",
+    "formula": "H2 O",
+    "formula_weight": 18.015,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "O",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": [
+      {
+        "atom_id_1": "O",
+        "atom_id_2": "H1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O",
+        "atom_id_2": "H2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ]
+  },
+  "NA": {
+    "id": "NA",
+    "name": "SODIUM ION",
+    "type": "non-polymer",
+    "formula": "Na 1",
+    "formula_weight": 22.99,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "NA",
+        "type_symbol": "Na",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": []
+  },
+  "NAG": {
+    "id": "NAG",
+    "name": "2-acetamido-2-deoxy-beta-D-glucopyranose",
+    "type": "D-saccharide, beta linking",
+    "formula": "C8 H15 N O6",
+    "formula_weight": 221.208,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "C1",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C2",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C3",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C4",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "S"
+      },
+      {
+        "atom_id": "C5",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C6",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C7",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C8",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "N2",
+        "type_symbol": "N",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O1",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O3",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O4",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O5",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O6",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O7",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H3",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H4",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H5",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H61",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H62",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H81",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H82",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H83",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HN2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO3",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO4",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO6",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": [
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "C2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "O1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "O5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "H1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "C3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "N2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "H2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "C4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "O3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "H3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "C5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "O4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "H4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "C6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "O5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "H5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "O6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "H61",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "H62",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "C8",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "N2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "O7",
+        "value_order": 2,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H81",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H82",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H83",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "N2",
+        "atom_id_2": "HN2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O1",
+        "atom_id_2": "HO1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O3",
+        "atom_id_2": "HO3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O4",
+        "atom_id_2": "HO4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O6",
+        "atom_id_2": "HO6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ]
+  },
+  "NDG": {
+    "id": "NDG",
+    "name": "2-acetamido-2-deoxy-alpha-D-glucopyranose",
+    "type": "D-saccharide, alpha linking",
+    "formula": "C8 H15 N O6",
+    "formula_weight": 221.208,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "C1",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "S"
+      },
+      {
+        "atom_id": "C2",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C3",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C4",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "S"
+      },
+      {
+        "atom_id": "C5",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": "R"
+      },
+      {
+        "atom_id": "C6",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C7",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "C8",
+        "type_symbol": "C",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O5",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O3",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O4",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O6",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O7",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "N2",
+        "type_symbol": "N",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O1",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H3",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H4",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H5",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H61",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H62",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H81",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H82",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "H83",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO3",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO4",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO6",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HN2",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "HO1",
+        "type_symbol": "H",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": [
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "C2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "O5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "O1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C1",
+        "atom_id_2": "H1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "C3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "N2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C2",
+        "atom_id_2": "H2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "C4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "O3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C3",
+        "atom_id_2": "H3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "C5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "O4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C4",
+        "atom_id_2": "H4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "C6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "O5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C5",
+        "atom_id_2": "H5",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "O6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "H61",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C6",
+        "atom_id_2": "H62",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "C8",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "O7",
+        "value_order": 2,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C7",
+        "atom_id_2": "N2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H81",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H82",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "C8",
+        "atom_id_2": "H83",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O3",
+        "atom_id_2": "HO3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O4",
+        "atom_id_2": "HO4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O6",
+        "atom_id_2": "HO6",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "N2",
+        "atom_id_2": "HN2",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "O1",
+        "atom_id_2": "HO1",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ]
+  },
+  "SO4": {
+    "id": "SO4",
+    "name": "SULFATE ION",
+    "type": "non-polymer",
+    "formula": "O4 S -2",
+    "formula_weight": 96.063,
+    "mon_nstd_flag": null,
+    "atoms": [
+      {
+        "atom_id": "S",
+        "type_symbol": "S",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O1",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O2",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O3",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id": "O4",
+        "type_symbol": "O",
+        "charge": 0.0,
+        "pdbx_aromatic_flag": false,
+        "pdbx_leaving_atom_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ],
+    "bonds": [
+      {
+        "atom_id_1": "S",
+        "atom_id_2": "O1",
+        "value_order": 2,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "S",
+        "atom_id_2": "O2",
+        "value_order": 2,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "S",
+        "atom_id_2": "O3",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      },
+      {
+        "atom_id_1": "S",
+        "atom_id_2": "O4",
+        "value_order": 1,
+        "pdbx_aromatic_flag": false,
+        "pdbx_stereo_config": null
+      }
+    ]
+  }
+}

--- a/tests/test_data/mmcif/4mb4.cif
+++ b/tests/test_data/mmcif/4mb4.cif
@@ -1,0 +1,13464 @@
+data_4MB4
+# 
+_entry.id   4MB4 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.397 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+_database_2.pdbx_database_accession 
+_database_2.pdbx_DOI 
+PDB   4MB4         pdb_00004mb4 10.2210/pdb4mb4/pdb 
+RCSB  RCSB081692   ?            ?                   
+WWPDB D_1000081692 ?            ?                   
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 2014-03-19 
+2 'Structure model' 2 0 2020-07-29 
+3 'Structure model' 2 1 2023-11-08 
+4 'Structure model' 2 2 2024-10-09 
+# 
+loop_
+_pdbx_audit_revision_details.ordinal 
+_pdbx_audit_revision_details.revision_ordinal 
+_pdbx_audit_revision_details.data_content_type 
+_pdbx_audit_revision_details.provider 
+_pdbx_audit_revision_details.type 
+_pdbx_audit_revision_details.description 
+_pdbx_audit_revision_details.details 
+1 1 'Structure model' repository 'Initial release' ?                          ? 
+2 2 'Structure model' repository Remediation       'Carbohydrate remediation' ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1  2 'Structure model' Advisory                 
+2  2 'Structure model' 'Atomic model'           
+3  2 'Structure model' 'Data collection'        
+4  2 'Structure model' 'Database references'    
+5  2 'Structure model' 'Derived calculations'   
+6  2 'Structure model' 'Structure summary'      
+7  3 'Structure model' Advisory                 
+8  3 'Structure model' 'Data collection'        
+9  3 'Structure model' 'Database references'    
+10 3 'Structure model' 'Refinement description' 
+11 3 'Structure model' 'Structure summary'      
+12 4 'Structure model' 'Structure summary'      
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1  2 'Structure model' atom_site                     
+2  2 'Structure model' atom_site_anisotrop           
+3  2 'Structure model' chem_comp                     
+4  2 'Structure model' entity                        
+5  2 'Structure model' pdbx_branch_scheme            
+6  2 'Structure model' pdbx_chem_comp_identifier     
+7  2 'Structure model' pdbx_entity_branch            
+8  2 'Structure model' pdbx_entity_branch_descriptor 
+9  2 'Structure model' pdbx_entity_branch_link       
+10 2 'Structure model' pdbx_entity_branch_list       
+11 2 'Structure model' pdbx_entity_nonpoly           
+12 2 'Structure model' pdbx_nonpoly_scheme           
+13 2 'Structure model' pdbx_struct_assembly_gen      
+14 2 'Structure model' pdbx_struct_conn_angle        
+15 2 'Structure model' pdbx_struct_special_symmetry  
+16 2 'Structure model' pdbx_unobs_or_zero_occ_atoms  
+17 2 'Structure model' struct_asym                   
+18 2 'Structure model' struct_conn                   
+19 2 'Structure model' struct_ref_seq_dif            
+20 2 'Structure model' struct_site                   
+21 2 'Structure model' struct_site_gen               
+22 3 'Structure model' chem_comp                     
+23 3 'Structure model' chem_comp_atom                
+24 3 'Structure model' chem_comp_bond                
+25 3 'Structure model' database_2                    
+26 3 'Structure model' pdbx_initial_refinement_model 
+27 3 'Structure model' pdbx_unobs_or_zero_occ_atoms  
+28 4 'Structure model' pdbx_entry_details            
+29 4 'Structure model' pdbx_modification_feature     
+# 
+loop_
+_pdbx_audit_revision_item.ordinal 
+_pdbx_audit_revision_item.revision_ordinal 
+_pdbx_audit_revision_item.data_content_type 
+_pdbx_audit_revision_item.item 
+1  2 'Structure model' '_atom_site.B_iso_or_equiv'                    
+2  2 'Structure model' '_atom_site.Cartn_x'                           
+3  2 'Structure model' '_atom_site.Cartn_y'                           
+4  2 'Structure model' '_atom_site.Cartn_z'                           
+5  2 'Structure model' '_atom_site.auth_asym_id'                      
+6  2 'Structure model' '_atom_site.auth_atom_id'                      
+7  2 'Structure model' '_atom_site.auth_comp_id'                      
+8  2 'Structure model' '_atom_site.auth_seq_id'                       
+9  2 'Structure model' '_atom_site.label_alt_id'                      
+10 2 'Structure model' '_atom_site.label_asym_id'                     
+11 2 'Structure model' '_atom_site.label_atom_id'                     
+12 2 'Structure model' '_atom_site.label_comp_id'                     
+13 2 'Structure model' '_atom_site.label_entity_id'                   
+14 2 'Structure model' '_atom_site.occupancy'                         
+15 2 'Structure model' '_atom_site.type_symbol'                       
+16 2 'Structure model' '_atom_site_anisotrop.U[1][1]'                 
+17 2 'Structure model' '_atom_site_anisotrop.U[1][2]'                 
+18 2 'Structure model' '_atom_site_anisotrop.U[1][3]'                 
+19 2 'Structure model' '_atom_site_anisotrop.U[2][2]'                 
+20 2 'Structure model' '_atom_site_anisotrop.U[2][3]'                 
+21 2 'Structure model' '_atom_site_anisotrop.U[3][3]'                 
+22 2 'Structure model' '_atom_site_anisotrop.pdbx_auth_asym_id'       
+23 2 'Structure model' '_atom_site_anisotrop.pdbx_auth_atom_id'       
+24 2 'Structure model' '_atom_site_anisotrop.pdbx_auth_comp_id'       
+25 2 'Structure model' '_atom_site_anisotrop.pdbx_auth_seq_id'        
+26 2 'Structure model' '_atom_site_anisotrop.pdbx_label_alt_id'       
+27 2 'Structure model' '_atom_site_anisotrop.pdbx_label_asym_id'      
+28 2 'Structure model' '_atom_site_anisotrop.pdbx_label_atom_id'      
+29 2 'Structure model' '_atom_site_anisotrop.pdbx_label_comp_id'      
+30 2 'Structure model' '_atom_site_anisotrop.type_symbol'             
+31 2 'Structure model' '_chem_comp.name'                              
+32 2 'Structure model' '_chem_comp.type'                              
+33 2 'Structure model' '_pdbx_struct_assembly_gen.asym_id_list'       
+34 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_auth_comp_id'   
+35 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_auth_seq_id'    
+36 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_label_asym_id'  
+37 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_label_atom_id'  
+38 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_label_comp_id'  
+39 2 'Structure model' '_pdbx_struct_conn_angle.ptnr1_label_seq_id'   
+40 2 'Structure model' '_pdbx_struct_conn_angle.ptnr2_label_asym_id'  
+41 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_auth_comp_id'   
+42 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_auth_seq_id'    
+43 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_label_asym_id'  
+44 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_label_atom_id'  
+45 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_label_comp_id'  
+46 2 'Structure model' '_pdbx_struct_conn_angle.ptnr3_label_seq_id'   
+47 2 'Structure model' '_pdbx_struct_conn_angle.value'                
+48 2 'Structure model' '_struct_conn.pdbx_dist_value'                 
+49 2 'Structure model' '_struct_conn.pdbx_leaving_atom_flag'          
+50 2 'Structure model' '_struct_conn.pdbx_ptnr1_label_alt_id'         
+51 2 'Structure model' '_struct_conn.pdbx_ptnr2_label_alt_id'         
+52 2 'Structure model' '_struct_conn.ptnr1_auth_asym_id'              
+53 2 'Structure model' '_struct_conn.ptnr1_auth_comp_id'              
+54 2 'Structure model' '_struct_conn.ptnr1_auth_seq_id'               
+55 2 'Structure model' '_struct_conn.ptnr1_label_asym_id'             
+56 2 'Structure model' '_struct_conn.ptnr1_label_atom_id'             
+57 2 'Structure model' '_struct_conn.ptnr1_label_comp_id'             
+58 2 'Structure model' '_struct_conn.ptnr1_label_seq_id'              
+59 2 'Structure model' '_struct_conn.ptnr2_auth_asym_id'              
+60 2 'Structure model' '_struct_conn.ptnr2_auth_comp_id'              
+61 2 'Structure model' '_struct_conn.ptnr2_auth_seq_id'               
+62 2 'Structure model' '_struct_conn.ptnr2_label_asym_id'             
+63 2 'Structure model' '_struct_conn.ptnr2_label_atom_id'             
+64 2 'Structure model' '_struct_conn.ptnr2_label_comp_id'             
+65 2 'Structure model' '_struct_ref_seq_dif.details'                  
+66 3 'Structure model' '_chem_comp.pdbx_synonyms'                     
+67 3 'Structure model' '_database_2.pdbx_DOI'                         
+68 3 'Structure model' '_database_2.pdbx_database_accession'          
+69 4 'Structure model' '_pdbx_entry_details.has_protein_modification' 
+# 
+_pdbx_database_status.entry_id                        4MB4 
+_pdbx_database_status.methods_development_category    ? 
+_pdbx_database_status.deposit_site                    RCSB 
+_pdbx_database_status.process_site                    PDBJ 
+_pdbx_database_status.recvd_initial_deposition_date   2013-08-19 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_nmr_data            ? 
+# 
+loop_
+_pdbx_database_related.db_name 
+_pdbx_database_related.db_id 
+_pdbx_database_related.details 
+_pdbx_database_related.content_type 
+PDB 4HMC 'Crystal structure of cold-adapted chitinase from Moritella marina'                                                      
+unspecified 
+PDB 4HMD 'Crystal structure of cold-adapted chitinase from Moritella marina with a reaction intermediate - oxazolinium ion (NGO)' 
+unspecified 
+PDB 4HME 'Crystal structure of cold-adapted chitinase from Moritella marina with a reaction product - NAG2'                       
+unspecified 
+PDB 4MB3 'Crystal structure of E153Q mutant of cold-adapted chitinase from Moritella marina'                                      
+unspecified 
+PDB 4MB5 'Crystal structure of E153Q mutant of cold-adapted chitinase from Moritella complex with Nag5'                           
+unspecified 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Malecki, P.H.'  1 
+'Vorgias, C.E.'  2 
+'Rypniewski, W.' 3 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 
+'Crystal structures of substrate-bound chitinase from the psychrophilic bacterium Moritella marina and its structure in solution' 
+'Acta Crystallogr.,Sect.D' 70 676 684 2014 ABCRE6 DK 0907-4449 0766 ? 24598737 10.1107/S1399004713032264 
+1       'Structure of a complete four-domain chitinase from Moritella marina, a marine psychrophilic bacterium' 
+'Acta Crystallogr.,Sect.D' 69 821 829 2013 ABCRE6 DK 0907-4449 0766 ? 23633591 10.1107/S0907444913002011 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+_citation_author.identifier_ORCID 
+primary 'Malecki, P.H.'   1 ? 
+primary 'Vorgias, C.E.'   2 ? 
+primary 'Petoukhov, M.V.' 3 ? 
+primary 'Svergun, D.I.'   4 ? 
+primary 'Rypniewski, W.'  5 ? 
+1       'Malecki, P.H.'   6 ? 
+1       'Raczynska, J.E.' 7 ? 
+1       'Vorgias, C.E.'   8 ? 
+1       'Rypniewski, W.'  9 ? 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     man 'Chitinase 60' 58616.371 1   3.2.1.14 E153Q ? ? 
+2 branched    man 
+;2-acetamido-2-deoxy-beta-D-glucopyranose-(1-4)-2-acetamido-2-deoxy-beta-D-glucopyranose-(1-4)-2-acetamido-2-deoxy-beta-D-glucopyranose-(1-4)-2-acetamido-2-deoxy-beta-D-glucopyranose
+;
+830.786   1   ?        ?     ? ? 
+3 non-polymer syn GLYCEROL 92.094    3   ?        ?     ? ? 
+4 non-polymer syn 'SODIUM ION' 22.990    1   ?        ?     ? ? 
+5 non-polymer syn 'SULFATE ION' 96.063    1   ?        ?     ? ? 
+6 non-polymer syn GLYCINE 75.067    3   ?        ?     ? ? 
+7 water       nat water 18.015    687 ?        ?     ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;GTITSQDDNVVVGYWHNWCDGRGYQGGNAPCVELKTVNPQYNVVNISFMKVYDIAEGRIPTFKLDPTIALSEAEFIAQID
+TLNSQGRSVLIALGGADAHIELTRGDEDALAAEIIRLTDLYGFDGLDIDLQQAAITAKDNQFVIPAALKMVKEHYRKTGD
+NFMITMAPEFPYLTANGAYTPYLTELDGYYDFINPQFYNQGGDGLWIEGVGWIAQNNDALKEEFIYYIADSLINGTRNYH
+KIPHDKLVFGLPSNIDAAATGYIQDPQDLYKAFDRLKAQGQPLRGVMTWSVNWDMGTDAANNSYNQQFIKDYGNFIHNQL
+PPVTDMTPTLSGIVDTRVELDSHFDPLIGITAKDYQGNDITADVTVSGSVNTNQVGDYLLTYSVSSDDETTNQPRKITVY
+EILPAFTGITDTTVVIDSEFDPMQGVSASHPTQGDLTANITVTGEVDTNVVGVYELTYQLFYGQDNQQNMTDKRIVTVVT
+DAVSDDDWQVGSTYVKDDKVTHNGATWTAQWWTKGEEPGTTGEWGVWR
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;GTITSQDDNVVVGYWHNWCDGRGYQGGNAPCVELKTVNPQYNVVNISFMKVYDIAEGRIPTFKLDPTIALSEAEFIAQID
+TLNSQGRSVLIALGGADAHIELTRGDEDALAAEIIRLTDLYGFDGLDIDLQQAAITAKDNQFVIPAALKMVKEHYRKTGD
+NFMITMAPEFPYLTANGAYTPYLTELDGYYDFINPQFYNQGGDGLWIEGVGWIAQNNDALKEEFIYYIADSLINGTRNYH
+KIPHDKLVFGLPSNIDAAATGYIQDPQDLYKAFDRLKAQGQPLRGVMTWSVNWDMGTDAANNSYNQQFIKDYGNFIHNQL
+PPVTDMTPTLSGIVDTRVELDSHFDPLIGITAKDYQGNDITADVTVSGSVNTNQVGDYLLTYSVSSDDETTNQPRKITVY
+EILPAFTGITDTTVVIDSEFDPMQGVSASHPTQGDLTANITVTGEVDTNVVGVYELTYQLFYGQDNQQNMTDKRIVTVVT
+DAVSDDDWQVGSTYVKDDKVTHNGATWTAQWWTKGEEPGTTGEWGVWR
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_pdbx_entity_nonpoly.entity_id 
+_pdbx_entity_nonpoly.name 
+_pdbx_entity_nonpoly.comp_id 
+3 GLYCEROL      GOL 
+4 'SODIUM ION'  NA  
+5 'SULFATE ION' SO4 
+6 GLYCINE       GLY 
+7 water         HOH 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   GLY n 
+1 2   THR n 
+1 3   ILE n 
+1 4   THR n 
+1 5   SER n 
+1 6   GLN n 
+1 7   ASP n 
+1 8   ASP n 
+1 9   ASN n 
+1 10  VAL n 
+1 11  VAL n 
+1 12  VAL n 
+1 13  GLY n 
+1 14  TYR n 
+1 15  TRP n 
+1 16  HIS n 
+1 17  ASN n 
+1 18  TRP n 
+1 19  CYS n 
+1 20  ASP n 
+1 21  GLY n 
+1 22  ARG n 
+1 23  GLY n 
+1 24  TYR n 
+1 25  GLN n 
+1 26  GLY n 
+1 27  GLY n 
+1 28  ASN n 
+1 29  ALA n 
+1 30  PRO n 
+1 31  CYS n 
+1 32  VAL n 
+1 33  GLU n 
+1 34  LEU n 
+1 35  LYS n 
+1 36  THR n 
+1 37  VAL n 
+1 38  ASN n 
+1 39  PRO n 
+1 40  GLN n 
+1 41  TYR n 
+1 42  ASN n 
+1 43  VAL n 
+1 44  VAL n 
+1 45  ASN n 
+1 46  ILE n 
+1 47  SER n 
+1 48  PHE n 
+1 49  MET n 
+1 50  LYS n 
+1 51  VAL n 
+1 52  TYR n 
+1 53  ASP n 
+1 54  ILE n 
+1 55  ALA n 
+1 56  GLU n 
+1 57  GLY n 
+1 58  ARG n 
+1 59  ILE n 
+1 60  PRO n 
+1 61  THR n 
+1 62  PHE n 
+1 63  LYS n 
+1 64  LEU n 
+1 65  ASP n 
+1 66  PRO n 
+1 67  THR n 
+1 68  ILE n 
+1 69  ALA n 
+1 70  LEU n 
+1 71  SER n 
+1 72  GLU n 
+1 73  ALA n 
+1 74  GLU n 
+1 75  PHE n 
+1 76  ILE n 
+1 77  ALA n 
+1 78  GLN n 
+1 79  ILE n 
+1 80  ASP n 
+1 81  THR n 
+1 82  LEU n 
+1 83  ASN n 
+1 84  SER n 
+1 85  GLN n 
+1 86  GLY n 
+1 87  ARG n 
+1 88  SER n 
+1 89  VAL n 
+1 90  LEU n 
+1 91  ILE n 
+1 92  ALA n 
+1 93  LEU n 
+1 94  GLY n 
+1 95  GLY n 
+1 96  ALA n 
+1 97  ASP n 
+1 98  ALA n 
+1 99  HIS n 
+1 100 ILE n 
+1 101 GLU n 
+1 102 LEU n 
+1 103 THR n 
+1 104 ARG n 
+1 105 GLY n 
+1 106 ASP n 
+1 107 GLU n 
+1 108 ASP n 
+1 109 ALA n 
+1 110 LEU n 
+1 111 ALA n 
+1 112 ALA n 
+1 113 GLU n 
+1 114 ILE n 
+1 115 ILE n 
+1 116 ARG n 
+1 117 LEU n 
+1 118 THR n 
+1 119 ASP n 
+1 120 LEU n 
+1 121 TYR n 
+1 122 GLY n 
+1 123 PHE n 
+1 124 ASP n 
+1 125 GLY n 
+1 126 LEU n 
+1 127 ASP n 
+1 128 ILE n 
+1 129 ASP n 
+1 130 LEU n 
+1 131 GLN n 
+1 132 GLN n 
+1 133 ALA n 
+1 134 ALA n 
+1 135 ILE n 
+1 136 THR n 
+1 137 ALA n 
+1 138 LYS n 
+1 139 ASP n 
+1 140 ASN n 
+1 141 GLN n 
+1 142 PHE n 
+1 143 VAL n 
+1 144 ILE n 
+1 145 PRO n 
+1 146 ALA n 
+1 147 ALA n 
+1 148 LEU n 
+1 149 LYS n 
+1 150 MET n 
+1 151 VAL n 
+1 152 LYS n 
+1 153 GLU n 
+1 154 HIS n 
+1 155 TYR n 
+1 156 ARG n 
+1 157 LYS n 
+1 158 THR n 
+1 159 GLY n 
+1 160 ASP n 
+1 161 ASN n 
+1 162 PHE n 
+1 163 MET n 
+1 164 ILE n 
+1 165 THR n 
+1 166 MET n 
+1 167 ALA n 
+1 168 PRO n 
+1 169 GLU n 
+1 170 PHE n 
+1 171 PRO n 
+1 172 TYR n 
+1 173 LEU n 
+1 174 THR n 
+1 175 ALA n 
+1 176 ASN n 
+1 177 GLY n 
+1 178 ALA n 
+1 179 TYR n 
+1 180 THR n 
+1 181 PRO n 
+1 182 TYR n 
+1 183 LEU n 
+1 184 THR n 
+1 185 GLU n 
+1 186 LEU n 
+1 187 ASP n 
+1 188 GLY n 
+1 189 TYR n 
+1 190 TYR n 
+1 191 ASP n 
+1 192 PHE n 
+1 193 ILE n 
+1 194 ASN n 
+1 195 PRO n 
+1 196 GLN n 
+1 197 PHE n 
+1 198 TYR n 
+1 199 ASN n 
+1 200 GLN n 
+1 201 GLY n 
+1 202 GLY n 
+1 203 ASP n 
+1 204 GLY n 
+1 205 LEU n 
+1 206 TRP n 
+1 207 ILE n 
+1 208 GLU n 
+1 209 GLY n 
+1 210 VAL n 
+1 211 GLY n 
+1 212 TRP n 
+1 213 ILE n 
+1 214 ALA n 
+1 215 GLN n 
+1 216 ASN n 
+1 217 ASN n 
+1 218 ASP n 
+1 219 ALA n 
+1 220 LEU n 
+1 221 LYS n 
+1 222 GLU n 
+1 223 GLU n 
+1 224 PHE n 
+1 225 ILE n 
+1 226 TYR n 
+1 227 TYR n 
+1 228 ILE n 
+1 229 ALA n 
+1 230 ASP n 
+1 231 SER n 
+1 232 LEU n 
+1 233 ILE n 
+1 234 ASN n 
+1 235 GLY n 
+1 236 THR n 
+1 237 ARG n 
+1 238 ASN n 
+1 239 TYR n 
+1 240 HIS n 
+1 241 LYS n 
+1 242 ILE n 
+1 243 PRO n 
+1 244 HIS n 
+1 245 ASP n 
+1 246 LYS n 
+1 247 LEU n 
+1 248 VAL n 
+1 249 PHE n 
+1 250 GLY n 
+1 251 LEU n 
+1 252 PRO n 
+1 253 SER n 
+1 254 ASN n 
+1 255 ILE n 
+1 256 ASP n 
+1 257 ALA n 
+1 258 ALA n 
+1 259 ALA n 
+1 260 THR n 
+1 261 GLY n 
+1 262 TYR n 
+1 263 ILE n 
+1 264 GLN n 
+1 265 ASP n 
+1 266 PRO n 
+1 267 GLN n 
+1 268 ASP n 
+1 269 LEU n 
+1 270 TYR n 
+1 271 LYS n 
+1 272 ALA n 
+1 273 PHE n 
+1 274 ASP n 
+1 275 ARG n 
+1 276 LEU n 
+1 277 LYS n 
+1 278 ALA n 
+1 279 GLN n 
+1 280 GLY n 
+1 281 GLN n 
+1 282 PRO n 
+1 283 LEU n 
+1 284 ARG n 
+1 285 GLY n 
+1 286 VAL n 
+1 287 MET n 
+1 288 THR n 
+1 289 TRP n 
+1 290 SER n 
+1 291 VAL n 
+1 292 ASN n 
+1 293 TRP n 
+1 294 ASP n 
+1 295 MET n 
+1 296 GLY n 
+1 297 THR n 
+1 298 ASP n 
+1 299 ALA n 
+1 300 ALA n 
+1 301 ASN n 
+1 302 ASN n 
+1 303 SER n 
+1 304 TYR n 
+1 305 ASN n 
+1 306 GLN n 
+1 307 GLN n 
+1 308 PHE n 
+1 309 ILE n 
+1 310 LYS n 
+1 311 ASP n 
+1 312 TYR n 
+1 313 GLY n 
+1 314 ASN n 
+1 315 PHE n 
+1 316 ILE n 
+1 317 HIS n 
+1 318 ASN n 
+1 319 GLN n 
+1 320 LEU n 
+1 321 PRO n 
+1 322 PRO n 
+1 323 VAL n 
+1 324 THR n 
+1 325 ASP n 
+1 326 MET n 
+1 327 THR n 
+1 328 PRO n 
+1 329 THR n 
+1 330 LEU n 
+1 331 SER n 
+1 332 GLY n 
+1 333 ILE n 
+1 334 VAL n 
+1 335 ASP n 
+1 336 THR n 
+1 337 ARG n 
+1 338 VAL n 
+1 339 GLU n 
+1 340 LEU n 
+1 341 ASP n 
+1 342 SER n 
+1 343 HIS n 
+1 344 PHE n 
+1 345 ASP n 
+1 346 PRO n 
+1 347 LEU n 
+1 348 ILE n 
+1 349 GLY n 
+1 350 ILE n 
+1 351 THR n 
+1 352 ALA n 
+1 353 LYS n 
+1 354 ASP n 
+1 355 TYR n 
+1 356 GLN n 
+1 357 GLY n 
+1 358 ASN n 
+1 359 ASP n 
+1 360 ILE n 
+1 361 THR n 
+1 362 ALA n 
+1 363 ASP n 
+1 364 VAL n 
+1 365 THR n 
+1 366 VAL n 
+1 367 SER n 
+1 368 GLY n 
+1 369 SER n 
+1 370 VAL n 
+1 371 ASN n 
+1 372 THR n 
+1 373 ASN n 
+1 374 GLN n 
+1 375 VAL n 
+1 376 GLY n 
+1 377 ASP n 
+1 378 TYR n 
+1 379 LEU n 
+1 380 LEU n 
+1 381 THR n 
+1 382 TYR n 
+1 383 SER n 
+1 384 VAL n 
+1 385 SER n 
+1 386 SER n 
+1 387 ASP n 
+1 388 ASP n 
+1 389 GLU n 
+1 390 THR n 
+1 391 THR n 
+1 392 ASN n 
+1 393 GLN n 
+1 394 PRO n 
+1 395 ARG n 
+1 396 LYS n 
+1 397 ILE n 
+1 398 THR n 
+1 399 VAL n 
+1 400 TYR n 
+1 401 GLU n 
+1 402 ILE n 
+1 403 LEU n 
+1 404 PRO n 
+1 405 ALA n 
+1 406 PHE n 
+1 407 THR n 
+1 408 GLY n 
+1 409 ILE n 
+1 410 THR n 
+1 411 ASP n 
+1 412 THR n 
+1 413 THR n 
+1 414 VAL n 
+1 415 VAL n 
+1 416 ILE n 
+1 417 ASP n 
+1 418 SER n 
+1 419 GLU n 
+1 420 PHE n 
+1 421 ASP n 
+1 422 PRO n 
+1 423 MET n 
+1 424 GLN n 
+1 425 GLY n 
+1 426 VAL n 
+1 427 SER n 
+1 428 ALA n 
+1 429 SER n 
+1 430 HIS n 
+1 431 PRO n 
+1 432 THR n 
+1 433 GLN n 
+1 434 GLY n 
+1 435 ASP n 
+1 436 LEU n 
+1 437 THR n 
+1 438 ALA n 
+1 439 ASN n 
+1 440 ILE n 
+1 441 THR n 
+1 442 VAL n 
+1 443 THR n 
+1 444 GLY n 
+1 445 GLU n 
+1 446 VAL n 
+1 447 ASP n 
+1 448 THR n 
+1 449 ASN n 
+1 450 VAL n 
+1 451 VAL n 
+1 452 GLY n 
+1 453 VAL n 
+1 454 TYR n 
+1 455 GLU n 
+1 456 LEU n 
+1 457 THR n 
+1 458 TYR n 
+1 459 GLN n 
+1 460 LEU n 
+1 461 PHE n 
+1 462 TYR n 
+1 463 GLY n 
+1 464 GLN n 
+1 465 ASP n 
+1 466 ASN n 
+1 467 GLN n 
+1 468 GLN n 
+1 469 ASN n 
+1 470 MET n 
+1 471 THR n 
+1 472 ASP n 
+1 473 LYS n 
+1 474 ARG n 
+1 475 ILE n 
+1 476 VAL n 
+1 477 THR n 
+1 478 VAL n 
+1 479 VAL n 
+1 480 THR n 
+1 481 ASP n 
+1 482 ALA n 
+1 483 VAL n 
+1 484 SER n 
+1 485 ASP n 
+1 486 ASP n 
+1 487 ASP n 
+1 488 TRP n 
+1 489 GLN n 
+1 490 VAL n 
+1 491 GLY n 
+1 492 SER n 
+1 493 THR n 
+1 494 TYR n 
+1 495 VAL n 
+1 496 LYS n 
+1 497 ASP n 
+1 498 ASP n 
+1 499 LYS n 
+1 500 VAL n 
+1 501 THR n 
+1 502 HIS n 
+1 503 ASN n 
+1 504 GLY n 
+1 505 ALA n 
+1 506 THR n 
+1 507 TRP n 
+1 508 THR n 
+1 509 ALA n 
+1 510 GLN n 
+1 511 TRP n 
+1 512 TRP n 
+1 513 THR n 
+1 514 LYS n 
+1 515 GLY n 
+1 516 GLU n 
+1 517 GLU n 
+1 518 PRO n 
+1 519 GLY n 
+1 520 THR n 
+1 521 THR n 
+1 522 GLY n 
+1 523 GLU n 
+1 524 TRP n 
+1 525 GLY n 
+1 526 VAL n 
+1 527 TRP n 
+1 528 ARG n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     ? 
+_entity_src_gen.pdbx_gene_src_gene                 chi60 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Moritella marina' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     90736 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Escherichia coli' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     562 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          Plasmid 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       pET-11a 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_pdbx_entity_branch.entity_id   2 
+_pdbx_entity_branch.type        oligosaccharide 
+# 
+loop_
+_pdbx_entity_branch_descriptor.ordinal 
+_pdbx_entity_branch_descriptor.entity_id 
+_pdbx_entity_branch_descriptor.descriptor 
+_pdbx_entity_branch_descriptor.type 
+_pdbx_entity_branch_descriptor.program 
+_pdbx_entity_branch_descriptor.program_version 
+1 2 DGlcpNAcb1-4DGlcpNAcb1-4DGlcpNAcb1-4DGlcpNAcb1-ROH                                    'Glycam Condensed Sequence' GMML       
+1.0   
+2 2 'WURCS=2.0/1,4,3/[a2122h-1b_1-5_2*NCC/3=O]/1-1-1-1/a4-b1_b4-c1_c4-d1'                 WURCS                       PDB2Glycan 
+1.1.0 
+3 2 '[][b-D-GlcpNAc]{[(4+1)][b-D-GlcpNAc]{[(4+1)][b-D-GlcpNAc]{[(4+1)][b-D-GlcpNAc]{}}}}' LINUCS                      PDB-CARE   ? 
+# 
+loop_
+_pdbx_entity_branch_link.link_id 
+_pdbx_entity_branch_link.entity_id 
+_pdbx_entity_branch_link.entity_branch_list_num_1 
+_pdbx_entity_branch_link.comp_id_1 
+_pdbx_entity_branch_link.atom_id_1 
+_pdbx_entity_branch_link.leaving_atom_id_1 
+_pdbx_entity_branch_link.entity_branch_list_num_2 
+_pdbx_entity_branch_link.comp_id_2 
+_pdbx_entity_branch_link.atom_id_2 
+_pdbx_entity_branch_link.leaving_atom_id_2 
+_pdbx_entity_branch_link.value_order 
+_pdbx_entity_branch_link.details 
+1 2 2 NAG C1 O1 1 NAG O4 HO4 sing ? 
+2 2 2 NAG C1 O1 1 NDG O4 HO4 sing ? 
+3 2 3 NAG C1 O1 2 NAG O4 HO4 sing ? 
+4 2 4 NAG C1 O1 3 NAG O4 HO4 sing ? 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking'           y ALANINE                                   ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking'           y ARGININE                                  ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking'           y ASPARAGINE                                ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking'           y 'ASPARTIC ACID'                           ? 'C4 H7 N O4'     133.103 
+CYS 'L-peptide linking'           y CYSTEINE                                  ? 'C3 H7 N O2 S'   121.158 
+GLN 'L-peptide linking'           y GLUTAMINE                                 ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking'           y 'GLUTAMIC ACID'                           ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'             y GLYCINE                                   ? 'C2 H5 N O2'     75.067  
+GOL non-polymer                   . GLYCEROL                                  'GLYCERIN; PROPANE-1,2,3-TRIOL' 'C3 H8 O3'       
+92.094  
+HIS 'L-peptide linking'           y HISTIDINE                                 ? 'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer                   . WATER                                     ? 'H2 O'           18.015  
+ILE 'L-peptide linking'           y ISOLEUCINE                                ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking'           y LEUCINE                                   ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking'           y LYSINE                                    ? 'C6 H15 N2 O2 1' 147.195 
+MET 'L-peptide linking'           y METHIONINE                                ? 'C5 H11 N O2 S'  149.211 
+NA  non-polymer                   . 'SODIUM ION'                              ? 'Na 1'           22.990  
+NAG 'D-saccharide, beta linking'  . 2-acetamido-2-deoxy-beta-D-glucopyranose  
+;N-acetyl-beta-D-glucosamine; 2-acetamido-2-deoxy-beta-D-glucose; 2-acetamido-2-deoxy-D-glucose; 2-acetamido-2-deoxy-glucose; N-ACETYL-D-GLUCOSAMINE
+;
+'C8 H15 N O6'    221.208 
+NDG 'D-saccharide, alpha linking' . 2-acetamido-2-deoxy-alpha-D-glucopyranose 
+;N-acetyl-alpha-D-glucosamine; 2-acetamido-2-deoxy-alpha-D-glucose; 2-acetamido-2-deoxy-D-glucose; 2-acetamido-2-deoxy-glucose; 2-(ACETYLAMINO)-2-DEOXY-A-D-GLUCOPYRANOSE
+;
+'C8 H15 N O6'    221.208 
+PHE 'L-peptide linking'           y PHENYLALANINE                             ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking'           y PROLINE                                   ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking'           y SERINE                                    ? 'C3 H7 N O3'     105.093 
+SO4 non-polymer                   . 'SULFATE ION'                             ? 'O4 S -2'        96.063  
+THR 'L-peptide linking'           y THREONINE                                 ? 'C4 H9 N O3'     119.119 
+TRP 'L-peptide linking'           y TRYPTOPHAN                                ? 'C11 H12 N2 O2'  204.225 
+TYR 'L-peptide linking'           y TYROSINE                                  ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking'           y VALINE                                    ? 'C5 H11 N O2'    117.146 
+# 
+loop_
+_pdbx_chem_comp_identifier.comp_id 
+_pdbx_chem_comp_identifier.type 
+_pdbx_chem_comp_identifier.program 
+_pdbx_chem_comp_identifier.program_version 
+_pdbx_chem_comp_identifier.identifier 
+NAG 'CONDENSED IUPAC CARBOHYDRATE SYMBOL' GMML     1.0 DGlcpNAcb                      
+NAG 'COMMON NAME'                         GMML     1.0 N-acetyl-b-D-glucopyranosamine 
+NAG 'IUPAC CARBOHYDRATE SYMBOL'           PDB-CARE 1.0 b-D-GlcpNAc                    
+NAG 'SNFG CARBOHYDRATE SYMBOL'            GMML     1.0 GlcNAc                         
+NDG 'CONDENSED IUPAC CARBOHYDRATE SYMBOL' GMML     1.0 DGlcpNAca                      
+NDG 'COMMON NAME'                         GMML     1.0 N-acetyl-a-D-glucopyranosamine 
+NDG 'IUPAC CARBOHYDRATE SYMBOL'           PDB-CARE 1.0 a-D-GlcpNAc                    
+NDG 'SNFG CARBOHYDRATE SYMBOL'            GMML     1.0 GlcNAc                         
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   GLY 1   23  23  GLY GLY A . n 
+A 1 2   THR 2   24  24  THR THR A . n 
+A 1 3   ILE 3   25  25  ILE ILE A . n 
+A 1 4   THR 4   26  26  THR THR A . n 
+A 1 5   SER 5   27  27  SER SER A . n 
+A 1 6   GLN 6   28  28  GLN GLN A . n 
+A 1 7   ASP 7   29  29  ASP ASP A . n 
+A 1 8   ASP 8   30  30  ASP ASP A . n 
+A 1 9   ASN 9   31  31  ASN ASN A . n 
+A 1 10  VAL 10  32  32  VAL VAL A . n 
+A 1 11  VAL 11  33  33  VAL VAL A . n 
+A 1 12  VAL 12  34  34  VAL VAL A . n 
+A 1 13  GLY 13  35  35  GLY GLY A . n 
+A 1 14  TYR 14  36  36  TYR TYR A . n 
+A 1 15  TRP 15  37  37  TRP TRP A . n 
+A 1 16  HIS 16  38  38  HIS HIS A . n 
+A 1 17  ASN 17  39  39  ASN ASN A . n 
+A 1 18  TRP 18  40  40  TRP TRP A . n 
+A 1 19  CYS 19  41  41  CYS CYS A . n 
+A 1 20  ASP 20  42  42  ASP ASP A . n 
+A 1 21  GLY 21  43  43  GLY GLY A . n 
+A 1 22  ARG 22  44  44  ARG ARG A . n 
+A 1 23  GLY 23  45  45  GLY GLY A . n 
+A 1 24  TYR 24  46  46  TYR TYR A . n 
+A 1 25  GLN 25  47  47  GLN GLN A . n 
+A 1 26  GLY 26  48  48  GLY GLY A . n 
+A 1 27  GLY 27  49  49  GLY GLY A . n 
+A 1 28  ASN 28  50  50  ASN ASN A . n 
+A 1 29  ALA 29  51  51  ALA ALA A . n 
+A 1 30  PRO 30  52  52  PRO PRO A . n 
+A 1 31  CYS 31  53  53  CYS CYS A . n 
+A 1 32  VAL 32  54  54  VAL VAL A . n 
+A 1 33  GLU 33  55  55  GLU GLU A . n 
+A 1 34  LEU 34  56  56  LEU LEU A . n 
+A 1 35  LYS 35  57  57  LYS LYS A . n 
+A 1 36  THR 36  58  58  THR THR A . n 
+A 1 37  VAL 37  59  59  VAL VAL A . n 
+A 1 38  ASN 38  60  60  ASN ASN A . n 
+A 1 39  PRO 39  61  61  PRO PRO A . n 
+A 1 40  GLN 40  62  62  GLN GLN A . n 
+A 1 41  TYR 41  63  63  TYR TYR A . n 
+A 1 42  ASN 42  64  64  ASN ASN A . n 
+A 1 43  VAL 43  65  65  VAL VAL A . n 
+A 1 44  VAL 44  66  66  VAL VAL A . n 
+A 1 45  ASN 45  67  67  ASN ASN A . n 
+A 1 46  ILE 46  68  68  ILE ILE A . n 
+A 1 47  SER 47  69  69  SER SER A . n 
+A 1 48  PHE 48  70  70  PHE PHE A . n 
+A 1 49  MET 49  71  71  MET MET A . n 
+A 1 50  LYS 50  72  72  LYS LYS A . n 
+A 1 51  VAL 51  73  73  VAL VAL A . n 
+A 1 52  TYR 52  74  74  TYR TYR A . n 
+A 1 53  ASP 53  75  75  ASP ASP A . n 
+A 1 54  ILE 54  76  76  ILE ILE A . n 
+A 1 55  ALA 55  77  77  ALA ALA A . n 
+A 1 56  GLU 56  78  78  GLU GLU A . n 
+A 1 57  GLY 57  79  79  GLY GLY A . n 
+A 1 58  ARG 58  80  80  ARG ARG A . n 
+A 1 59  ILE 59  81  81  ILE ILE A . n 
+A 1 60  PRO 60  82  82  PRO PRO A . n 
+A 1 61  THR 61  83  83  THR THR A . n 
+A 1 62  PHE 62  84  84  PHE PHE A . n 
+A 1 63  LYS 63  85  85  LYS LYS A . n 
+A 1 64  LEU 64  86  86  LEU LEU A . n 
+A 1 65  ASP 65  87  87  ASP ASP A . n 
+A 1 66  PRO 66  88  88  PRO PRO A . n 
+A 1 67  THR 67  89  89  THR THR A . n 
+A 1 68  ILE 68  90  90  ILE ILE A . n 
+A 1 69  ALA 69  91  91  ALA ALA A . n 
+A 1 70  LEU 70  92  92  LEU LEU A . n 
+A 1 71  SER 71  93  93  SER SER A . n 
+A 1 72  GLU 72  94  94  GLU GLU A . n 
+A 1 73  ALA 73  95  95  ALA ALA A . n 
+A 1 74  GLU 74  96  96  GLU GLU A . n 
+A 1 75  PHE 75  97  97  PHE PHE A . n 
+A 1 76  ILE 76  98  98  ILE ILE A . n 
+A 1 77  ALA 77  99  99  ALA ALA A . n 
+A 1 78  GLN 78  100 100 GLN GLN A . n 
+A 1 79  ILE 79  101 101 ILE ILE A . n 
+A 1 80  ASP 80  102 102 ASP ASP A . n 
+A 1 81  THR 81  103 103 THR THR A . n 
+A 1 82  LEU 82  104 104 LEU LEU A . n 
+A 1 83  ASN 83  105 105 ASN ASN A . n 
+A 1 84  SER 84  106 106 SER SER A . n 
+A 1 85  GLN 85  107 107 GLN GLN A . n 
+A 1 86  GLY 86  108 108 GLY GLY A . n 
+A 1 87  ARG 87  109 109 ARG ARG A . n 
+A 1 88  SER 88  110 110 SER SER A . n 
+A 1 89  VAL 89  111 111 VAL VAL A . n 
+A 1 90  LEU 90  112 112 LEU LEU A . n 
+A 1 91  ILE 91  113 113 ILE ILE A . n 
+A 1 92  ALA 92  114 114 ALA ALA A . n 
+A 1 93  LEU 93  115 115 LEU LEU A . n 
+A 1 94  GLY 94  116 116 GLY GLY A . n 
+A 1 95  GLY 95  117 117 GLY GLY A . n 
+A 1 96  ALA 96  118 118 ALA ALA A . n 
+A 1 97  ASP 97  119 119 ASP ASP A . n 
+A 1 98  ALA 98  120 120 ALA ALA A . n 
+A 1 99  HIS 99  121 121 HIS HIS A . n 
+A 1 100 ILE 100 122 122 ILE ILE A . n 
+A 1 101 GLU 101 123 123 GLU GLU A . n 
+A 1 102 LEU 102 124 124 LEU LEU A . n 
+A 1 103 THR 103 125 125 THR THR A . n 
+A 1 104 ARG 104 126 126 ARG ARG A . n 
+A 1 105 GLY 105 127 127 GLY GLY A . n 
+A 1 106 ASP 106 128 128 ASP ASP A . n 
+A 1 107 GLU 107 129 129 GLU GLU A . n 
+A 1 108 ASP 108 130 130 ASP ASP A . n 
+A 1 109 ALA 109 131 131 ALA ALA A . n 
+A 1 110 LEU 110 132 132 LEU LEU A . n 
+A 1 111 ALA 111 133 133 ALA ALA A . n 
+A 1 112 ALA 112 134 134 ALA ALA A . n 
+A 1 113 GLU 113 135 135 GLU GLU A . n 
+A 1 114 ILE 114 136 136 ILE ILE A . n 
+A 1 115 ILE 115 137 137 ILE ILE A . n 
+A 1 116 ARG 116 138 138 ARG ARG A . n 
+A 1 117 LEU 117 139 139 LEU LEU A . n 
+A 1 118 THR 118 140 140 THR THR A . n 
+A 1 119 ASP 119 141 141 ASP ASP A . n 
+A 1 120 LEU 120 142 142 LEU LEU A . n 
+A 1 121 TYR 121 143 143 TYR TYR A . n 
+A 1 122 GLY 122 144 144 GLY GLY A . n 
+A 1 123 PHE 123 145 145 PHE PHE A . n 
+A 1 124 ASP 124 146 146 ASP ASP A . n 
+A 1 125 GLY 125 147 147 GLY GLY A . n 
+A 1 126 LEU 126 148 148 LEU LEU A . n 
+A 1 127 ASP 127 149 149 ASP ASP A . n 
+A 1 128 ILE 128 150 150 ILE ILE A . n 
+A 1 129 ASP 129 151 151 ASP ASP A . n 
+A 1 130 LEU 130 152 152 LEU LEU A . n 
+A 1 131 GLN 131 153 153 GLN GLN A . n 
+A 1 132 GLN 132 154 154 GLN GLN A . n 
+A 1 133 ALA 133 155 155 ALA ALA A . n 
+A 1 134 ALA 134 156 156 ALA ALA A . n 
+A 1 135 ILE 135 157 157 ILE ILE A . n 
+A 1 136 THR 136 158 158 THR THR A . n 
+A 1 137 ALA 137 159 159 ALA ALA A . n 
+A 1 138 LYS 138 160 160 LYS LYS A . n 
+A 1 139 ASP 139 161 161 ASP ASP A . n 
+A 1 140 ASN 140 162 162 ASN ASN A . n 
+A 1 141 GLN 141 163 163 GLN GLN A . n 
+A 1 142 PHE 142 164 164 PHE PHE A . n 
+A 1 143 VAL 143 165 165 VAL VAL A . n 
+A 1 144 ILE 144 166 166 ILE ILE A . n 
+A 1 145 PRO 145 167 167 PRO PRO A . n 
+A 1 146 ALA 146 168 168 ALA ALA A . n 
+A 1 147 ALA 147 169 169 ALA ALA A . n 
+A 1 148 LEU 148 170 170 LEU LEU A . n 
+A 1 149 LYS 149 171 171 LYS LYS A . n 
+A 1 150 MET 150 172 172 MET MET A . n 
+A 1 151 VAL 151 173 173 VAL VAL A . n 
+A 1 152 LYS 152 174 174 LYS LYS A . n 
+A 1 153 GLU 153 175 175 GLU GLU A . n 
+A 1 154 HIS 154 176 176 HIS HIS A . n 
+A 1 155 TYR 155 177 177 TYR TYR A . n 
+A 1 156 ARG 156 178 178 ARG ARG A . n 
+A 1 157 LYS 157 179 179 LYS LYS A . n 
+A 1 158 THR 158 180 180 THR THR A . n 
+A 1 159 GLY 159 181 181 GLY GLY A . n 
+A 1 160 ASP 160 182 182 ASP ASP A . n 
+A 1 161 ASN 161 183 183 ASN ASN A . n 
+A 1 162 PHE 162 184 184 PHE PHE A . n 
+A 1 163 MET 163 185 185 MET MET A . n 
+A 1 164 ILE 164 186 186 ILE ILE A . n 
+A 1 165 THR 165 187 187 THR THR A . n 
+A 1 166 MET 166 188 188 MET MET A . n 
+A 1 167 ALA 167 189 189 ALA ALA A . n 
+A 1 168 PRO 168 190 190 PRO PRO A . n 
+A 1 169 GLU 169 191 191 GLU GLU A . n 
+A 1 170 PHE 170 192 192 PHE PHE A . n 
+A 1 171 PRO 171 193 193 PRO PRO A . n 
+A 1 172 TYR 172 194 194 TYR TYR A . n 
+A 1 173 LEU 173 195 195 LEU LEU A . n 
+A 1 174 THR 174 196 196 THR THR A . n 
+A 1 175 ALA 175 197 197 ALA ALA A . n 
+A 1 176 ASN 176 198 198 ASN ASN A . n 
+A 1 177 GLY 177 199 199 GLY GLY A . n 
+A 1 178 ALA 178 200 200 ALA ALA A . n 
+A 1 179 TYR 179 201 201 TYR TYR A . n 
+A 1 180 THR 180 202 202 THR THR A . n 
+A 1 181 PRO 181 203 203 PRO PRO A . n 
+A 1 182 TYR 182 204 204 TYR TYR A . n 
+A 1 183 LEU 183 205 205 LEU LEU A . n 
+A 1 184 THR 184 206 206 THR THR A . n 
+A 1 185 GLU 185 207 207 GLU GLU A . n 
+A 1 186 LEU 186 208 208 LEU LEU A . n 
+A 1 187 ASP 187 209 209 ASP ASP A . n 
+A 1 188 GLY 188 210 210 GLY GLY A . n 
+A 1 189 TYR 189 211 211 TYR TYR A . n 
+A 1 190 TYR 190 212 212 TYR TYR A . n 
+A 1 191 ASP 191 213 213 ASP ASP A . n 
+A 1 192 PHE 192 214 214 PHE PHE A . n 
+A 1 193 ILE 193 215 215 ILE ILE A . n 
+A 1 194 ASN 194 216 216 ASN ASN A . n 
+A 1 195 PRO 195 217 217 PRO PRO A . n 
+A 1 196 GLN 196 218 218 GLN GLN A . n 
+A 1 197 PHE 197 219 219 PHE PHE A . n 
+A 1 198 TYR 198 220 220 TYR TYR A . n 
+A 1 199 ASN 199 221 221 ASN ASN A . n 
+A 1 200 GLN 200 222 222 GLN GLN A . n 
+A 1 201 GLY 201 223 223 GLY GLY A . n 
+A 1 202 GLY 202 224 224 GLY GLY A . n 
+A 1 203 ASP 203 225 225 ASP ASP A . n 
+A 1 204 GLY 204 226 226 GLY GLY A . n 
+A 1 205 LEU 205 227 227 LEU LEU A . n 
+A 1 206 TRP 206 228 228 TRP TRP A . n 
+A 1 207 ILE 207 229 229 ILE ILE A . n 
+A 1 208 GLU 208 230 230 GLU GLU A . n 
+A 1 209 GLY 209 231 231 GLY GLY A . n 
+A 1 210 VAL 210 232 232 VAL VAL A . n 
+A 1 211 GLY 211 233 233 GLY GLY A . n 
+A 1 212 TRP 212 234 234 TRP TRP A . n 
+A 1 213 ILE 213 235 235 ILE ILE A . n 
+A 1 214 ALA 214 236 236 ALA ALA A . n 
+A 1 215 GLN 215 237 237 GLN GLN A . n 
+A 1 216 ASN 216 238 238 ASN ASN A . n 
+A 1 217 ASN 217 239 239 ASN ASN A . n 
+A 1 218 ASP 218 240 240 ASP ASP A . n 
+A 1 219 ALA 219 241 241 ALA ALA A . n 
+A 1 220 LEU 220 242 242 LEU LEU A . n 
+A 1 221 LYS 221 243 243 LYS LYS A . n 
+A 1 222 GLU 222 244 244 GLU GLU A . n 
+A 1 223 GLU 223 245 245 GLU GLU A . n 
+A 1 224 PHE 224 246 246 PHE PHE A . n 
+A 1 225 ILE 225 247 247 ILE ILE A . n 
+A 1 226 TYR 226 248 248 TYR TYR A . n 
+A 1 227 TYR 227 249 249 TYR TYR A . n 
+A 1 228 ILE 228 250 250 ILE ILE A . n 
+A 1 229 ALA 229 251 251 ALA ALA A . n 
+A 1 230 ASP 230 252 252 ASP ASP A . n 
+A 1 231 SER 231 253 253 SER SER A . n 
+A 1 232 LEU 232 254 254 LEU LEU A . n 
+A 1 233 ILE 233 255 255 ILE ILE A . n 
+A 1 234 ASN 234 256 256 ASN ASN A . n 
+A 1 235 GLY 235 257 257 GLY GLY A . n 
+A 1 236 THR 236 258 258 THR THR A . n 
+A 1 237 ARG 237 259 259 ARG ARG A . n 
+A 1 238 ASN 238 260 260 ASN ASN A . n 
+A 1 239 TYR 239 261 261 TYR TYR A . n 
+A 1 240 HIS 240 262 262 HIS HIS A . n 
+A 1 241 LYS 241 263 263 LYS LYS A . n 
+A 1 242 ILE 242 264 264 ILE ILE A . n 
+A 1 243 PRO 243 265 265 PRO PRO A . n 
+A 1 244 HIS 244 266 266 HIS HIS A . n 
+A 1 245 ASP 245 267 267 ASP ASP A . n 
+A 1 246 LYS 246 268 268 LYS LYS A . n 
+A 1 247 LEU 247 269 269 LEU LEU A . n 
+A 1 248 VAL 248 270 270 VAL VAL A . n 
+A 1 249 PHE 249 271 271 PHE PHE A . n 
+A 1 250 GLY 250 272 272 GLY GLY A . n 
+A 1 251 LEU 251 273 273 LEU LEU A . n 
+A 1 252 PRO 252 274 274 PRO PRO A . n 
+A 1 253 SER 253 275 275 SER SER A . n 
+A 1 254 ASN 254 276 276 ASN ASN A . n 
+A 1 255 ILE 255 277 277 ILE ILE A . n 
+A 1 256 ASP 256 278 278 ASP ASP A . n 
+A 1 257 ALA 257 279 279 ALA ALA A . n 
+A 1 258 ALA 258 280 280 ALA ALA A . n 
+A 1 259 ALA 259 281 281 ALA ALA A . n 
+A 1 260 THR 260 282 282 THR THR A . n 
+A 1 261 GLY 261 283 283 GLY GLY A . n 
+A 1 262 TYR 262 284 284 TYR TYR A . n 
+A 1 263 ILE 263 285 285 ILE ILE A . n 
+A 1 264 GLN 264 286 286 GLN GLN A . n 
+A 1 265 ASP 265 287 287 ASP ASP A . n 
+A 1 266 PRO 266 288 288 PRO PRO A . n 
+A 1 267 GLN 267 289 289 GLN GLN A . n 
+A 1 268 ASP 268 290 290 ASP ASP A . n 
+A 1 269 LEU 269 291 291 LEU LEU A . n 
+A 1 270 TYR 270 292 292 TYR TYR A . n 
+A 1 271 LYS 271 293 293 LYS LYS A . n 
+A 1 272 ALA 272 294 294 ALA ALA A . n 
+A 1 273 PHE 273 295 295 PHE PHE A . n 
+A 1 274 ASP 274 296 296 ASP ASP A . n 
+A 1 275 ARG 275 297 297 ARG ARG A . n 
+A 1 276 LEU 276 298 298 LEU LEU A . n 
+A 1 277 LYS 277 299 299 LYS LYS A . n 
+A 1 278 ALA 278 300 300 ALA ALA A . n 
+A 1 279 GLN 279 301 301 GLN GLN A . n 
+A 1 280 GLY 280 302 302 GLY GLY A . n 
+A 1 281 GLN 281 303 303 GLN GLN A . n 
+A 1 282 PRO 282 304 304 PRO PRO A . n 
+A 1 283 LEU 283 305 305 LEU LEU A . n 
+A 1 284 ARG 284 306 306 ARG ARG A . n 
+A 1 285 GLY 285 307 307 GLY GLY A . n 
+A 1 286 VAL 286 308 308 VAL VAL A . n 
+A 1 287 MET 287 309 309 MET MET A . n 
+A 1 288 THR 288 310 310 THR THR A . n 
+A 1 289 TRP 289 311 311 TRP TRP A . n 
+A 1 290 SER 290 312 312 SER SER A . n 
+A 1 291 VAL 291 313 313 VAL VAL A . n 
+A 1 292 ASN 292 314 314 ASN ASN A . n 
+A 1 293 TRP 293 315 315 TRP TRP A . n 
+A 1 294 ASP 294 316 316 ASP ASP A . n 
+A 1 295 MET 295 317 317 MET MET A . n 
+A 1 296 GLY 296 318 318 GLY GLY A . n 
+A 1 297 THR 297 319 319 THR THR A . n 
+A 1 298 ASP 298 320 320 ASP ASP A . n 
+A 1 299 ALA 299 321 321 ALA ALA A . n 
+A 1 300 ALA 300 322 322 ALA ALA A . n 
+A 1 301 ASN 301 323 323 ASN ASN A . n 
+A 1 302 ASN 302 324 324 ASN ASN A . n 
+A 1 303 SER 303 325 325 SER SER A . n 
+A 1 304 TYR 304 326 326 TYR TYR A . n 
+A 1 305 ASN 305 327 327 ASN ASN A . n 
+A 1 306 GLN 306 328 328 GLN GLN A . n 
+A 1 307 GLN 307 329 329 GLN GLN A . n 
+A 1 308 PHE 308 330 330 PHE PHE A . n 
+A 1 309 ILE 309 331 331 ILE ILE A . n 
+A 1 310 LYS 310 332 332 LYS LYS A . n 
+A 1 311 ASP 311 333 333 ASP ASP A . n 
+A 1 312 TYR 312 334 334 TYR TYR A . n 
+A 1 313 GLY 313 335 335 GLY GLY A . n 
+A 1 314 ASN 314 336 336 ASN ASN A . n 
+A 1 315 PHE 315 337 337 PHE PHE A . n 
+A 1 316 ILE 316 338 338 ILE ILE A . n 
+A 1 317 HIS 317 339 339 HIS HIS A . n 
+A 1 318 ASN 318 340 340 ASN ASN A . n 
+A 1 319 GLN 319 341 341 GLN GLN A . n 
+A 1 320 LEU 320 342 342 LEU LEU A . n 
+A 1 321 PRO 321 343 343 PRO PRO A . n 
+A 1 322 PRO 322 344 344 PRO PRO A . n 
+A 1 323 VAL 323 345 345 VAL VAL A . n 
+A 1 324 THR 324 346 346 THR THR A . n 
+A 1 325 ASP 325 347 347 ASP ASP A . n 
+A 1 326 MET 326 348 348 MET MET A . n 
+A 1 327 THR 327 349 349 THR THR A . n 
+A 1 328 PRO 328 350 350 PRO PRO A . n 
+A 1 329 THR 329 351 351 THR THR A . n 
+A 1 330 LEU 330 352 352 LEU LEU A . n 
+A 1 331 SER 331 353 353 SER SER A . n 
+A 1 332 GLY 332 354 354 GLY GLY A . n 
+A 1 333 ILE 333 355 355 ILE ILE A . n 
+A 1 334 VAL 334 356 356 VAL VAL A . n 
+A 1 335 ASP 335 357 357 ASP ASP A . n 
+A 1 336 THR 336 358 358 THR THR A . n 
+A 1 337 ARG 337 359 359 ARG ARG A . n 
+A 1 338 VAL 338 360 360 VAL VAL A . n 
+A 1 339 GLU 339 361 361 GLU GLU A . n 
+A 1 340 LEU 340 362 362 LEU LEU A . n 
+A 1 341 ASP 341 363 363 ASP ASP A . n 
+A 1 342 SER 342 364 364 SER SER A . n 
+A 1 343 HIS 343 365 365 HIS HIS A . n 
+A 1 344 PHE 344 366 366 PHE PHE A . n 
+A 1 345 ASP 345 367 367 ASP ASP A . n 
+A 1 346 PRO 346 368 368 PRO PRO A . n 
+A 1 347 LEU 347 369 369 LEU LEU A . n 
+A 1 348 ILE 348 370 370 ILE ILE A . n 
+A 1 349 GLY 349 371 371 GLY GLY A . n 
+A 1 350 ILE 350 372 372 ILE ILE A . n 
+A 1 351 THR 351 373 373 THR THR A . n 
+A 1 352 ALA 352 374 374 ALA ALA A . n 
+A 1 353 LYS 353 375 375 LYS LYS A . n 
+A 1 354 ASP 354 376 376 ASP ASP A . n 
+A 1 355 TYR 355 377 377 TYR TYR A . n 
+A 1 356 GLN 356 378 378 GLN GLN A . n 
+A 1 357 GLY 357 379 379 GLY GLY A . n 
+A 1 358 ASN 358 380 380 ASN ASN A . n 
+A 1 359 ASP 359 381 381 ASP ASP A . n 
+A 1 360 ILE 360 382 382 ILE ILE A . n 
+A 1 361 THR 361 383 383 THR THR A . n 
+A 1 362 ALA 362 384 384 ALA ALA A . n 
+A 1 363 ASP 363 385 385 ASP ASP A . n 
+A 1 364 VAL 364 386 386 VAL VAL A . n 
+A 1 365 THR 365 387 387 THR THR A . n 
+A 1 366 VAL 366 388 388 VAL VAL A . n 
+A 1 367 SER 367 389 389 SER SER A . n 
+A 1 368 GLY 368 390 390 GLY GLY A . n 
+A 1 369 SER 369 391 391 SER SER A . n 
+A 1 370 VAL 370 392 392 VAL VAL A . n 
+A 1 371 ASN 371 393 393 ASN ASN A . n 
+A 1 372 THR 372 394 394 THR THR A . n 
+A 1 373 ASN 373 395 395 ASN ASN A . n 
+A 1 374 GLN 374 396 396 GLN GLN A . n 
+A 1 375 VAL 375 397 397 VAL VAL A . n 
+A 1 376 GLY 376 398 398 GLY GLY A . n 
+A 1 377 ASP 377 399 399 ASP ASP A . n 
+A 1 378 TYR 378 400 400 TYR TYR A . n 
+A 1 379 LEU 379 401 401 LEU LEU A . n 
+A 1 380 LEU 380 402 402 LEU LEU A . n 
+A 1 381 THR 381 403 403 THR THR A . n 
+A 1 382 TYR 382 404 404 TYR TYR A . n 
+A 1 383 SER 383 405 405 SER SER A . n 
+A 1 384 VAL 384 406 406 VAL VAL A . n 
+A 1 385 SER 385 407 407 SER SER A . n 
+A 1 386 SER 386 408 408 SER SER A . n 
+A 1 387 ASP 387 409 409 ASP ASP A . n 
+A 1 388 ASP 388 410 410 ASP ASP A . n 
+A 1 389 GLU 389 411 411 GLU GLU A . n 
+A 1 390 THR 390 412 412 THR THR A . n 
+A 1 391 THR 391 413 413 THR THR A . n 
+A 1 392 ASN 392 414 414 ASN ASN A . n 
+A 1 393 GLN 393 415 415 GLN GLN A . n 
+A 1 394 PRO 394 416 416 PRO PRO A . n 
+A 1 395 ARG 395 417 417 ARG ARG A . n 
+A 1 396 LYS 396 418 418 LYS LYS A . n 
+A 1 397 ILE 397 419 419 ILE ILE A . n 
+A 1 398 THR 398 420 420 THR THR A . n 
+A 1 399 VAL 399 421 421 VAL VAL A . n 
+A 1 400 TYR 400 422 422 TYR TYR A . n 
+A 1 401 GLU 401 423 423 GLU GLU A . n 
+A 1 402 ILE 402 424 424 ILE ILE A . n 
+A 1 403 LEU 403 425 425 LEU LEU A . n 
+A 1 404 PRO 404 426 426 PRO PRO A . n 
+A 1 405 ALA 405 427 427 ALA ALA A . n 
+A 1 406 PHE 406 428 428 PHE PHE A . n 
+A 1 407 THR 407 429 429 THR THR A . n 
+A 1 408 GLY 408 430 430 GLY GLY A . n 
+A 1 409 ILE 409 431 431 ILE ILE A . n 
+A 1 410 THR 410 432 432 THR THR A . n 
+A 1 411 ASP 411 433 433 ASP ASP A . n 
+A 1 412 THR 412 434 434 THR THR A . n 
+A 1 413 THR 413 435 435 THR THR A . n 
+A 1 414 VAL 414 436 436 VAL VAL A . n 
+A 1 415 VAL 415 437 437 VAL VAL A . n 
+A 1 416 ILE 416 438 438 ILE ILE A . n 
+A 1 417 ASP 417 439 439 ASP ASP A . n 
+A 1 418 SER 418 440 440 SER SER A . n 
+A 1 419 GLU 419 441 441 GLU GLU A . n 
+A 1 420 PHE 420 442 442 PHE PHE A . n 
+A 1 421 ASP 421 443 443 ASP ASP A . n 
+A 1 422 PRO 422 444 444 PRO PRO A . n 
+A 1 423 MET 423 445 445 MET MET A . n 
+A 1 424 GLN 424 446 446 GLN GLN A . n 
+A 1 425 GLY 425 447 447 GLY GLY A . n 
+A 1 426 VAL 426 448 448 VAL VAL A . n 
+A 1 427 SER 427 449 449 SER SER A . n 
+A 1 428 ALA 428 450 450 ALA ALA A . n 
+A 1 429 SER 429 451 451 SER SER A . n 
+A 1 430 HIS 430 452 452 HIS HIS A . n 
+A 1 431 PRO 431 453 453 PRO PRO A . n 
+A 1 432 THR 432 454 454 THR THR A . n 
+A 1 433 GLN 433 455 455 GLN GLN A . n 
+A 1 434 GLY 434 456 456 GLY GLY A . n 
+A 1 435 ASP 435 457 457 ASP ASP A . n 
+A 1 436 LEU 436 458 458 LEU LEU A . n 
+A 1 437 THR 437 459 459 THR THR A . n 
+A 1 438 ALA 438 460 460 ALA ALA A . n 
+A 1 439 ASN 439 461 461 ASN ASN A . n 
+A 1 440 ILE 440 462 462 ILE ILE A . n 
+A 1 441 THR 441 463 463 THR THR A . n 
+A 1 442 VAL 442 464 464 VAL VAL A . n 
+A 1 443 THR 443 465 465 THR THR A . n 
+A 1 444 GLY 444 466 466 GLY GLY A . n 
+A 1 445 GLU 445 467 467 GLU GLU A . n 
+A 1 446 VAL 446 468 468 VAL VAL A . n 
+A 1 447 ASP 447 469 469 ASP ASP A . n 
+A 1 448 THR 448 470 470 THR THR A . n 
+A 1 449 ASN 449 471 471 ASN ASN A . n 
+A 1 450 VAL 450 472 472 VAL VAL A . n 
+A 1 451 VAL 451 473 473 VAL VAL A . n 
+A 1 452 GLY 452 474 474 GLY GLY A . n 
+A 1 453 VAL 453 475 475 VAL VAL A . n 
+A 1 454 TYR 454 476 476 TYR TYR A . n 
+A 1 455 GLU 455 477 477 GLU GLU A . n 
+A 1 456 LEU 456 478 478 LEU LEU A . n 
+A 1 457 THR 457 479 479 THR THR A . n 
+A 1 458 TYR 458 480 480 TYR TYR A . n 
+A 1 459 GLN 459 481 481 GLN GLN A . n 
+A 1 460 LEU 460 482 482 LEU LEU A . n 
+A 1 461 PHE 461 483 483 PHE PHE A . n 
+A 1 462 TYR 462 484 484 TYR TYR A . n 
+A 1 463 GLY 463 485 485 GLY GLY A . n 
+A 1 464 GLN 464 486 486 GLN GLN A . n 
+A 1 465 ASP 465 487 487 ASP ASP A . n 
+A 1 466 ASN 466 488 488 ASN ASN A . n 
+A 1 467 GLN 467 489 489 GLN GLN A . n 
+A 1 468 GLN 468 490 490 GLN GLN A . n 
+A 1 469 ASN 469 491 491 ASN ASN A . n 
+A 1 470 MET 470 492 492 MET MET A . n 
+A 1 471 THR 471 493 493 THR THR A . n 
+A 1 472 ASP 472 494 494 ASP ASP A . n 
+A 1 473 LYS 473 495 495 LYS LYS A . n 
+A 1 474 ARG 474 496 496 ARG ARG A . n 
+A 1 475 ILE 475 497 497 ILE ILE A . n 
+A 1 476 VAL 476 498 498 VAL VAL A . n 
+A 1 477 THR 477 499 499 THR THR A . n 
+A 1 478 VAL 478 500 500 VAL VAL A . n 
+A 1 479 VAL 479 501 501 VAL VAL A . n 
+A 1 480 THR 480 502 502 THR THR A . n 
+A 1 481 ASP 481 503 503 ASP ASP A . n 
+A 1 482 ALA 482 504 504 ALA ALA A . n 
+A 1 483 VAL 483 505 505 VAL VAL A . n 
+A 1 484 SER 484 506 506 SER SER A . n 
+A 1 485 ASP 485 507 507 ASP ASP A . n 
+A 1 486 ASP 486 508 508 ASP ASP A . n 
+A 1 487 ASP 487 509 509 ASP ASP A . n 
+A 1 488 TRP 488 510 510 TRP TRP A . n 
+A 1 489 GLN 489 511 511 GLN GLN A . n 
+A 1 490 VAL 490 512 512 VAL VAL A . n 
+A 1 491 GLY 491 513 513 GLY GLY A . n 
+A 1 492 SER 492 514 514 SER SER A . n 
+A 1 493 THR 493 515 515 THR THR A . n 
+A 1 494 TYR 494 516 516 TYR TYR A . n 
+A 1 495 VAL 495 517 517 VAL VAL A . n 
+A 1 496 LYS 496 518 518 LYS LYS A . n 
+A 1 497 ASP 497 519 519 ASP ASP A . n 
+A 1 498 ASP 498 520 520 ASP ASP A . n 
+A 1 499 LYS 499 521 521 LYS LYS A . n 
+A 1 500 VAL 500 522 522 VAL VAL A . n 
+A 1 501 THR 501 523 523 THR THR A . n 
+A 1 502 HIS 502 524 524 HIS HIS A . n 
+A 1 503 ASN 503 525 525 ASN ASN A . n 
+A 1 504 GLY 504 526 526 GLY GLY A . n 
+A 1 505 ALA 505 527 527 ALA ALA A . n 
+A 1 506 THR 506 528 528 THR THR A . n 
+A 1 507 TRP 507 529 529 TRP TRP A . n 
+A 1 508 THR 508 530 530 THR THR A . n 
+A 1 509 ALA 509 531 531 ALA ALA A . n 
+A 1 510 GLN 510 532 532 GLN GLN A . n 
+A 1 511 TRP 511 533 533 TRP TRP A . n 
+A 1 512 TRP 512 534 534 TRP TRP A . n 
+A 1 513 THR 513 535 535 THR THR A . n 
+A 1 514 LYS 514 536 536 LYS LYS A . n 
+A 1 515 GLY 515 537 537 GLY GLY A . n 
+A 1 516 GLU 516 538 538 GLU GLU A . n 
+A 1 517 GLU 517 539 539 GLU GLU A . n 
+A 1 518 PRO 518 540 540 PRO PRO A . n 
+A 1 519 GLY 519 541 541 GLY GLY A . n 
+A 1 520 THR 520 542 542 THR THR A . n 
+A 1 521 THR 521 543 543 THR THR A . n 
+A 1 522 GLY 522 544 544 GLY GLY A . n 
+A 1 523 GLU 523 545 545 GLU GLU A . n 
+A 1 524 TRP 524 546 546 TRP TRP A . n 
+A 1 525 GLY 525 547 547 GLY GLY A . n 
+A 1 526 VAL 526 548 548 VAL VAL A . n 
+A 1 527 TRP 527 549 549 TRP TRP A . n 
+A 1 528 ARG 528 550 550 ARG ARG A . n 
+# 
+loop_
+_pdbx_branch_scheme.asym_id 
+_pdbx_branch_scheme.entity_id 
+_pdbx_branch_scheme.mon_id 
+_pdbx_branch_scheme.num 
+_pdbx_branch_scheme.pdb_asym_id 
+_pdbx_branch_scheme.pdb_mon_id 
+_pdbx_branch_scheme.pdb_seq_num 
+_pdbx_branch_scheme.auth_asym_id 
+_pdbx_branch_scheme.auth_mon_id 
+_pdbx_branch_scheme.auth_seq_num 
+_pdbx_branch_scheme.hetero 
+B 2 NAG 1 B NAG 1 A NAG 612 y 
+B 2 NDG 1 B NDG 1 A NDG 613 y 
+B 2 NAG 2 B NAG 2 A NAG 611 n 
+B 2 NAG 3 B NAG 3 A NAG 610 n 
+B 2 NAG 4 B NAG 4 A NAG 609 n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+C 3 GOL 1   601  601  GOL GOL A . 
+D 3 GOL 1   602  602  GOL GOL A . 
+E 3 GOL 1   603  603  GOL GOL A . 
+F 4 NA  1   604  604  NA  NA  A . 
+G 5 SO4 1   605  605  SO4 SO4 A . 
+H 6 GLY 1   606  606  GLY GLY A . 
+I 6 GLY 1   607  607  GLY GLY A . 
+J 6 GLY 1   608  608  GLY GLY A . 
+K 7 HOH 1   701  701  HOH HOH A . 
+K 7 HOH 2   702  702  HOH HOH A . 
+K 7 HOH 3   703  703  HOH HOH A . 
+K 7 HOH 4   704  704  HOH HOH A . 
+K 7 HOH 5   705  705  HOH HOH A . 
+K 7 HOH 6   706  706  HOH HOH A . 
+K 7 HOH 7   707  707  HOH HOH A . 
+K 7 HOH 8   708  708  HOH HOH A . 
+K 7 HOH 9   709  709  HOH HOH A . 
+K 7 HOH 10  710  710  HOH HOH A . 
+K 7 HOH 11  711  711  HOH HOH A . 
+K 7 HOH 12  712  712  HOH HOH A . 
+K 7 HOH 13  713  713  HOH HOH A . 
+K 7 HOH 14  714  714  HOH HOH A . 
+K 7 HOH 15  715  715  HOH HOH A . 
+K 7 HOH 16  716  716  HOH HOH A . 
+K 7 HOH 17  717  717  HOH HOH A . 
+K 7 HOH 18  718  718  HOH HOH A . 
+K 7 HOH 19  719  719  HOH HOH A . 
+K 7 HOH 20  720  720  HOH HOH A . 
+K 7 HOH 21  721  721  HOH HOH A . 
+K 7 HOH 22  722  722  HOH HOH A . 
+K 7 HOH 23  723  723  HOH HOH A . 
+K 7 HOH 24  724  724  HOH HOH A . 
+K 7 HOH 25  725  725  HOH HOH A . 
+K 7 HOH 26  726  726  HOH HOH A . 
+K 7 HOH 27  727  727  HOH HOH A . 
+K 7 HOH 28  728  728  HOH HOH A . 
+K 7 HOH 29  729  729  HOH HOH A . 
+K 7 HOH 30  730  730  HOH HOH A . 
+K 7 HOH 31  731  731  HOH HOH A . 
+K 7 HOH 32  732  732  HOH HOH A . 
+K 7 HOH 33  733  733  HOH HOH A . 
+K 7 HOH 34  734  734  HOH HOH A . 
+K 7 HOH 35  735  735  HOH HOH A . 
+K 7 HOH 36  736  736  HOH HOH A . 
+K 7 HOH 37  737  737  HOH HOH A . 
+K 7 HOH 38  738  738  HOH HOH A . 
+K 7 HOH 39  739  739  HOH HOH A . 
+K 7 HOH 40  740  740  HOH HOH A . 
+K 7 HOH 41  741  741  HOH HOH A . 
+K 7 HOH 42  742  742  HOH HOH A . 
+K 7 HOH 43  743  743  HOH HOH A . 
+K 7 HOH 44  744  744  HOH HOH A . 
+K 7 HOH 45  745  745  HOH HOH A . 
+K 7 HOH 46  746  746  HOH HOH A . 
+K 7 HOH 47  747  747  HOH HOH A . 
+K 7 HOH 48  748  748  HOH HOH A . 
+K 7 HOH 49  749  749  HOH HOH A . 
+K 7 HOH 50  750  750  HOH HOH A . 
+K 7 HOH 51  751  751  HOH HOH A . 
+K 7 HOH 52  752  752  HOH HOH A . 
+K 7 HOH 53  753  753  HOH HOH A . 
+K 7 HOH 54  754  754  HOH HOH A . 
+K 7 HOH 55  755  755  HOH HOH A . 
+K 7 HOH 56  756  756  HOH HOH A . 
+K 7 HOH 57  757  757  HOH HOH A . 
+K 7 HOH 58  758  758  HOH HOH A . 
+K 7 HOH 59  759  759  HOH HOH A . 
+K 7 HOH 60  760  760  HOH HOH A . 
+K 7 HOH 61  761  761  HOH HOH A . 
+K 7 HOH 62  762  762  HOH HOH A . 
+K 7 HOH 63  763  763  HOH HOH A . 
+K 7 HOH 64  764  764  HOH HOH A . 
+K 7 HOH 65  765  765  HOH HOH A . 
+K 7 HOH 66  766  766  HOH HOH A . 
+K 7 HOH 67  767  767  HOH HOH A . 
+K 7 HOH 68  768  768  HOH HOH A . 
+K 7 HOH 69  769  769  HOH HOH A . 
+K 7 HOH 70  770  770  HOH HOH A . 
+K 7 HOH 71  771  771  HOH HOH A . 
+K 7 HOH 72  772  772  HOH HOH A . 
+K 7 HOH 73  773  773  HOH HOH A . 
+K 7 HOH 74  774  774  HOH HOH A . 
+K 7 HOH 75  775  775  HOH HOH A . 
+K 7 HOH 76  776  776  HOH HOH A . 
+K 7 HOH 77  777  777  HOH HOH A . 
+K 7 HOH 78  778  778  HOH HOH A . 
+K 7 HOH 79  779  779  HOH HOH A . 
+K 7 HOH 80  780  780  HOH HOH A . 
+K 7 HOH 81  781  781  HOH HOH A . 
+K 7 HOH 82  782  782  HOH HOH A . 
+K 7 HOH 83  783  783  HOH HOH A . 
+K 7 HOH 84  784  784  HOH HOH A . 
+K 7 HOH 85  785  785  HOH HOH A . 
+K 7 HOH 86  786  786  HOH HOH A . 
+K 7 HOH 87  787  787  HOH HOH A . 
+K 7 HOH 88  788  788  HOH HOH A . 
+K 7 HOH 89  789  789  HOH HOH A . 
+K 7 HOH 90  790  790  HOH HOH A . 
+K 7 HOH 91  791  791  HOH HOH A . 
+K 7 HOH 92  792  792  HOH HOH A . 
+K 7 HOH 93  793  793  HOH HOH A . 
+K 7 HOH 94  794  794  HOH HOH A . 
+K 7 HOH 95  795  795  HOH HOH A . 
+K 7 HOH 96  796  796  HOH HOH A . 
+K 7 HOH 97  797  797  HOH HOH A . 
+K 7 HOH 98  798  798  HOH HOH A . 
+K 7 HOH 99  799  799  HOH HOH A . 
+K 7 HOH 100 800  800  HOH HOH A . 
+K 7 HOH 101 801  801  HOH HOH A . 
+K 7 HOH 102 802  802  HOH HOH A . 
+K 7 HOH 103 803  803  HOH HOH A . 
+K 7 HOH 104 804  804  HOH HOH A . 
+K 7 HOH 105 805  805  HOH HOH A . 
+K 7 HOH 106 806  806  HOH HOH A . 
+K 7 HOH 107 807  807  HOH HOH A . 
+K 7 HOH 108 808  808  HOH HOH A . 
+K 7 HOH 109 809  809  HOH HOH A . 
+K 7 HOH 110 810  810  HOH HOH A . 
+K 7 HOH 111 811  811  HOH HOH A . 
+K 7 HOH 112 812  812  HOH HOH A . 
+K 7 HOH 113 813  813  HOH HOH A . 
+K 7 HOH 114 814  814  HOH HOH A . 
+K 7 HOH 115 815  815  HOH HOH A . 
+K 7 HOH 116 816  816  HOH HOH A . 
+K 7 HOH 117 817  817  HOH HOH A . 
+K 7 HOH 118 818  818  HOH HOH A . 
+K 7 HOH 119 819  819  HOH HOH A . 
+K 7 HOH 120 820  820  HOH HOH A . 
+K 7 HOH 121 821  821  HOH HOH A . 
+K 7 HOH 122 822  822  HOH HOH A . 
+K 7 HOH 123 823  823  HOH HOH A . 
+K 7 HOH 124 824  824  HOH HOH A . 
+K 7 HOH 125 825  825  HOH HOH A . 
+K 7 HOH 126 826  826  HOH HOH A . 
+K 7 HOH 127 827  827  HOH HOH A . 
+K 7 HOH 128 828  828  HOH HOH A . 
+K 7 HOH 129 829  829  HOH HOH A . 
+K 7 HOH 130 830  830  HOH HOH A . 
+K 7 HOH 131 831  831  HOH HOH A . 
+K 7 HOH 132 832  832  HOH HOH A . 
+K 7 HOH 133 833  833  HOH HOH A . 
+K 7 HOH 134 834  834  HOH HOH A . 
+K 7 HOH 135 835  835  HOH HOH A . 
+K 7 HOH 136 836  836  HOH HOH A . 
+K 7 HOH 137 837  837  HOH HOH A . 
+K 7 HOH 138 838  838  HOH HOH A . 
+K 7 HOH 139 839  839  HOH HOH A . 
+K 7 HOH 140 840  840  HOH HOH A . 
+K 7 HOH 141 841  841  HOH HOH A . 
+K 7 HOH 142 842  842  HOH HOH A . 
+K 7 HOH 143 843  843  HOH HOH A . 
+K 7 HOH 144 844  844  HOH HOH A . 
+K 7 HOH 145 845  845  HOH HOH A . 
+K 7 HOH 146 846  846  HOH HOH A . 
+K 7 HOH 147 847  847  HOH HOH A . 
+K 7 HOH 148 848  848  HOH HOH A . 
+K 7 HOH 149 849  849  HOH HOH A . 
+K 7 HOH 150 850  850  HOH HOH A . 
+K 7 HOH 151 851  851  HOH HOH A . 
+K 7 HOH 152 852  852  HOH HOH A . 
+K 7 HOH 153 853  853  HOH HOH A . 
+K 7 HOH 154 854  854  HOH HOH A . 
+K 7 HOH 155 855  855  HOH HOH A . 
+K 7 HOH 156 856  856  HOH HOH A . 
+K 7 HOH 157 857  857  HOH HOH A . 
+K 7 HOH 158 858  858  HOH HOH A . 
+K 7 HOH 159 859  859  HOH HOH A . 
+K 7 HOH 160 860  860  HOH HOH A . 
+K 7 HOH 161 861  861  HOH HOH A . 
+K 7 HOH 162 862  862  HOH HOH A . 
+K 7 HOH 163 863  863  HOH HOH A . 
+K 7 HOH 164 864  864  HOH HOH A . 
+K 7 HOH 165 865  865  HOH HOH A . 
+K 7 HOH 166 866  866  HOH HOH A . 
+K 7 HOH 167 867  867  HOH HOH A . 
+K 7 HOH 168 868  868  HOH HOH A . 
+K 7 HOH 169 869  869  HOH HOH A . 
+K 7 HOH 170 870  870  HOH HOH A . 
+K 7 HOH 171 871  871  HOH HOH A . 
+K 7 HOH 172 872  872  HOH HOH A . 
+K 7 HOH 173 873  873  HOH HOH A . 
+K 7 HOH 174 874  874  HOH HOH A . 
+K 7 HOH 175 875  875  HOH HOH A . 
+K 7 HOH 176 876  876  HOH HOH A . 
+K 7 HOH 177 877  877  HOH HOH A . 
+K 7 HOH 178 878  878  HOH HOH A . 
+K 7 HOH 179 879  879  HOH HOH A . 
+K 7 HOH 180 880  880  HOH HOH A . 
+K 7 HOH 181 881  881  HOH HOH A . 
+K 7 HOH 182 882  882  HOH HOH A . 
+K 7 HOH 183 883  883  HOH HOH A . 
+K 7 HOH 184 884  884  HOH HOH A . 
+K 7 HOH 185 885  885  HOH HOH A . 
+K 7 HOH 186 886  886  HOH HOH A . 
+K 7 HOH 187 887  887  HOH HOH A . 
+K 7 HOH 188 888  888  HOH HOH A . 
+K 7 HOH 189 889  889  HOH HOH A . 
+K 7 HOH 190 890  890  HOH HOH A . 
+K 7 HOH 191 891  891  HOH HOH A . 
+K 7 HOH 192 892  892  HOH HOH A . 
+K 7 HOH 193 893  893  HOH HOH A . 
+K 7 HOH 194 894  894  HOH HOH A . 
+K 7 HOH 195 895  895  HOH HOH A . 
+K 7 HOH 196 896  896  HOH HOH A . 
+K 7 HOH 197 897  897  HOH HOH A . 
+K 7 HOH 198 898  898  HOH HOH A . 
+K 7 HOH 199 899  899  HOH HOH A . 
+K 7 HOH 200 900  900  HOH HOH A . 
+K 7 HOH 201 901  901  HOH HOH A . 
+K 7 HOH 202 902  902  HOH HOH A . 
+K 7 HOH 203 903  903  HOH HOH A . 
+K 7 HOH 204 904  904  HOH HOH A . 
+K 7 HOH 205 905  905  HOH HOH A . 
+K 7 HOH 206 906  906  HOH HOH A . 
+K 7 HOH 207 907  907  HOH HOH A . 
+K 7 HOH 208 908  908  HOH HOH A . 
+K 7 HOH 209 909  909  HOH HOH A . 
+K 7 HOH 210 910  910  HOH HOH A . 
+K 7 HOH 211 911  911  HOH HOH A . 
+K 7 HOH 212 912  912  HOH HOH A . 
+K 7 HOH 213 913  913  HOH HOH A . 
+K 7 HOH 214 914  914  HOH HOH A . 
+K 7 HOH 215 915  915  HOH HOH A . 
+K 7 HOH 216 916  916  HOH HOH A . 
+K 7 HOH 217 917  917  HOH HOH A . 
+K 7 HOH 218 918  918  HOH HOH A . 
+K 7 HOH 219 919  919  HOH HOH A . 
+K 7 HOH 220 920  920  HOH HOH A . 
+K 7 HOH 221 921  921  HOH HOH A . 
+K 7 HOH 222 922  922  HOH HOH A . 
+K 7 HOH 223 923  923  HOH HOH A . 
+K 7 HOH 224 924  924  HOH HOH A . 
+K 7 HOH 225 925  925  HOH HOH A . 
+K 7 HOH 226 926  926  HOH HOH A . 
+K 7 HOH 227 927  927  HOH HOH A . 
+K 7 HOH 228 928  928  HOH HOH A . 
+K 7 HOH 229 929  929  HOH HOH A . 
+K 7 HOH 230 930  930  HOH HOH A . 
+K 7 HOH 231 931  931  HOH HOH A . 
+K 7 HOH 232 932  932  HOH HOH A . 
+K 7 HOH 233 933  933  HOH HOH A . 
+K 7 HOH 234 934  934  HOH HOH A . 
+K 7 HOH 235 935  935  HOH HOH A . 
+K 7 HOH 236 936  936  HOH HOH A . 
+K 7 HOH 237 937  937  HOH HOH A . 
+K 7 HOH 238 938  938  HOH HOH A . 
+K 7 HOH 239 939  939  HOH HOH A . 
+K 7 HOH 240 940  940  HOH HOH A . 
+K 7 HOH 241 941  941  HOH HOH A . 
+K 7 HOH 242 942  942  HOH HOH A . 
+K 7 HOH 243 943  943  HOH HOH A . 
+K 7 HOH 244 944  944  HOH HOH A . 
+K 7 HOH 245 945  945  HOH HOH A . 
+K 7 HOH 246 946  946  HOH HOH A . 
+K 7 HOH 247 947  947  HOH HOH A . 
+K 7 HOH 248 948  948  HOH HOH A . 
+K 7 HOH 249 949  949  HOH HOH A . 
+K 7 HOH 250 950  950  HOH HOH A . 
+K 7 HOH 251 951  951  HOH HOH A . 
+K 7 HOH 252 952  952  HOH HOH A . 
+K 7 HOH 253 953  953  HOH HOH A . 
+K 7 HOH 254 954  954  HOH HOH A . 
+K 7 HOH 255 955  955  HOH HOH A . 
+K 7 HOH 256 956  956  HOH HOH A . 
+K 7 HOH 257 957  957  HOH HOH A . 
+K 7 HOH 258 958  958  HOH HOH A . 
+K 7 HOH 259 959  959  HOH HOH A . 
+K 7 HOH 260 960  960  HOH HOH A . 
+K 7 HOH 261 961  961  HOH HOH A . 
+K 7 HOH 262 962  962  HOH HOH A . 
+K 7 HOH 263 963  963  HOH HOH A . 
+K 7 HOH 264 964  964  HOH HOH A . 
+K 7 HOH 265 965  965  HOH HOH A . 
+K 7 HOH 266 966  966  HOH HOH A . 
+K 7 HOH 267 967  967  HOH HOH A . 
+K 7 HOH 268 968  968  HOH HOH A . 
+K 7 HOH 269 969  969  HOH HOH A . 
+K 7 HOH 270 970  970  HOH HOH A . 
+K 7 HOH 271 971  971  HOH HOH A . 
+K 7 HOH 272 972  972  HOH HOH A . 
+K 7 HOH 273 973  973  HOH HOH A . 
+K 7 HOH 274 974  974  HOH HOH A . 
+K 7 HOH 275 975  975  HOH HOH A . 
+K 7 HOH 276 976  976  HOH HOH A . 
+K 7 HOH 277 977  977  HOH HOH A . 
+K 7 HOH 278 978  978  HOH HOH A . 
+K 7 HOH 279 979  979  HOH HOH A . 
+K 7 HOH 280 980  980  HOH HOH A . 
+K 7 HOH 281 981  981  HOH HOH A . 
+K 7 HOH 282 982  982  HOH HOH A . 
+K 7 HOH 283 983  983  HOH HOH A . 
+K 7 HOH 284 984  984  HOH HOH A . 
+K 7 HOH 285 985  985  HOH HOH A . 
+K 7 HOH 286 986  986  HOH HOH A . 
+K 7 HOH 287 987  987  HOH HOH A . 
+K 7 HOH 288 988  988  HOH HOH A . 
+K 7 HOH 289 989  989  HOH HOH A . 
+K 7 HOH 290 990  990  HOH HOH A . 
+K 7 HOH 291 991  991  HOH HOH A . 
+K 7 HOH 292 992  992  HOH HOH A . 
+K 7 HOH 293 993  993  HOH HOH A . 
+K 7 HOH 294 994  994  HOH HOH A . 
+K 7 HOH 295 995  995  HOH HOH A . 
+K 7 HOH 296 996  996  HOH HOH A . 
+K 7 HOH 297 997  997  HOH HOH A . 
+K 7 HOH 298 998  998  HOH HOH A . 
+K 7 HOH 299 999  999  HOH HOH A . 
+K 7 HOH 300 1000 1000 HOH HOH A . 
+K 7 HOH 301 1001 1001 HOH HOH A . 
+K 7 HOH 302 1002 1002 HOH HOH A . 
+K 7 HOH 303 1003 1003 HOH HOH A . 
+K 7 HOH 304 1004 1004 HOH HOH A . 
+K 7 HOH 305 1005 1005 HOH HOH A . 
+K 7 HOH 306 1006 1006 HOH HOH A . 
+K 7 HOH 307 1007 1007 HOH HOH A . 
+K 7 HOH 308 1008 1008 HOH HOH A . 
+K 7 HOH 309 1009 1009 HOH HOH A . 
+K 7 HOH 310 1010 1010 HOH HOH A . 
+K 7 HOH 311 1011 1011 HOH HOH A . 
+K 7 HOH 312 1012 1012 HOH HOH A . 
+K 7 HOH 313 1013 1013 HOH HOH A . 
+K 7 HOH 314 1014 1014 HOH HOH A . 
+K 7 HOH 315 1015 1015 HOH HOH A . 
+K 7 HOH 316 1016 1016 HOH HOH A . 
+K 7 HOH 317 1017 1017 HOH HOH A . 
+K 7 HOH 318 1018 1018 HOH HOH A . 
+K 7 HOH 319 1019 1019 HOH HOH A . 
+K 7 HOH 320 1020 1020 HOH HOH A . 
+K 7 HOH 321 1021 1021 HOH HOH A . 
+K 7 HOH 322 1022 1022 HOH HOH A . 
+K 7 HOH 323 1023 1023 HOH HOH A . 
+K 7 HOH 324 1024 1024 HOH HOH A . 
+K 7 HOH 325 1025 1025 HOH HOH A . 
+K 7 HOH 326 1026 1026 HOH HOH A . 
+K 7 HOH 327 1027 1027 HOH HOH A . 
+K 7 HOH 328 1028 1028 HOH HOH A . 
+K 7 HOH 329 1029 1029 HOH HOH A . 
+K 7 HOH 330 1030 1030 HOH HOH A . 
+K 7 HOH 331 1031 1031 HOH HOH A . 
+K 7 HOH 332 1032 1032 HOH HOH A . 
+K 7 HOH 333 1033 1033 HOH HOH A . 
+K 7 HOH 334 1034 1034 HOH HOH A . 
+K 7 HOH 335 1035 1035 HOH HOH A . 
+K 7 HOH 336 1036 1036 HOH HOH A . 
+K 7 HOH 337 1037 1037 HOH HOH A . 
+K 7 HOH 338 1038 1038 HOH HOH A . 
+K 7 HOH 339 1039 1039 HOH HOH A . 
+K 7 HOH 340 1040 1040 HOH HOH A . 
+K 7 HOH 341 1041 1041 HOH HOH A . 
+K 7 HOH 342 1042 1042 HOH HOH A . 
+K 7 HOH 343 1043 1043 HOH HOH A . 
+K 7 HOH 344 1044 1044 HOH HOH A . 
+K 7 HOH 345 1045 1045 HOH HOH A . 
+K 7 HOH 346 1046 1046 HOH HOH A . 
+K 7 HOH 347 1047 1047 HOH HOH A . 
+K 7 HOH 348 1048 1048 HOH HOH A . 
+K 7 HOH 349 1049 1049 HOH HOH A . 
+K 7 HOH 350 1050 1050 HOH HOH A . 
+K 7 HOH 351 1051 1051 HOH HOH A . 
+K 7 HOH 352 1052 1052 HOH HOH A . 
+K 7 HOH 353 1053 1053 HOH HOH A . 
+K 7 HOH 354 1054 1054 HOH HOH A . 
+K 7 HOH 355 1055 1055 HOH HOH A . 
+K 7 HOH 356 1056 1056 HOH HOH A . 
+K 7 HOH 357 1057 1057 HOH HOH A . 
+K 7 HOH 358 1058 1058 HOH HOH A . 
+K 7 HOH 359 1059 1059 HOH HOH A . 
+K 7 HOH 360 1060 1060 HOH HOH A . 
+K 7 HOH 361 1061 1061 HOH HOH A . 
+K 7 HOH 362 1062 1062 HOH HOH A . 
+K 7 HOH 363 1063 1063 HOH HOH A . 
+K 7 HOH 364 1064 1064 HOH HOH A . 
+K 7 HOH 365 1065 1065 HOH HOH A . 
+K 7 HOH 366 1066 1066 HOH HOH A . 
+K 7 HOH 367 1067 1067 HOH HOH A . 
+K 7 HOH 368 1068 1068 HOH HOH A . 
+K 7 HOH 369 1069 1069 HOH HOH A . 
+K 7 HOH 370 1070 1070 HOH HOH A . 
+K 7 HOH 371 1071 1071 HOH HOH A . 
+K 7 HOH 372 1072 1072 HOH HOH A . 
+K 7 HOH 373 1073 1073 HOH HOH A . 
+K 7 HOH 374 1074 1074 HOH HOH A . 
+K 7 HOH 375 1075 1075 HOH HOH A . 
+K 7 HOH 376 1076 1076 HOH HOH A . 
+K 7 HOH 377 1077 1077 HOH HOH A . 
+K 7 HOH 378 1078 1078 HOH HOH A . 
+K 7 HOH 379 1079 1079 HOH HOH A . 
+K 7 HOH 380 1080 1080 HOH HOH A . 
+K 7 HOH 381 1081 1081 HOH HOH A . 
+K 7 HOH 382 1082 1082 HOH HOH A . 
+K 7 HOH 383 1083 1083 HOH HOH A . 
+K 7 HOH 384 1084 1084 HOH HOH A . 
+K 7 HOH 385 1085 1085 HOH HOH A . 
+K 7 HOH 386 1086 1086 HOH HOH A . 
+K 7 HOH 387 1087 1087 HOH HOH A . 
+K 7 HOH 388 1088 1088 HOH HOH A . 
+K 7 HOH 389 1089 1089 HOH HOH A . 
+K 7 HOH 390 1090 1090 HOH HOH A . 
+K 7 HOH 391 1091 1091 HOH HOH A . 
+K 7 HOH 392 1092 1092 HOH HOH A . 
+K 7 HOH 393 1093 1093 HOH HOH A . 
+K 7 HOH 394 1094 1094 HOH HOH A . 
+K 7 HOH 395 1095 1095 HOH HOH A . 
+K 7 HOH 396 1096 1096 HOH HOH A . 
+K 7 HOH 397 1097 1097 HOH HOH A . 
+K 7 HOH 398 1098 1098 HOH HOH A . 
+K 7 HOH 399 1099 1099 HOH HOH A . 
+K 7 HOH 400 1100 1100 HOH HOH A . 
+K 7 HOH 401 1101 1101 HOH HOH A . 
+K 7 HOH 402 1102 1102 HOH HOH A . 
+K 7 HOH 403 1103 1103 HOH HOH A . 
+K 7 HOH 404 1104 1104 HOH HOH A . 
+K 7 HOH 405 1105 1105 HOH HOH A . 
+K 7 HOH 406 1106 1106 HOH HOH A . 
+K 7 HOH 407 1107 1107 HOH HOH A . 
+K 7 HOH 408 1108 1108 HOH HOH A . 
+K 7 HOH 409 1109 1109 HOH HOH A . 
+K 7 HOH 410 1110 1110 HOH HOH A . 
+K 7 HOH 411 1111 1111 HOH HOH A . 
+K 7 HOH 412 1112 1112 HOH HOH A . 
+K 7 HOH 413 1113 1113 HOH HOH A . 
+K 7 HOH 414 1114 1114 HOH HOH A . 
+K 7 HOH 415 1115 1115 HOH HOH A . 
+K 7 HOH 416 1116 1116 HOH HOH A . 
+K 7 HOH 417 1117 1117 HOH HOH A . 
+K 7 HOH 418 1118 1118 HOH HOH A . 
+K 7 HOH 419 1119 1119 HOH HOH A . 
+K 7 HOH 420 1120 1120 HOH HOH A . 
+K 7 HOH 421 1121 1121 HOH HOH A . 
+K 7 HOH 422 1122 1122 HOH HOH A . 
+K 7 HOH 423 1123 1123 HOH HOH A . 
+K 7 HOH 424 1124 1124 HOH HOH A . 
+K 7 HOH 425 1125 1125 HOH HOH A . 
+K 7 HOH 426 1126 1126 HOH HOH A . 
+K 7 HOH 427 1127 1127 HOH HOH A . 
+K 7 HOH 428 1128 1128 HOH HOH A . 
+K 7 HOH 429 1129 1129 HOH HOH A . 
+K 7 HOH 430 1130 1130 HOH HOH A . 
+K 7 HOH 431 1131 1131 HOH HOH A . 
+K 7 HOH 432 1132 1132 HOH HOH A . 
+K 7 HOH 433 1133 1133 HOH HOH A . 
+K 7 HOH 434 1134 1134 HOH HOH A . 
+K 7 HOH 435 1135 1135 HOH HOH A . 
+K 7 HOH 436 1136 1136 HOH HOH A . 
+K 7 HOH 437 1137 1137 HOH HOH A . 
+K 7 HOH 438 1138 1138 HOH HOH A . 
+K 7 HOH 439 1139 1139 HOH HOH A . 
+K 7 HOH 440 1140 1140 HOH HOH A . 
+K 7 HOH 441 1141 1141 HOH HOH A . 
+K 7 HOH 442 1142 1142 HOH HOH A . 
+K 7 HOH 443 1143 1143 HOH HOH A . 
+K 7 HOH 444 1144 1144 HOH HOH A . 
+K 7 HOH 445 1145 1145 HOH HOH A . 
+K 7 HOH 446 1146 1146 HOH HOH A . 
+K 7 HOH 447 1147 1147 HOH HOH A . 
+K 7 HOH 448 1148 1148 HOH HOH A . 
+K 7 HOH 449 1149 1149 HOH HOH A . 
+K 7 HOH 450 1150 1150 HOH HOH A . 
+K 7 HOH 451 1151 1151 HOH HOH A . 
+K 7 HOH 452 1152 1152 HOH HOH A . 
+K 7 HOH 453 1153 1153 HOH HOH A . 
+K 7 HOH 454 1154 1154 HOH HOH A . 
+K 7 HOH 455 1155 1155 HOH HOH A . 
+K 7 HOH 456 1156 1156 HOH HOH A . 
+K 7 HOH 457 1157 1157 HOH HOH A . 
+K 7 HOH 458 1158 1158 HOH HOH A . 
+K 7 HOH 459 1159 1159 HOH HOH A . 
+K 7 HOH 460 1160 1160 HOH HOH A . 
+K 7 HOH 461 1161 1161 HOH HOH A . 
+K 7 HOH 462 1162 1162 HOH HOH A . 
+K 7 HOH 463 1163 1163 HOH HOH A . 
+K 7 HOH 464 1164 1164 HOH HOH A . 
+K 7 HOH 465 1165 1165 HOH HOH A . 
+K 7 HOH 466 1166 1166 HOH HOH A . 
+K 7 HOH 467 1167 1167 HOH HOH A . 
+K 7 HOH 468 1168 1168 HOH HOH A . 
+K 7 HOH 469 1169 1169 HOH HOH A . 
+K 7 HOH 470 1170 1170 HOH HOH A . 
+K 7 HOH 471 1171 1171 HOH HOH A . 
+K 7 HOH 472 1172 1172 HOH HOH A . 
+K 7 HOH 473 1173 1173 HOH HOH A . 
+K 7 HOH 474 1174 1174 HOH HOH A . 
+K 7 HOH 475 1175 1175 HOH HOH A . 
+K 7 HOH 476 1176 1176 HOH HOH A . 
+K 7 HOH 477 1177 1177 HOH HOH A . 
+K 7 HOH 478 1178 1178 HOH HOH A . 
+K 7 HOH 479 1179 1179 HOH HOH A . 
+K 7 HOH 480 1180 1180 HOH HOH A . 
+K 7 HOH 481 1181 1181 HOH HOH A . 
+K 7 HOH 482 1182 1182 HOH HOH A . 
+K 7 HOH 483 1183 1183 HOH HOH A . 
+K 7 HOH 484 1184 1184 HOH HOH A . 
+K 7 HOH 485 1185 1185 HOH HOH A . 
+K 7 HOH 486 1186 1186 HOH HOH A . 
+K 7 HOH 487 1187 1187 HOH HOH A . 
+K 7 HOH 488 1188 1188 HOH HOH A . 
+K 7 HOH 489 1189 1189 HOH HOH A . 
+K 7 HOH 490 1190 1190 HOH HOH A . 
+K 7 HOH 491 1191 1191 HOH HOH A . 
+K 7 HOH 492 1192 1192 HOH HOH A . 
+K 7 HOH 493 1193 1193 HOH HOH A . 
+K 7 HOH 494 1194 1194 HOH HOH A . 
+K 7 HOH 495 1195 1195 HOH HOH A . 
+K 7 HOH 496 1196 1196 HOH HOH A . 
+K 7 HOH 497 1197 1197 HOH HOH A . 
+K 7 HOH 498 1198 1198 HOH HOH A . 
+K 7 HOH 499 1199 1199 HOH HOH A . 
+K 7 HOH 500 1200 1200 HOH HOH A . 
+K 7 HOH 501 1201 1201 HOH HOH A . 
+K 7 HOH 502 1202 1202 HOH HOH A . 
+K 7 HOH 503 1203 1203 HOH HOH A . 
+K 7 HOH 504 1204 1204 HOH HOH A . 
+K 7 HOH 505 1205 1205 HOH HOH A . 
+K 7 HOH 506 1206 1206 HOH HOH A . 
+K 7 HOH 507 1207 1207 HOH HOH A . 
+K 7 HOH 508 1208 1208 HOH HOH A . 
+K 7 HOH 509 1209 1209 HOH HOH A . 
+K 7 HOH 510 1210 1210 HOH HOH A . 
+K 7 HOH 511 1211 1211 HOH HOH A . 
+K 7 HOH 512 1212 1212 HOH HOH A . 
+K 7 HOH 513 1213 1213 HOH HOH A . 
+K 7 HOH 514 1214 1214 HOH HOH A . 
+K 7 HOH 515 1215 1215 HOH HOH A . 
+K 7 HOH 516 1216 1216 HOH HOH A . 
+K 7 HOH 517 1217 1217 HOH HOH A . 
+K 7 HOH 518 1218 1218 HOH HOH A . 
+K 7 HOH 519 1219 1219 HOH HOH A . 
+K 7 HOH 520 1220 1220 HOH HOH A . 
+K 7 HOH 521 1221 1221 HOH HOH A . 
+K 7 HOH 522 1222 1222 HOH HOH A . 
+K 7 HOH 523 1223 1223 HOH HOH A . 
+K 7 HOH 524 1224 1224 HOH HOH A . 
+K 7 HOH 525 1225 1225 HOH HOH A . 
+K 7 HOH 526 1226 1226 HOH HOH A . 
+K 7 HOH 527 1227 1227 HOH HOH A . 
+K 7 HOH 528 1228 1228 HOH HOH A . 
+K 7 HOH 529 1229 1229 HOH HOH A . 
+K 7 HOH 530 1230 1230 HOH HOH A . 
+K 7 HOH 531 1231 1231 HOH HOH A . 
+K 7 HOH 532 1232 1232 HOH HOH A . 
+K 7 HOH 533 1233 1233 HOH HOH A . 
+K 7 HOH 534 1234 1234 HOH HOH A . 
+K 7 HOH 535 1235 1235 HOH HOH A . 
+K 7 HOH 536 1236 1236 HOH HOH A . 
+K 7 HOH 537 1237 1237 HOH HOH A . 
+K 7 HOH 538 1238 1238 HOH HOH A . 
+K 7 HOH 539 1239 1239 HOH HOH A . 
+K 7 HOH 540 1240 1240 HOH HOH A . 
+K 7 HOH 541 1241 1241 HOH HOH A . 
+K 7 HOH 542 1242 1242 HOH HOH A . 
+K 7 HOH 543 1243 1243 HOH HOH A . 
+K 7 HOH 544 1244 1244 HOH HOH A . 
+K 7 HOH 545 1245 1245 HOH HOH A . 
+K 7 HOH 546 1246 1246 HOH HOH A . 
+K 7 HOH 547 1247 1247 HOH HOH A . 
+K 7 HOH 548 1248 1248 HOH HOH A . 
+K 7 HOH 549 1249 1249 HOH HOH A . 
+K 7 HOH 550 1250 1250 HOH HOH A . 
+K 7 HOH 551 1251 1251 HOH HOH A . 
+K 7 HOH 552 1252 1252 HOH HOH A . 
+K 7 HOH 553 1253 1253 HOH HOH A . 
+K 7 HOH 554 1254 1254 HOH HOH A . 
+K 7 HOH 555 1255 1255 HOH HOH A . 
+K 7 HOH 556 1256 1256 HOH HOH A . 
+K 7 HOH 557 1257 1257 HOH HOH A . 
+K 7 HOH 558 1258 1258 HOH HOH A . 
+K 7 HOH 559 1259 1259 HOH HOH A . 
+K 7 HOH 560 1260 1260 HOH HOH A . 
+K 7 HOH 561 1261 1261 HOH HOH A . 
+K 7 HOH 562 1262 1262 HOH HOH A . 
+K 7 HOH 563 1263 1263 HOH HOH A . 
+K 7 HOH 564 1264 1264 HOH HOH A . 
+K 7 HOH 565 1265 1265 HOH HOH A . 
+K 7 HOH 566 1266 1266 HOH HOH A . 
+K 7 HOH 567 1267 1267 HOH HOH A . 
+K 7 HOH 568 1268 1268 HOH HOH A . 
+K 7 HOH 569 1269 1269 HOH HOH A . 
+K 7 HOH 570 1270 1270 HOH HOH A . 
+K 7 HOH 571 1271 1271 HOH HOH A . 
+K 7 HOH 572 1272 1272 HOH HOH A . 
+K 7 HOH 573 1273 1273 HOH HOH A . 
+K 7 HOH 574 1274 1274 HOH HOH A . 
+K 7 HOH 575 1275 1275 HOH HOH A . 
+K 7 HOH 576 1276 1276 HOH HOH A . 
+K 7 HOH 577 1277 1277 HOH HOH A . 
+K 7 HOH 578 1278 1278 HOH HOH A . 
+K 7 HOH 579 1279 1279 HOH HOH A . 
+K 7 HOH 580 1280 1280 HOH HOH A . 
+K 7 HOH 581 1281 1281 HOH HOH A . 
+K 7 HOH 582 1282 1282 HOH HOH A . 
+K 7 HOH 583 1283 1283 HOH HOH A . 
+K 7 HOH 584 1284 1284 HOH HOH A . 
+K 7 HOH 585 1285 1285 HOH HOH A . 
+K 7 HOH 586 1286 1286 HOH HOH A . 
+K 7 HOH 587 1287 1287 HOH HOH A . 
+K 7 HOH 588 1288 1288 HOH HOH A . 
+K 7 HOH 589 1289 1289 HOH HOH A . 
+K 7 HOH 590 1290 1290 HOH HOH A . 
+K 7 HOH 591 1291 1291 HOH HOH A . 
+K 7 HOH 592 1292 1292 HOH HOH A . 
+K 7 HOH 593 1293 1293 HOH HOH A . 
+K 7 HOH 594 1294 1294 HOH HOH A . 
+K 7 HOH 595 1295 1295 HOH HOH A . 
+K 7 HOH 596 1296 1296 HOH HOH A . 
+K 7 HOH 597 1297 1297 HOH HOH A . 
+K 7 HOH 598 1298 1298 HOH HOH A . 
+K 7 HOH 599 1299 1299 HOH HOH A . 
+K 7 HOH 600 1300 1300 HOH HOH A . 
+K 7 HOH 601 1301 1301 HOH HOH A . 
+K 7 HOH 602 1302 1302 HOH HOH A . 
+K 7 HOH 603 1303 1303 HOH HOH A . 
+K 7 HOH 604 1304 1304 HOH HOH A . 
+K 7 HOH 605 1305 1305 HOH HOH A . 
+K 7 HOH 606 1306 1306 HOH HOH A . 
+K 7 HOH 607 1307 1307 HOH HOH A . 
+K 7 HOH 608 1308 1308 HOH HOH A . 
+K 7 HOH 609 1309 1309 HOH HOH A . 
+K 7 HOH 610 1310 1310 HOH HOH A . 
+K 7 HOH 611 1311 1311 HOH HOH A . 
+K 7 HOH 612 1312 1312 HOH HOH A . 
+K 7 HOH 613 1313 1313 HOH HOH A . 
+K 7 HOH 614 1314 1314 HOH HOH A . 
+K 7 HOH 615 1315 1315 HOH HOH A . 
+K 7 HOH 616 1316 1316 HOH HOH A . 
+K 7 HOH 617 1317 1317 HOH HOH A . 
+K 7 HOH 618 1318 1318 HOH HOH A . 
+K 7 HOH 619 1319 1319 HOH HOH A . 
+K 7 HOH 620 1320 1320 HOH HOH A . 
+K 7 HOH 621 1321 1321 HOH HOH A . 
+K 7 HOH 622 1322 1322 HOH HOH A . 
+K 7 HOH 623 1323 1323 HOH HOH A . 
+K 7 HOH 624 1324 1324 HOH HOH A . 
+K 7 HOH 625 1325 1325 HOH HOH A . 
+K 7 HOH 626 1326 1326 HOH HOH A . 
+K 7 HOH 627 1327 1327 HOH HOH A . 
+K 7 HOH 628 1328 1328 HOH HOH A . 
+K 7 HOH 629 1329 1329 HOH HOH A . 
+K 7 HOH 630 1330 1330 HOH HOH A . 
+K 7 HOH 631 1331 1331 HOH HOH A . 
+K 7 HOH 632 1332 1332 HOH HOH A . 
+K 7 HOH 633 1333 1333 HOH HOH A . 
+K 7 HOH 634 1334 1334 HOH HOH A . 
+K 7 HOH 635 1335 1335 HOH HOH A . 
+K 7 HOH 636 1336 1336 HOH HOH A . 
+K 7 HOH 637 1337 1337 HOH HOH A . 
+K 7 HOH 638 1338 1338 HOH HOH A . 
+K 7 HOH 639 1339 1339 HOH HOH A . 
+K 7 HOH 640 1340 1340 HOH HOH A . 
+K 7 HOH 641 1341 1341 HOH HOH A . 
+K 7 HOH 642 1342 1342 HOH HOH A . 
+K 7 HOH 643 1343 1343 HOH HOH A . 
+K 7 HOH 644 1344 1344 HOH HOH A . 
+K 7 HOH 645 1345 1345 HOH HOH A . 
+K 7 HOH 646 1346 1346 HOH HOH A . 
+K 7 HOH 647 1347 1347 HOH HOH A . 
+K 7 HOH 648 1348 1348 HOH HOH A . 
+K 7 HOH 649 1349 1349 HOH HOH A . 
+K 7 HOH 650 1350 1350 HOH HOH A . 
+K 7 HOH 651 1351 1351 HOH HOH A . 
+K 7 HOH 652 1352 1352 HOH HOH A . 
+K 7 HOH 653 1353 1353 HOH HOH A . 
+K 7 HOH 654 1354 1354 HOH HOH A . 
+K 7 HOH 655 1355 1355 HOH HOH A . 
+K 7 HOH 656 1356 1356 HOH HOH A . 
+K 7 HOH 657 1357 1357 HOH HOH A . 
+K 7 HOH 658 1358 1358 HOH HOH A . 
+K 7 HOH 659 1359 1359 HOH HOH A . 
+K 7 HOH 660 1360 1360 HOH HOH A . 
+K 7 HOH 661 1361 1361 HOH HOH A . 
+K 7 HOH 662 1362 1362 HOH HOH A . 
+K 7 HOH 663 1363 1363 HOH HOH A . 
+K 7 HOH 664 1364 1364 HOH HOH A . 
+K 7 HOH 665 1365 1365 HOH HOH A . 
+K 7 HOH 666 1366 1366 HOH HOH A . 
+K 7 HOH 667 1367 1367 HOH HOH A . 
+K 7 HOH 668 1368 1368 HOH HOH A . 
+K 7 HOH 669 1369 1369 HOH HOH A . 
+K 7 HOH 670 1370 1370 HOH HOH A . 
+K 7 HOH 671 1371 1371 HOH HOH A . 
+K 7 HOH 672 1372 1372 HOH HOH A . 
+K 7 HOH 673 1373 1373 HOH HOH A . 
+K 7 HOH 674 1374 1374 HOH HOH A . 
+K 7 HOH 675 1375 1375 HOH HOH A . 
+K 7 HOH 676 1376 1376 HOH HOH A . 
+K 7 HOH 677 1377 1377 HOH HOH A . 
+K 7 HOH 678 1378 1378 HOH HOH A . 
+K 7 HOH 679 1379 1379 HOH HOH A . 
+K 7 HOH 680 1380 1380 HOH HOH A . 
+K 7 HOH 681 1381 1381 HOH HOH A . 
+K 7 HOH 682 1382 1382 HOH HOH A . 
+K 7 HOH 683 1383 1383 HOH HOH A . 
+K 7 HOH 684 1384 1384 HOH HOH A . 
+K 7 HOH 685 1385 1385 HOH HOH A . 
+K 7 HOH 686 1386 1386 HOH HOH A . 
+K 7 HOH 687 1387 1387 HOH HOH A . 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_atoms.id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_model_num 
+_pdbx_unobs_or_zero_occ_atoms.polymer_flag 
+_pdbx_unobs_or_zero_occ_atoms.occupancy_flag 
+_pdbx_unobs_or_zero_occ_atoms.auth_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.auth_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_atoms.auth_atom_id 
+_pdbx_unobs_or_zero_occ_atoms.label_alt_id 
+_pdbx_unobs_or_zero_occ_atoms.label_asym_id 
+_pdbx_unobs_or_zero_occ_atoms.label_comp_id 
+_pdbx_unobs_or_zero_occ_atoms.label_seq_id 
+_pdbx_unobs_or_zero_occ_atoms.label_atom_id 
+1 1 Y 0 A ARG 44 ? CD  ? A ARG 22 CD  
+2 1 Y 0 A ARG 44 ? NE  ? A ARG 22 NE  
+3 1 Y 0 A ARG 44 ? CZ  ? A ARG 22 CZ  
+4 1 Y 0 A ARG 44 ? NH1 ? A ARG 22 NH1 
+5 1 Y 0 A ARG 44 ? NH2 ? A ARG 22 NH2 
+# 
+loop_
+_software.pdbx_ordinal 
+_software.name 
+_software.version 
+_software.date 
+_software.type 
+_software.contact_author 
+_software.contact_author_email 
+_software.classification 
+_software.location 
+_software.language 
+_software.citation_id 
+1 XSCALE      .          ?                package 'Wolfgang Kabsch' ?                           'data scaling'    
+http://www.mpimf-heidelberg.mpg.de/~kabsch/xds/html_doc/xscale_program.html ?   ? 
+2 PHASER      .          ?                program 'Randy J. Read'   cimr-phaser@lists.cam.ac.uk phasing           
+http://www-structmed.cimr.cam.ac.uk/phaser/                                 ?   ? 
+3 PHENIX      1.8.1_1168 ?                package 'Paul D. Adams'   PDAdams@lbl.gov             refinement        
+http://www.phenix-online.org/                                               C++ ? 
+4 PDB_EXTRACT 3.11       'April 22, 2011' package PDB               deposit@deposit.rcsb.org    'data extraction' 
+http://sw-tools.pdb.org/apps/PDB_EXTRACT/                                   C++ ? 
+5 MAR345dtb   .          ?                ?       ?                 ?                           'data collection' ? ?   ? 
+6 XDS         .          ?                ?       ?                 ?                           'data reduction'  ? ?   ? 
+7 XDS         .          ?                ?       ?                 ?                           'data scaling'    ? ?   ? 
+# 
+_cell.entry_id           4MB4 
+_cell.length_a           67.318 
+_cell.length_b           67.318 
+_cell.length_c           255.764 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        120.00 
+_cell.Z_PDB              6 
+_cell.pdbx_unique_axis   ? 
+_cell.length_a_esd       ? 
+_cell.length_b_esd       ? 
+_cell.length_c_esd       ? 
+_cell.angle_alpha_esd    ? 
+_cell.angle_beta_esd     ? 
+_cell.angle_gamma_esd    ? 
+# 
+_symmetry.entry_id                         4MB4 
+_symmetry.space_group_name_H-M             'P 31 1 2' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                151 
+_symmetry.space_group_name_Hall            ? 
+# 
+_exptl.entry_id          4MB4 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.85 
+_exptl_crystal.density_percent_sol   56.90 
+_exptl_crystal.description           ? 
+_exptl_crystal.F_000                 ? 
+_exptl_crystal.preparation           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, HANGING DROP' 
+_exptl_crystal_grow.temp            292 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              6.5 
+_exptl_crystal_grow.pdbx_pH_range   ? 
+_exptl_crystal_grow.pdbx_details    
+;12.5% w/v PEG 1000, 12.5% w/v PEG 3350, 12.5% v/v MPD, 0.02M Na-L-glutamate, 0.02M alanine (racemic), 0.02M glycine, 0.02M lysine HCl (racemic), 0.02M serine (racemic), 0.1M MES/imidazole pH 6.5, VAPOR DIFFUSION, HANGING DROP, temperature 292K
+;
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           100 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               CCD 
+_diffrn_detector.type                   'RAYONIX MX-225' 
+_diffrn_detector.pdbx_collection_date   2012-04-21 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    Double-crystal 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   0.91841 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.type                        'BESSY BEAMLINE 14.2' 
+_diffrn_source.pdbx_synchrotron_site       BESSY 
+_diffrn_source.pdbx_synchrotron_beamline   14.2 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_wavelength_list        0.91841 
+# 
+_reflns.pdbx_diffrn_id               1 
+_reflns.pdbx_ordinal                 1 
+_reflns.entry_id                     4MB4 
+_reflns.observed_criterion_sigma_I   -3 
+_reflns.observed_criterion_sigma_F   ? 
+_reflns.d_resolution_low             33.371 
+_reflns.d_resolution_high            1.48 
+_reflns.number_obs                   110794 
+_reflns.number_all                   110794 
+_reflns.percent_possible_obs         99.8 
+_reflns.pdbx_Rmerge_I_obs            0.054 
+_reflns.pdbx_Rsym_value              ? 
+_reflns.pdbx_netI_over_sigmaI        20.52 
+_reflns.B_iso_Wilson_estimate        16.830 
+_reflns.pdbx_redundancy              6.9 
+_reflns.R_free_details               ? 
+_reflns.limit_h_max                  ? 
+_reflns.limit_h_min                  ? 
+_reflns.limit_k_max                  ? 
+_reflns.limit_k_min                  ? 
+_reflns.limit_l_max                  ? 
+_reflns.limit_l_min                  ? 
+_reflns.observed_criterion_F_max     ? 
+_reflns.observed_criterion_F_min     ? 
+_reflns.pdbx_chi_squared             ? 
+_reflns.pdbx_scaling_rejects         ? 
+# 
+_reflns_shell.pdbx_diffrn_id         1 
+_reflns_shell.pdbx_ordinal           1 
+_reflns_shell.d_res_high             1.48 
+_reflns_shell.d_res_low              1.57 
+_reflns_shell.percent_possible_all   99.4 
+_reflns_shell.Rmerge_I_obs           0.853 
+_reflns_shell.pdbx_Rsym_value        ? 
+_reflns_shell.meanI_over_sigI_obs    2.02 
+_reflns_shell.pdbx_redundancy        6.77 
+_reflns_shell.percent_possible_obs   ? 
+_reflns_shell.number_unique_all      ? 
+_reflns_shell.number_measured_all    ? 
+_reflns_shell.number_measured_obs    ? 
+_reflns_shell.number_unique_obs      ? 
+_reflns_shell.pdbx_chi_squared       ? 
+# 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.entry_id                                 4MB4 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.ls_number_reflns_obs                     110729 
+_refine.ls_number_reflns_all                     110729 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          1.99 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             33.371 
+_refine.ls_d_res_high                            1.481 
+_refine.ls_percent_reflns_obs                    99.78 
+_refine.ls_R_factor_obs                          0.1344 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       0.1340 
+_refine.ls_R_factor_R_free                       0.1702 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 1.00 
+_refine.ls_number_reflns_R_free                  1107 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.B_iso_mean                               25.3686 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    'FLAT BULK SOLVENT MODEL' 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_solvent_vdw_probe_radii             1.11 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             0.90 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      4HMC 
+_refine.pdbx_method_to_determine_struct          'MOLECULAR REPLACEMENT' 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ML 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            0.14 
+_refine.B_iso_max                                65.490 
+_refine.B_iso_min                                10.130 
+_refine.pdbx_overall_phase_error                 18.7500 
+_refine.occupancy_max                            1.000 
+_refine.occupancy_min                            0.000 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.overall_SU_B                             ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.overall_SU_R_free                        ? 
+_refine.ls_wR_factor_R_free                      ? 
+_refine.ls_wR_factor_R_work                      ? 
+_refine.overall_FOM_free_R_set                   ? 
+_refine.overall_FOM_work_R_set                   ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_analyze.pdbx_refine_id                  'X-RAY DIFFRACTION' 
+_refine_analyze.entry_id                        4MB4 
+_refine_analyze.Luzzati_coordinate_error_obs    0.14 
+_refine_analyze.Luzzati_sigma_a_obs             ? 
+_refine_analyze.Luzzati_d_res_low_obs           ? 
+_refine_analyze.Luzzati_coordinate_error_free   ? 
+_refine_analyze.Luzzati_sigma_a_free            ? 
+_refine_analyze.Luzzati_d_res_low_free          ? 
+_refine_analyze.number_disordered_residues      ? 
+_refine_analyze.occupancy_sum_hydrogen          ? 
+_refine_analyze.occupancy_sum_non_hydrogen      ? 
+_refine_analyze.pdbx_Luzzati_d_res_high_obs     ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        4137 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         111 
+_refine_hist.number_atoms_solvent             687 
+_refine_hist.number_atoms_total               4935 
+_refine_hist.d_res_high                       1.481 
+_refine_hist.d_res_low                        33.371 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+f_bond_d           0.020  ? ? 4445 'X-RAY DIFFRACTION' ? 
+f_angle_d          1.763  ? ? 6084 'X-RAY DIFFRACTION' ? 
+f_dihedral_angle_d 14.699 ? ? 1568 'X-RAY DIFFRACTION' ? 
+f_chiral_restr     0.113  ? ? 684  'X-RAY DIFFRACTION' ? 
+f_plane_restr      0.011  ? ? 798  'X-RAY DIFFRACTION' ? 
+# 
+loop_
+_refine_ls_shell.d_res_high 
+_refine_ls_shell.d_res_low 
+_refine_ls_shell.pdbx_total_number_of_bins_used 
+_refine_ls_shell.percent_reflns_obs 
+_refine_ls_shell.number_reflns_R_work 
+_refine_ls_shell.R_factor_all 
+_refine_ls_shell.R_factor_R_work 
+_refine_ls_shell.R_factor_R_free 
+_refine_ls_shell.percent_reflns_R_free 
+_refine_ls_shell.number_reflns_R_free 
+_refine_ls_shell.R_factor_R_free_error 
+_refine_ls_shell.number_reflns_all 
+_refine_ls_shell.number_reflns_obs 
+_refine_ls_shell.pdbx_refine_id 
+_refine_ls_shell.redundancy_reflns_obs 
+1.4808 1.5482  8 99.0000  13509 . 0.2290 0.2876 . 136 . 13645 . 'X-RAY DIFFRACTION' . 
+1.5482 1.6298  8 100.0000 13633 . 0.1906 0.2566 . 138 . 13771 . 'X-RAY DIFFRACTION' . 
+1.6298 1.7319  8 100.0000 13630 . 0.1547 0.2200 . 138 . 13768 . 'X-RAY DIFFRACTION' . 
+1.7319 1.8656  8 100.0000 13648 . 0.1299 0.1805 . 138 . 13786 . 'X-RAY DIFFRACTION' . 
+1.8656 2.0534  8 100.0000 13663 . 0.1134 0.1538 . 138 . 13801 . 'X-RAY DIFFRACTION' . 
+2.0534 2.3504  8 100.0000 13712 . 0.1105 0.1584 . 138 . 13850 . 'X-RAY DIFFRACTION' . 
+2.3504 2.9610  8 100.0000 13798 . 0.1295 0.1682 . 140 . 13938 . 'X-RAY DIFFRACTION' . 
+2.9610 33.3797 8 100.0000 14029 . 0.1323 0.1511 . 141 . 14170 . 'X-RAY DIFFRACTION' . 
+# 
+_struct.entry_id                  4MB4 
+_struct.title                     'Crystal structure of E153Q mutant of cold-adapted chitinase from Moritella complex with Nag4' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        4MB4 
+_struct_keywords.pdbx_keywords   HYDROLASE 
+_struct_keywords.text            
+;TIM-barrel, alpha/beta-barrel Ig-like, Immunoglobulin like domain, ChBD, Chitin binding domain, Nag4, Chitinase, hydrolaze, low activity mutant, HYDROLASE
+;
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+D N N 3 ? 
+E N N 3 ? 
+F N N 4 ? 
+G N N 5 ? 
+H N N 6 ? 
+I N N 6 ? 
+J N N 6 ? 
+K N N 7 ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    B1VBB0_VIBMA 
+_struct_ref.pdbx_db_accession          B1VBB0 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_seq_one_letter_code   
+;GTITSQDDNVVVGYWHNWCDGRGYQGGNAPCVELKTVNPQYNVVNISFMKVYDIAEGRIPTFKLDPTIALSEAEFIAQID
+TLNSQGRSVLIALGGADAHIELTRGDEDALAAEIIRLTDLYGFDGLDIDLEQAAITAKDNQFVIPAALKMVKEHYRKTGD
+NFMITMAPEFPYLTANGAYTPYLTELDGYYDFINPQFYNQGGDGLWIEGVGWIAQNNDALKEEFIYYIADSLINGTRNYH
+KIPHDKLVFGLPSNIDAAATGYIQDPQDLYKAFDRLKAQGQPLRGVMTWSVNWDMGTDAANNSYNQQFIKDYGNFIHNQL
+PPVTDMTPTLSGIVDTRVELDSHFDPLIGITAKDYQGNDITADVTVSGSVNTNQVGDYLLTYSVSSDDETTNQPRKITVY
+EILPAFTGITDTTVVIDSEFDPMQGVSASRPTQGDLTANITVTGEVDANVVGVYELTYQLFYGQDNQQNMTDKRIVTVVT
+DAVSDDDWQVGSTYVKDDKVTHNGATWTAQWWTKGEEPGTTGEWGVWR
+;
+_struct_ref.pdbx_align_begin           23 
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              4MB4 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 528 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             B1VBB0 
+_struct_ref_seq.db_align_beg                  23 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  550 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       23 
+_struct_ref_seq.pdbx_auth_seq_align_end       550 
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 4MB4 GLN A 131 ? UNP B1VBB0 GLU 153 'engineered mutation' 153 1 
+1 4MB4 HIS A 430 ? UNP B1VBB0 ARG 452 'SEE REMARK 999'      452 2 
+1 4MB4 THR A 448 ? UNP B1VBB0 ALA 470 'SEE REMARK 999'      470 3 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D,E,F,G,H,I,J,K 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+_struct_biol.id        1 
+_struct_biol.details   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1  1  GLU A 33  ? VAL A 37  ? GLU A 55  VAL A 59  5 ? 5  
+HELX_P HELX_P2  2  ASP A 53  ? GLY A 57  ? ASP A 75  GLY A 79  5 ? 5  
+HELX_P HELX_P3  3  ASP A 65  ? ALA A 69  ? ASP A 87  ALA A 91  5 ? 5  
+HELX_P HELX_P4  4  SER A 71  ? GLN A 85  ? SER A 93  GLN A 107 1 ? 15 
+HELX_P HELX_P5  5  ASP A 106 ? GLY A 122 ? ASP A 128 GLY A 144 1 ? 17 
+HELX_P HELX_P6  6  GLN A 131 ? THR A 136 ? GLN A 153 THR A 158 5 ? 6  
+HELX_P HELX_P7  7  ASP A 139 ? LYS A 157 ? ASP A 161 LYS A 179 1 ? 19 
+HELX_P HELX_P8  8  GLU A 169 ? THR A 174 ? GLU A 191 THR A 196 5 ? 6  
+HELX_P HELX_P9  9  TYR A 179 ? LEU A 186 ? TYR A 201 LEU A 208 1 ? 8  
+HELX_P HELX_P10 10 LEU A 220 ? GLY A 235 ? LEU A 242 GLY A 257 1 ? 16 
+HELX_P HELX_P11 11 PRO A 243 ? LYS A 246 ? PRO A 265 LYS A 268 5 ? 4  
+HELX_P HELX_P12 12 ASP A 265 ? GLN A 279 ? ASP A 287 GLN A 301 1 ? 15 
+HELX_P HELX_P13 13 SER A 290 ? MET A 295 ? SER A 312 MET A 317 1 ? 6  
+HELX_P HELX_P14 14 GLN A 306 ? ASN A 318 ? GLN A 328 ASN A 340 1 ? 13 
+HELX_P HELX_P15 15 ILE A 360 ? VAL A 364 ? ILE A 382 VAL A 386 5 ? 5  
+HELX_P HELX_P16 16 GLY A 463 ? GLN A 467 ? GLY A 485 GLN A 489 5 ? 5  
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+_struct_conn.pdbx_role 
+disulf1 disulf ?    ? A CYS 19  SG  ? ? ? 1_555 A CYS 31 SG ? ? A CYS 41  A CYS 53  1_555 ? ? ? ? ? ? ? 2.177 ? ? 
+covale1 covale both ? B NAG .   O4  A ? ? 1_555 B NAG .  C1 ? ? B NAG 1   B NAG 2   1_555 ? ? ? ? ? ? ? 1.462 ? ? 
+covale2 covale both ? B NDG .   O4  B ? ? 1_555 B NAG .  C1 ? ? B NDG 1   B NAG 2   1_555 ? ? ? ? ? ? ? 1.463 ? ? 
+covale3 covale both ? B NAG .   O4  ? ? ? 1_555 B NAG .  C1 ? ? B NAG 2   B NAG 3   1_555 ? ? ? ? ? ? ? 1.560 ? ? 
+covale4 covale both ? B NAG .   O4  ? ? ? 1_555 B NAG .  C1 ? ? B NAG 3   B NAG 4   1_555 ? ? ? ? ? ? ? 1.526 ? ? 
+metalc1 metalc ?    ? A THR 2   O   ? ? ? 1_555 F NA  .  NA ? ? A THR 24  A NA  604 1_555 ? ? ? ? ? ? ? 2.601 ? ? 
+metalc2 metalc ?    ? A ASN 83  OD1 ? ? ? 1_555 F NA  .  NA ? ? A ASN 105 A NA  604 1_555 ? ? ? ? ? ? ? 2.264 ? ? 
+metalc3 metalc ?    ? A GLY 122 O   ? ? ? 1_555 F NA  .  NA ? ? A GLY 144 A NA  604 1_555 ? ? ? ? ? ? ? 2.266 ? ? 
+metalc4 metalc ?    ? A ASP 124 OD1 ? ? ? 1_555 F NA  .  NA ? ? A ASP 146 A NA  604 1_555 ? ? ? ? ? ? ? 2.307 ? ? 
+metalc5 metalc ?    ? F NA  .   NA  ? ? ? 1_555 K HOH .  O  ? ? A NA  604 A HOH 743 1_555 ? ? ? ? ? ? ? 2.341 ? ? 
+# 
+loop_
+_struct_conn_type.id 
+_struct_conn_type.criteria 
+_struct_conn_type.reference 
+disulf ? ? 
+covale ? ? 
+metalc ? ? 
+# 
+loop_
+_pdbx_struct_conn_angle.id 
+_pdbx_struct_conn_angle.ptnr1_label_atom_id 
+_pdbx_struct_conn_angle.ptnr1_label_alt_id 
+_pdbx_struct_conn_angle.ptnr1_label_asym_id 
+_pdbx_struct_conn_angle.ptnr1_label_comp_id 
+_pdbx_struct_conn_angle.ptnr1_label_seq_id 
+_pdbx_struct_conn_angle.ptnr1_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr1_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr1_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr1_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr1_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr1_symmetry 
+_pdbx_struct_conn_angle.ptnr2_label_atom_id 
+_pdbx_struct_conn_angle.ptnr2_label_alt_id 
+_pdbx_struct_conn_angle.ptnr2_label_asym_id 
+_pdbx_struct_conn_angle.ptnr2_label_comp_id 
+_pdbx_struct_conn_angle.ptnr2_label_seq_id 
+_pdbx_struct_conn_angle.ptnr2_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr2_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr2_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr2_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr2_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr2_symmetry 
+_pdbx_struct_conn_angle.ptnr3_label_atom_id 
+_pdbx_struct_conn_angle.ptnr3_label_alt_id 
+_pdbx_struct_conn_angle.ptnr3_label_asym_id 
+_pdbx_struct_conn_angle.ptnr3_label_comp_id 
+_pdbx_struct_conn_angle.ptnr3_label_seq_id 
+_pdbx_struct_conn_angle.ptnr3_auth_atom_id 
+_pdbx_struct_conn_angle.ptnr3_auth_asym_id 
+_pdbx_struct_conn_angle.ptnr3_auth_comp_id 
+_pdbx_struct_conn_angle.ptnr3_auth_seq_id 
+_pdbx_struct_conn_angle.ptnr3_PDB_ins_code 
+_pdbx_struct_conn_angle.ptnr3_symmetry 
+_pdbx_struct_conn_angle.value 
+_pdbx_struct_conn_angle.value_esd 
+1  O   ? A THR 2   ? A THR 24  ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 OD1 ? A ASN 83  ? A ASN 105 ? 1_555 88.3  ? 
+2  O   ? A THR 2   ? A THR 24  ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? A GLY 122 ? A GLY 144 ? 1_555 167.9 ? 
+3  OD1 ? A ASN 83  ? A ASN 105 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? A GLY 122 ? A GLY 144 ? 1_555 98.3  ? 
+4  O   ? A THR 2   ? A THR 24  ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 OD1 ? A ASP 124 ? A ASP 146 ? 1_555 82.4  ? 
+5  OD1 ? A ASN 83  ? A ASN 105 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 OD1 ? A ASP 124 ? A ASP 146 ? 1_555 112.3 ? 
+6  O   ? A GLY 122 ? A GLY 144 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 OD1 ? A ASP 124 ? A ASP 146 ? 1_555 104.1 ? 
+7  O   ? A THR 2   ? A THR 24  ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? K HOH .   ? A HOH 743 ? 1_555 75.8  ? 
+8  OD1 ? A ASN 83  ? A ASN 105 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? K HOH .   ? A HOH 743 ? 1_555 123.3 ? 
+9  O   ? A GLY 122 ? A GLY 144 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? K HOH .   ? A HOH 743 ? 1_555 92.1  ? 
+10 OD1 ? A ASP 124 ? A ASP 146 ? 1_555 NA ? F NA . ? A NA 604 ? 1_555 O   ? K HOH .   ? A HOH 743 ? 1_555 118.6 ? 
+# 
+_pdbx_modification_feature.ordinal                            1 
+_pdbx_modification_feature.label_comp_id                      CYS 
+_pdbx_modification_feature.label_asym_id                      A 
+_pdbx_modification_feature.label_seq_id                       19 
+_pdbx_modification_feature.label_alt_id                       ? 
+_pdbx_modification_feature.modified_residue_label_comp_id     CYS 
+_pdbx_modification_feature.modified_residue_label_asym_id     A 
+_pdbx_modification_feature.modified_residue_label_seq_id      31 
+_pdbx_modification_feature.modified_residue_label_alt_id      ? 
+_pdbx_modification_feature.auth_comp_id                       CYS 
+_pdbx_modification_feature.auth_asym_id                       A 
+_pdbx_modification_feature.auth_seq_id                        41 
+_pdbx_modification_feature.PDB_ins_code                       ? 
+_pdbx_modification_feature.symmetry                           1_555 
+_pdbx_modification_feature.modified_residue_auth_comp_id      CYS 
+_pdbx_modification_feature.modified_residue_auth_asym_id      A 
+_pdbx_modification_feature.modified_residue_auth_seq_id       53 
+_pdbx_modification_feature.modified_residue_PDB_ins_code      ? 
+_pdbx_modification_feature.modified_residue_symmetry          1_555 
+_pdbx_modification_feature.comp_id_linking_atom               SG 
+_pdbx_modification_feature.modified_residue_id_linking_atom   SG 
+_pdbx_modification_feature.modified_residue_id                . 
+_pdbx_modification_feature.ref_pcm_id                         . 
+_pdbx_modification_feature.ref_comp_id                        . 
+_pdbx_modification_feature.type                               None 
+_pdbx_modification_feature.category                           'Disulfide bridge' 
+# 
+loop_
+_struct_mon_prot_cis.pdbx_id 
+_struct_mon_prot_cis.label_comp_id 
+_struct_mon_prot_cis.label_seq_id 
+_struct_mon_prot_cis.label_asym_id 
+_struct_mon_prot_cis.label_alt_id 
+_struct_mon_prot_cis.pdbx_PDB_ins_code 
+_struct_mon_prot_cis.auth_comp_id 
+_struct_mon_prot_cis.auth_seq_id 
+_struct_mon_prot_cis.auth_asym_id 
+_struct_mon_prot_cis.pdbx_label_comp_id_2 
+_struct_mon_prot_cis.pdbx_label_seq_id_2 
+_struct_mon_prot_cis.pdbx_label_asym_id_2 
+_struct_mon_prot_cis.pdbx_PDB_ins_code_2 
+_struct_mon_prot_cis.pdbx_auth_comp_id_2 
+_struct_mon_prot_cis.pdbx_auth_seq_id_2 
+_struct_mon_prot_cis.pdbx_auth_asym_id_2 
+_struct_mon_prot_cis.pdbx_PDB_model_num 
+_struct_mon_prot_cis.pdbx_omega_angle 
+1 SER 47  A . ? SER 69  A PHE 48  A ? PHE 70  A 1 9.98  
+2 TRP 289 A . ? TRP 311 A SER 290 A ? SER 312 A 1 10.78 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+A ? 8 ? 
+B ? 2 ? 
+C ? 2 ? 
+D ? 2 ? 
+E ? 4 ? 
+F ? 3 ? 
+G ? 4 ? 
+H ? 2 ? 
+I ? 2 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+A 1 2 ? parallel      
+A 2 3 ? parallel      
+A 3 4 ? parallel      
+A 4 5 ? parallel      
+A 5 6 ? parallel      
+A 6 7 ? parallel      
+A 7 8 ? parallel      
+B 1 2 ? anti-parallel 
+C 1 2 ? anti-parallel 
+D 1 2 ? anti-parallel 
+E 1 2 ? parallel      
+E 2 3 ? anti-parallel 
+E 3 4 ? anti-parallel 
+F 1 2 ? anti-parallel 
+F 2 3 ? anti-parallel 
+G 1 2 ? parallel      
+G 2 3 ? anti-parallel 
+G 3 4 ? anti-parallel 
+H 1 2 ? anti-parallel 
+I 1 2 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 PHE A 192 ? ILE A 193 ? PHE A 214 ILE A 215 
+A 2 MET A 163 ? MET A 166 ? MET A 185 MET A 188 
+A 3 GLY A 125 ? ASP A 129 ? GLY A 147 ASP A 151 
+A 4 SER A 88  ? GLY A 94  ? SER A 110 GLY A 116 
+A 5 VAL A 43  ? MET A 49  ? VAL A 65  MET A 71  
+A 6 VAL A 10  ? HIS A 16  ? VAL A 32  HIS A 38  
+A 7 GLY A 285 ? TRP A 289 ? GLY A 307 TRP A 311 
+A 8 VAL A 248 ? PRO A 252 ? VAL A 270 PRO A 274 
+B 1 GLY A 21  ? ARG A 22  ? GLY A 43  ARG A 44  
+B 2 ASN A 28  ? ALA A 29  ? ASN A 50  ALA A 51  
+C 1 GLY A 204 ? ILE A 207 ? GLY A 226 ILE A 229 
+C 2 GLY A 211 ? ALA A 214 ? GLY A 233 ALA A 236 
+D 1 THR A 329 ? SER A 331 ? THR A 351 SER A 353 
+D 2 THR A 351 ? LYS A 353 ? THR A 373 LYS A 375 
+E 1 THR A 336 ? GLU A 339 ? THR A 358 GLU A 361 
+E 2 GLU A 389 ? TYR A 400 ? GLU A 411 TYR A 422 
+E 3 GLY A 376 ? SER A 386 ? GLY A 398 SER A 408 
+E 4 THR A 365 ? SER A 367 ? THR A 387 SER A 389 
+F 1 ALA A 405 ? THR A 407 ? ALA A 427 THR A 429 
+F 2 SER A 427 ? HIS A 430 ? SER A 449 HIS A 452 
+F 3 GLY A 434 ? ASP A 435 ? GLY A 456 ASP A 457 
+G 1 THR A 412 ? VAL A 415 ? THR A 434 VAL A 437 
+G 2 GLN A 468 ? VAL A 479 ? GLN A 490 VAL A 501 
+G 3 GLY A 452 ? TYR A 462 ? GLY A 474 TYR A 484 
+G 4 ILE A 440 ? THR A 443 ? ILE A 462 THR A 465 
+H 1 THR A 493 ? TYR A 494 ? THR A 515 TYR A 516 
+H 2 THR A 513 ? LYS A 514 ? THR A 535 LYS A 536 
+I 1 LYS A 499 ? HIS A 502 ? LYS A 521 HIS A 524 
+I 2 ALA A 505 ? THR A 508 ? ALA A 527 THR A 530 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+A 1 2 N PHE A 192 ? N PHE A 214 O ILE A 164 ? O ILE A 186 
+A 2 3 O THR A 165 ? O THR A 187 N ILE A 128 ? N ILE A 150 
+A 3 4 O ASP A 127 ? O ASP A 149 N LEU A 93  ? N LEU A 115 
+A 4 5 O LEU A 90  ? O LEU A 112 N ILE A 46  ? N ILE A 68  
+A 5 6 O ASN A 45  ? O ASN A 67  N TRP A 15  ? N TRP A 37  
+A 6 7 N VAL A 12  ? N VAL A 34  O VAL A 286 ? O VAL A 308 
+A 7 8 O MET A 287 ? O MET A 309 N LEU A 251 ? N LEU A 273 
+B 1 2 N GLY A 21  ? N GLY A 43  O ALA A 29  ? O ALA A 51  
+C 1 2 N LEU A 205 ? N LEU A 227 O ILE A 213 ? O ILE A 235 
+D 1 2 N SER A 331 ? N SER A 353 O THR A 351 ? O THR A 373 
+E 1 2 N VAL A 338 ? N VAL A 360 O THR A 398 ? O THR A 420 
+E 2 3 O ILE A 397 ? O ILE A 419 N TYR A 378 ? N TYR A 400 
+E 3 4 O SER A 383 ? O SER A 405 N THR A 365 ? N THR A 387 
+F 1 2 N THR A 407 ? N THR A 429 O SER A 427 ? O SER A 449 
+F 2 3 N HIS A 430 ? N HIS A 452 O GLY A 434 ? O GLY A 456 
+G 1 2 N VAL A 414 ? N VAL A 436 O THR A 477 ? O THR A 499 
+G 2 3 O ASP A 472 ? O ASP A 494 N TYR A 458 ? N TYR A 480 
+G 3 4 O THR A 457 ? O THR A 479 N THR A 443 ? N THR A 465 
+H 1 2 N TYR A 494 ? N TYR A 516 O THR A 513 ? O THR A 535 
+I 1 2 N VAL A 500 ? N VAL A 522 O TRP A 507 ? O TRP A 529 
+# 
+_pdbx_entry_details.entry_id                   4MB4 
+_pdbx_entry_details.nonpolymer_details         ? 
+_pdbx_entry_details.sequence_details           
+'THE SEQUENCE DISCREPANCIES (R452H, A470T) WERE NOT INTENTIONAL MUTATIONS, AND COULD BE THE CORRECT SEQUENCE OF THE NATIVE GENE.' 
+_pdbx_entry_details.compound_details           ? 
+_pdbx_entry_details.source_details             ? 
+_pdbx_entry_details.has_ligand_of_interest     ? 
+_pdbx_entry_details.has_protein_modification   Y 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 NE A ARG 109 ? ? CZ A ARG 109 ? ? NH2 A ARG 109 ? ? 123.64 120.30 3.34  0.50 N 
+2 1 CB A ASP 225 ? ? CG A ASP 225 ? ? OD2 A ASP 225 ? ? 112.86 118.30 -5.44 0.90 N 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1 1 ASP A 30  ? ? -114.11 -162.30 
+2 1 GLN A 154 ? ? 52.47   -134.76 
+3 1 LYS A 160 ? ? 40.77   -119.62 
+4 1 ASN A 216 ? ? -118.58 79.58   
+5 1 PHE A 219 ? ? -106.33 50.10   
+6 1 ILE A 431 ? ? -100.40 74.16   
+7 1 ASP A 519 ? ? 79.33   -2.04   
+8 1 TRP A 533 ? ? -171.53 -166.71 
+# 
+_pdbx_struct_special_symmetry.id              1 
+_pdbx_struct_special_symmetry.PDB_model_num   1 
+_pdbx_struct_special_symmetry.auth_asym_id    A 
+_pdbx_struct_special_symmetry.auth_comp_id    HOH 
+_pdbx_struct_special_symmetry.auth_seq_id     920 
+_pdbx_struct_special_symmetry.PDB_ins_code    ? 
+_pdbx_struct_special_symmetry.label_asym_id   K 
+_pdbx_struct_special_symmetry.label_comp_id   HOH 
+_pdbx_struct_special_symmetry.label_seq_id    . 
+# 
+_diffrn_reflns.diffrn_id                   1 
+_diffrn_reflns.pdbx_d_res_high             1.480 
+_diffrn_reflns.pdbx_d_res_low              ? 
+_diffrn_reflns.pdbx_number_obs             110785 
+_diffrn_reflns.pdbx_Rmerge_I_obs           0.054 
+_diffrn_reflns.pdbx_Rsym_value             ? 
+_diffrn_reflns.pdbx_chi_squared            ? 
+_diffrn_reflns.av_sigmaI_over_netI         ? 
+_diffrn_reflns.pdbx_redundancy             ? 
+_diffrn_reflns.pdbx_percent_possible_obs   99.80 
+_diffrn_reflns.number                      758690 
+_diffrn_reflns.pdbx_observed_criterion     ? 
+_diffrn_reflns.limit_h_max                 ? 
+_diffrn_reflns.limit_h_min                 ? 
+_diffrn_reflns.limit_k_max                 ? 
+_diffrn_reflns.limit_k_min                 ? 
+_diffrn_reflns.limit_l_max                 ? 
+_diffrn_reflns.limit_l_min                 ? 
+# 
+loop_
+_pdbx_diffrn_reflns_shell.diffrn_id 
+_pdbx_diffrn_reflns_shell.d_res_high 
+_pdbx_diffrn_reflns_shell.d_res_low 
+_pdbx_diffrn_reflns_shell.number_obs 
+_pdbx_diffrn_reflns_shell.rejects 
+_pdbx_diffrn_reflns_shell.Rmerge_I_obs 
+_pdbx_diffrn_reflns_shell.Rsym_value 
+_pdbx_diffrn_reflns_shell.chi_squared 
+_pdbx_diffrn_reflns_shell.redundancy 
+_pdbx_diffrn_reflns_shell.percent_possible_obs 
+1 1.48 1.57  17713 ? 0.853 ? ? ? 99.40  
+1 1.57 1.68  16759 ? 0.504 ? ? ? 99.90  
+1 1.68 1.81  15604 ? 0.284 ? ? ? 100.00 
+1 1.81 1.99  14392 ? 0.147 ? ? ? 99.90  
+1 1.99 2.22  12978 ? 0.079 ? ? ? 100.00 
+1 2.22 2.56  11557 ? 0.050 ? ? ? 100.00 
+1 2.56 3.14  9792  ? 0.034 ? ? ? 99.90  
+1 3.14 4.43  7661  ? 0.025 ? ? ? 99.90  
+1 4.43 33.37 4329  ? 0.021 ? ? ? 99.00  
+# 
+_phasing.method   MR 
+# 
+loop_
+_chem_comp_atom.comp_id 
+_chem_comp_atom.atom_id 
+_chem_comp_atom.type_symbol 
+_chem_comp_atom.pdbx_aromatic_flag 
+_chem_comp_atom.pdbx_stereo_config 
+_chem_comp_atom.pdbx_ordinal 
+ALA N    N  N N 1   
+ALA CA   C  N S 2   
+ALA C    C  N N 3   
+ALA O    O  N N 4   
+ALA CB   C  N N 5   
+ALA OXT  O  N N 6   
+ALA H    H  N N 7   
+ALA H2   H  N N 8   
+ALA HA   H  N N 9   
+ALA HB1  H  N N 10  
+ALA HB2  H  N N 11  
+ALA HB3  H  N N 12  
+ALA HXT  H  N N 13  
+ARG N    N  N N 14  
+ARG CA   C  N S 15  
+ARG C    C  N N 16  
+ARG O    O  N N 17  
+ARG CB   C  N N 18  
+ARG CG   C  N N 19  
+ARG CD   C  N N 20  
+ARG NE   N  N N 21  
+ARG CZ   C  N N 22  
+ARG NH1  N  N N 23  
+ARG NH2  N  N N 24  
+ARG OXT  O  N N 25  
+ARG H    H  N N 26  
+ARG H2   H  N N 27  
+ARG HA   H  N N 28  
+ARG HB2  H  N N 29  
+ARG HB3  H  N N 30  
+ARG HG2  H  N N 31  
+ARG HG3  H  N N 32  
+ARG HD2  H  N N 33  
+ARG HD3  H  N N 34  
+ARG HE   H  N N 35  
+ARG HH11 H  N N 36  
+ARG HH12 H  N N 37  
+ARG HH21 H  N N 38  
+ARG HH22 H  N N 39  
+ARG HXT  H  N N 40  
+ASN N    N  N N 41  
+ASN CA   C  N S 42  
+ASN C    C  N N 43  
+ASN O    O  N N 44  
+ASN CB   C  N N 45  
+ASN CG   C  N N 46  
+ASN OD1  O  N N 47  
+ASN ND2  N  N N 48  
+ASN OXT  O  N N 49  
+ASN H    H  N N 50  
+ASN H2   H  N N 51  
+ASN HA   H  N N 52  
+ASN HB2  H  N N 53  
+ASN HB3  H  N N 54  
+ASN HD21 H  N N 55  
+ASN HD22 H  N N 56  
+ASN HXT  H  N N 57  
+ASP N    N  N N 58  
+ASP CA   C  N S 59  
+ASP C    C  N N 60  
+ASP O    O  N N 61  
+ASP CB   C  N N 62  
+ASP CG   C  N N 63  
+ASP OD1  O  N N 64  
+ASP OD2  O  N N 65  
+ASP OXT  O  N N 66  
+ASP H    H  N N 67  
+ASP H2   H  N N 68  
+ASP HA   H  N N 69  
+ASP HB2  H  N N 70  
+ASP HB3  H  N N 71  
+ASP HD2  H  N N 72  
+ASP HXT  H  N N 73  
+CYS N    N  N N 74  
+CYS CA   C  N R 75  
+CYS C    C  N N 76  
+CYS O    O  N N 77  
+CYS CB   C  N N 78  
+CYS SG   S  N N 79  
+CYS OXT  O  N N 80  
+CYS H    H  N N 81  
+CYS H2   H  N N 82  
+CYS HA   H  N N 83  
+CYS HB2  H  N N 84  
+CYS HB3  H  N N 85  
+CYS HG   H  N N 86  
+CYS HXT  H  N N 87  
+GLN N    N  N N 88  
+GLN CA   C  N S 89  
+GLN C    C  N N 90  
+GLN O    O  N N 91  
+GLN CB   C  N N 92  
+GLN CG   C  N N 93  
+GLN CD   C  N N 94  
+GLN OE1  O  N N 95  
+GLN NE2  N  N N 96  
+GLN OXT  O  N N 97  
+GLN H    H  N N 98  
+GLN H2   H  N N 99  
+GLN HA   H  N N 100 
+GLN HB2  H  N N 101 
+GLN HB3  H  N N 102 
+GLN HG2  H  N N 103 
+GLN HG3  H  N N 104 
+GLN HE21 H  N N 105 
+GLN HE22 H  N N 106 
+GLN HXT  H  N N 107 
+GLU N    N  N N 108 
+GLU CA   C  N S 109 
+GLU C    C  N N 110 
+GLU O    O  N N 111 
+GLU CB   C  N N 112 
+GLU CG   C  N N 113 
+GLU CD   C  N N 114 
+GLU OE1  O  N N 115 
+GLU OE2  O  N N 116 
+GLU OXT  O  N N 117 
+GLU H    H  N N 118 
+GLU H2   H  N N 119 
+GLU HA   H  N N 120 
+GLU HB2  H  N N 121 
+GLU HB3  H  N N 122 
+GLU HG2  H  N N 123 
+GLU HG3  H  N N 124 
+GLU HE2  H  N N 125 
+GLU HXT  H  N N 126 
+GLY N    N  N N 127 
+GLY CA   C  N N 128 
+GLY C    C  N N 129 
+GLY O    O  N N 130 
+GLY OXT  O  N N 131 
+GLY H    H  N N 132 
+GLY H2   H  N N 133 
+GLY HA2  H  N N 134 
+GLY HA3  H  N N 135 
+GLY HXT  H  N N 136 
+GOL C1   C  N N 137 
+GOL O1   O  N N 138 
+GOL C2   C  N N 139 
+GOL O2   O  N N 140 
+GOL C3   C  N N 141 
+GOL O3   O  N N 142 
+GOL H11  H  N N 143 
+GOL H12  H  N N 144 
+GOL HO1  H  N N 145 
+GOL H2   H  N N 146 
+GOL HO2  H  N N 147 
+GOL H31  H  N N 148 
+GOL H32  H  N N 149 
+GOL HO3  H  N N 150 
+HIS N    N  N N 151 
+HIS CA   C  N S 152 
+HIS C    C  N N 153 
+HIS O    O  N N 154 
+HIS CB   C  N N 155 
+HIS CG   C  Y N 156 
+HIS ND1  N  Y N 157 
+HIS CD2  C  Y N 158 
+HIS CE1  C  Y N 159 
+HIS NE2  N  Y N 160 
+HIS OXT  O  N N 161 
+HIS H    H  N N 162 
+HIS H2   H  N N 163 
+HIS HA   H  N N 164 
+HIS HB2  H  N N 165 
+HIS HB3  H  N N 166 
+HIS HD1  H  N N 167 
+HIS HD2  H  N N 168 
+HIS HE1  H  N N 169 
+HIS HE2  H  N N 170 
+HIS HXT  H  N N 171 
+HOH O    O  N N 172 
+HOH H1   H  N N 173 
+HOH H2   H  N N 174 
+ILE N    N  N N 175 
+ILE CA   C  N S 176 
+ILE C    C  N N 177 
+ILE O    O  N N 178 
+ILE CB   C  N S 179 
+ILE CG1  C  N N 180 
+ILE CG2  C  N N 181 
+ILE CD1  C  N N 182 
+ILE OXT  O  N N 183 
+ILE H    H  N N 184 
+ILE H2   H  N N 185 
+ILE HA   H  N N 186 
+ILE HB   H  N N 187 
+ILE HG12 H  N N 188 
+ILE HG13 H  N N 189 
+ILE HG21 H  N N 190 
+ILE HG22 H  N N 191 
+ILE HG23 H  N N 192 
+ILE HD11 H  N N 193 
+ILE HD12 H  N N 194 
+ILE HD13 H  N N 195 
+ILE HXT  H  N N 196 
+LEU N    N  N N 197 
+LEU CA   C  N S 198 
+LEU C    C  N N 199 
+LEU O    O  N N 200 
+LEU CB   C  N N 201 
+LEU CG   C  N N 202 
+LEU CD1  C  N N 203 
+LEU CD2  C  N N 204 
+LEU OXT  O  N N 205 
+LEU H    H  N N 206 
+LEU H2   H  N N 207 
+LEU HA   H  N N 208 
+LEU HB2  H  N N 209 
+LEU HB3  H  N N 210 
+LEU HG   H  N N 211 
+LEU HD11 H  N N 212 
+LEU HD12 H  N N 213 
+LEU HD13 H  N N 214 
+LEU HD21 H  N N 215 
+LEU HD22 H  N N 216 
+LEU HD23 H  N N 217 
+LEU HXT  H  N N 218 
+LYS N    N  N N 219 
+LYS CA   C  N S 220 
+LYS C    C  N N 221 
+LYS O    O  N N 222 
+LYS CB   C  N N 223 
+LYS CG   C  N N 224 
+LYS CD   C  N N 225 
+LYS CE   C  N N 226 
+LYS NZ   N  N N 227 
+LYS OXT  O  N N 228 
+LYS H    H  N N 229 
+LYS H2   H  N N 230 
+LYS HA   H  N N 231 
+LYS HB2  H  N N 232 
+LYS HB3  H  N N 233 
+LYS HG2  H  N N 234 
+LYS HG3  H  N N 235 
+LYS HD2  H  N N 236 
+LYS HD3  H  N N 237 
+LYS HE2  H  N N 238 
+LYS HE3  H  N N 239 
+LYS HZ1  H  N N 240 
+LYS HZ2  H  N N 241 
+LYS HZ3  H  N N 242 
+LYS HXT  H  N N 243 
+MET N    N  N N 244 
+MET CA   C  N S 245 
+MET C    C  N N 246 
+MET O    O  N N 247 
+MET CB   C  N N 248 
+MET CG   C  N N 249 
+MET SD   S  N N 250 
+MET CE   C  N N 251 
+MET OXT  O  N N 252 
+MET H    H  N N 253 
+MET H2   H  N N 254 
+MET HA   H  N N 255 
+MET HB2  H  N N 256 
+MET HB3  H  N N 257 
+MET HG2  H  N N 258 
+MET HG3  H  N N 259 
+MET HE1  H  N N 260 
+MET HE2  H  N N 261 
+MET HE3  H  N N 262 
+MET HXT  H  N N 263 
+NA  NA   NA N N 264 
+NAG C1   C  N R 265 
+NAG C2   C  N R 266 
+NAG C3   C  N R 267 
+NAG C4   C  N S 268 
+NAG C5   C  N R 269 
+NAG C6   C  N N 270 
+NAG C7   C  N N 271 
+NAG C8   C  N N 272 
+NAG N2   N  N N 273 
+NAG O1   O  N N 274 
+NAG O3   O  N N 275 
+NAG O4   O  N N 276 
+NAG O5   O  N N 277 
+NAG O6   O  N N 278 
+NAG O7   O  N N 279 
+NAG H1   H  N N 280 
+NAG H2   H  N N 281 
+NAG H3   H  N N 282 
+NAG H4   H  N N 283 
+NAG H5   H  N N 284 
+NAG H61  H  N N 285 
+NAG H62  H  N N 286 
+NAG H81  H  N N 287 
+NAG H82  H  N N 288 
+NAG H83  H  N N 289 
+NAG HN2  H  N N 290 
+NAG HO1  H  N N 291 
+NAG HO3  H  N N 292 
+NAG HO4  H  N N 293 
+NAG HO6  H  N N 294 
+NDG C1   C  N S 295 
+NDG C2   C  N R 296 
+NDG C3   C  N R 297 
+NDG C4   C  N S 298 
+NDG C5   C  N R 299 
+NDG C6   C  N N 300 
+NDG C7   C  N N 301 
+NDG C8   C  N N 302 
+NDG O5   O  N N 303 
+NDG O3   O  N N 304 
+NDG O4   O  N N 305 
+NDG O6   O  N N 306 
+NDG O7   O  N N 307 
+NDG N2   N  N N 308 
+NDG O1   O  N N 309 
+NDG H1   H  N N 310 
+NDG H2   H  N N 311 
+NDG H3   H  N N 312 
+NDG H4   H  N N 313 
+NDG H5   H  N N 314 
+NDG H61  H  N N 315 
+NDG H62  H  N N 316 
+NDG H81  H  N N 317 
+NDG H82  H  N N 318 
+NDG H83  H  N N 319 
+NDG HO3  H  N N 320 
+NDG HO4  H  N N 321 
+NDG HO6  H  N N 322 
+NDG HN2  H  N N 323 
+NDG HO1  H  N N 324 
+PHE N    N  N N 325 
+PHE CA   C  N S 326 
+PHE C    C  N N 327 
+PHE O    O  N N 328 
+PHE CB   C  N N 329 
+PHE CG   C  Y N 330 
+PHE CD1  C  Y N 331 
+PHE CD2  C  Y N 332 
+PHE CE1  C  Y N 333 
+PHE CE2  C  Y N 334 
+PHE CZ   C  Y N 335 
+PHE OXT  O  N N 336 
+PHE H    H  N N 337 
+PHE H2   H  N N 338 
+PHE HA   H  N N 339 
+PHE HB2  H  N N 340 
+PHE HB3  H  N N 341 
+PHE HD1  H  N N 342 
+PHE HD2  H  N N 343 
+PHE HE1  H  N N 344 
+PHE HE2  H  N N 345 
+PHE HZ   H  N N 346 
+PHE HXT  H  N N 347 
+PRO N    N  N N 348 
+PRO CA   C  N S 349 
+PRO C    C  N N 350 
+PRO O    O  N N 351 
+PRO CB   C  N N 352 
+PRO CG   C  N N 353 
+PRO CD   C  N N 354 
+PRO OXT  O  N N 355 
+PRO H    H  N N 356 
+PRO HA   H  N N 357 
+PRO HB2  H  N N 358 
+PRO HB3  H  N N 359 
+PRO HG2  H  N N 360 
+PRO HG3  H  N N 361 
+PRO HD2  H  N N 362 
+PRO HD3  H  N N 363 
+PRO HXT  H  N N 364 
+SER N    N  N N 365 
+SER CA   C  N S 366 
+SER C    C  N N 367 
+SER O    O  N N 368 
+SER CB   C  N N 369 
+SER OG   O  N N 370 
+SER OXT  O  N N 371 
+SER H    H  N N 372 
+SER H2   H  N N 373 
+SER HA   H  N N 374 
+SER HB2  H  N N 375 
+SER HB3  H  N N 376 
+SER HG   H  N N 377 
+SER HXT  H  N N 378 
+SO4 S    S  N N 379 
+SO4 O1   O  N N 380 
+SO4 O2   O  N N 381 
+SO4 O3   O  N N 382 
+SO4 O4   O  N N 383 
+THR N    N  N N 384 
+THR CA   C  N S 385 
+THR C    C  N N 386 
+THR O    O  N N 387 
+THR CB   C  N R 388 
+THR OG1  O  N N 389 
+THR CG2  C  N N 390 
+THR OXT  O  N N 391 
+THR H    H  N N 392 
+THR H2   H  N N 393 
+THR HA   H  N N 394 
+THR HB   H  N N 395 
+THR HG1  H  N N 396 
+THR HG21 H  N N 397 
+THR HG22 H  N N 398 
+THR HG23 H  N N 399 
+THR HXT  H  N N 400 
+TRP N    N  N N 401 
+TRP CA   C  N S 402 
+TRP C    C  N N 403 
+TRP O    O  N N 404 
+TRP CB   C  N N 405 
+TRP CG   C  Y N 406 
+TRP CD1  C  Y N 407 
+TRP CD2  C  Y N 408 
+TRP NE1  N  Y N 409 
+TRP CE2  C  Y N 410 
+TRP CE3  C  Y N 411 
+TRP CZ2  C  Y N 412 
+TRP CZ3  C  Y N 413 
+TRP CH2  C  Y N 414 
+TRP OXT  O  N N 415 
+TRP H    H  N N 416 
+TRP H2   H  N N 417 
+TRP HA   H  N N 418 
+TRP HB2  H  N N 419 
+TRP HB3  H  N N 420 
+TRP HD1  H  N N 421 
+TRP HE1  H  N N 422 
+TRP HE3  H  N N 423 
+TRP HZ2  H  N N 424 
+TRP HZ3  H  N N 425 
+TRP HH2  H  N N 426 
+TRP HXT  H  N N 427 
+TYR N    N  N N 428 
+TYR CA   C  N S 429 
+TYR C    C  N N 430 
+TYR O    O  N N 431 
+TYR CB   C  N N 432 
+TYR CG   C  Y N 433 
+TYR CD1  C  Y N 434 
+TYR CD2  C  Y N 435 
+TYR CE1  C  Y N 436 
+TYR CE2  C  Y N 437 
+TYR CZ   C  Y N 438 
+TYR OH   O  N N 439 
+TYR OXT  O  N N 440 
+TYR H    H  N N 441 
+TYR H2   H  N N 442 
+TYR HA   H  N N 443 
+TYR HB2  H  N N 444 
+TYR HB3  H  N N 445 
+TYR HD1  H  N N 446 
+TYR HD2  H  N N 447 
+TYR HE1  H  N N 448 
+TYR HE2  H  N N 449 
+TYR HH   H  N N 450 
+TYR HXT  H  N N 451 
+VAL N    N  N N 452 
+VAL CA   C  N S 453 
+VAL C    C  N N 454 
+VAL O    O  N N 455 
+VAL CB   C  N N 456 
+VAL CG1  C  N N 457 
+VAL CG2  C  N N 458 
+VAL OXT  O  N N 459 
+VAL H    H  N N 460 
+VAL H2   H  N N 461 
+VAL HA   H  N N 462 
+VAL HB   H  N N 463 
+VAL HG11 H  N N 464 
+VAL HG12 H  N N 465 
+VAL HG13 H  N N 466 
+VAL HG21 H  N N 467 
+VAL HG22 H  N N 468 
+VAL HG23 H  N N 469 
+VAL HXT  H  N N 470 
+# 
+loop_
+_chem_comp_bond.comp_id 
+_chem_comp_bond.atom_id_1 
+_chem_comp_bond.atom_id_2 
+_chem_comp_bond.value_order 
+_chem_comp_bond.pdbx_aromatic_flag 
+_chem_comp_bond.pdbx_stereo_config 
+_chem_comp_bond.pdbx_ordinal 
+ALA N   CA   sing N N 1   
+ALA N   H    sing N N 2   
+ALA N   H2   sing N N 3   
+ALA CA  C    sing N N 4   
+ALA CA  CB   sing N N 5   
+ALA CA  HA   sing N N 6   
+ALA C   O    doub N N 7   
+ALA C   OXT  sing N N 8   
+ALA CB  HB1  sing N N 9   
+ALA CB  HB2  sing N N 10  
+ALA CB  HB3  sing N N 11  
+ALA OXT HXT  sing N N 12  
+ARG N   CA   sing N N 13  
+ARG N   H    sing N N 14  
+ARG N   H2   sing N N 15  
+ARG CA  C    sing N N 16  
+ARG CA  CB   sing N N 17  
+ARG CA  HA   sing N N 18  
+ARG C   O    doub N N 19  
+ARG C   OXT  sing N N 20  
+ARG CB  CG   sing N N 21  
+ARG CB  HB2  sing N N 22  
+ARG CB  HB3  sing N N 23  
+ARG CG  CD   sing N N 24  
+ARG CG  HG2  sing N N 25  
+ARG CG  HG3  sing N N 26  
+ARG CD  NE   sing N N 27  
+ARG CD  HD2  sing N N 28  
+ARG CD  HD3  sing N N 29  
+ARG NE  CZ   sing N N 30  
+ARG NE  HE   sing N N 31  
+ARG CZ  NH1  sing N N 32  
+ARG CZ  NH2  doub N N 33  
+ARG NH1 HH11 sing N N 34  
+ARG NH1 HH12 sing N N 35  
+ARG NH2 HH21 sing N N 36  
+ARG NH2 HH22 sing N N 37  
+ARG OXT HXT  sing N N 38  
+ASN N   CA   sing N N 39  
+ASN N   H    sing N N 40  
+ASN N   H2   sing N N 41  
+ASN CA  C    sing N N 42  
+ASN CA  CB   sing N N 43  
+ASN CA  HA   sing N N 44  
+ASN C   O    doub N N 45  
+ASN C   OXT  sing N N 46  
+ASN CB  CG   sing N N 47  
+ASN CB  HB2  sing N N 48  
+ASN CB  HB3  sing N N 49  
+ASN CG  OD1  doub N N 50  
+ASN CG  ND2  sing N N 51  
+ASN ND2 HD21 sing N N 52  
+ASN ND2 HD22 sing N N 53  
+ASN OXT HXT  sing N N 54  
+ASP N   CA   sing N N 55  
+ASP N   H    sing N N 56  
+ASP N   H2   sing N N 57  
+ASP CA  C    sing N N 58  
+ASP CA  CB   sing N N 59  
+ASP CA  HA   sing N N 60  
+ASP C   O    doub N N 61  
+ASP C   OXT  sing N N 62  
+ASP CB  CG   sing N N 63  
+ASP CB  HB2  sing N N 64  
+ASP CB  HB3  sing N N 65  
+ASP CG  OD1  doub N N 66  
+ASP CG  OD2  sing N N 67  
+ASP OD2 HD2  sing N N 68  
+ASP OXT HXT  sing N N 69  
+CYS N   CA   sing N N 70  
+CYS N   H    sing N N 71  
+CYS N   H2   sing N N 72  
+CYS CA  C    sing N N 73  
+CYS CA  CB   sing N N 74  
+CYS CA  HA   sing N N 75  
+CYS C   O    doub N N 76  
+CYS C   OXT  sing N N 77  
+CYS CB  SG   sing N N 78  
+CYS CB  HB2  sing N N 79  
+CYS CB  HB3  sing N N 80  
+CYS SG  HG   sing N N 81  
+CYS OXT HXT  sing N N 82  
+GLN N   CA   sing N N 83  
+GLN N   H    sing N N 84  
+GLN N   H2   sing N N 85  
+GLN CA  C    sing N N 86  
+GLN CA  CB   sing N N 87  
+GLN CA  HA   sing N N 88  
+GLN C   O    doub N N 89  
+GLN C   OXT  sing N N 90  
+GLN CB  CG   sing N N 91  
+GLN CB  HB2  sing N N 92  
+GLN CB  HB3  sing N N 93  
+GLN CG  CD   sing N N 94  
+GLN CG  HG2  sing N N 95  
+GLN CG  HG3  sing N N 96  
+GLN CD  OE1  doub N N 97  
+GLN CD  NE2  sing N N 98  
+GLN NE2 HE21 sing N N 99  
+GLN NE2 HE22 sing N N 100 
+GLN OXT HXT  sing N N 101 
+GLU N   CA   sing N N 102 
+GLU N   H    sing N N 103 
+GLU N   H2   sing N N 104 
+GLU CA  C    sing N N 105 
+GLU CA  CB   sing N N 106 
+GLU CA  HA   sing N N 107 
+GLU C   O    doub N N 108 
+GLU C   OXT  sing N N 109 
+GLU CB  CG   sing N N 110 
+GLU CB  HB2  sing N N 111 
+GLU CB  HB3  sing N N 112 
+GLU CG  CD   sing N N 113 
+GLU CG  HG2  sing N N 114 
+GLU CG  HG3  sing N N 115 
+GLU CD  OE1  doub N N 116 
+GLU CD  OE2  sing N N 117 
+GLU OE2 HE2  sing N N 118 
+GLU OXT HXT  sing N N 119 
+GLY N   CA   sing N N 120 
+GLY N   H    sing N N 121 
+GLY N   H2   sing N N 122 
+GLY CA  C    sing N N 123 
+GLY CA  HA2  sing N N 124 
+GLY CA  HA3  sing N N 125 
+GLY C   O    doub N N 126 
+GLY C   OXT  sing N N 127 
+GLY OXT HXT  sing N N 128 
+GOL C1  O1   sing N N 129 
+GOL C1  C2   sing N N 130 
+GOL C1  H11  sing N N 131 
+GOL C1  H12  sing N N 132 
+GOL O1  HO1  sing N N 133 
+GOL C2  O2   sing N N 134 
+GOL C2  C3   sing N N 135 
+GOL C2  H2   sing N N 136 
+GOL O2  HO2  sing N N 137 
+GOL C3  O3   sing N N 138 
+GOL C3  H31  sing N N 139 
+GOL C3  H32  sing N N 140 
+GOL O3  HO3  sing N N 141 
+HIS N   CA   sing N N 142 
+HIS N   H    sing N N 143 
+HIS N   H2   sing N N 144 
+HIS CA  C    sing N N 145 
+HIS CA  CB   sing N N 146 
+HIS CA  HA   sing N N 147 
+HIS C   O    doub N N 148 
+HIS C   OXT  sing N N 149 
+HIS CB  CG   sing N N 150 
+HIS CB  HB2  sing N N 151 
+HIS CB  HB3  sing N N 152 
+HIS CG  ND1  sing Y N 153 
+HIS CG  CD2  doub Y N 154 
+HIS ND1 CE1  doub Y N 155 
+HIS ND1 HD1  sing N N 156 
+HIS CD2 NE2  sing Y N 157 
+HIS CD2 HD2  sing N N 158 
+HIS CE1 NE2  sing Y N 159 
+HIS CE1 HE1  sing N N 160 
+HIS NE2 HE2  sing N N 161 
+HIS OXT HXT  sing N N 162 
+HOH O   H1   sing N N 163 
+HOH O   H2   sing N N 164 
+ILE N   CA   sing N N 165 
+ILE N   H    sing N N 166 
+ILE N   H2   sing N N 167 
+ILE CA  C    sing N N 168 
+ILE CA  CB   sing N N 169 
+ILE CA  HA   sing N N 170 
+ILE C   O    doub N N 171 
+ILE C   OXT  sing N N 172 
+ILE CB  CG1  sing N N 173 
+ILE CB  CG2  sing N N 174 
+ILE CB  HB   sing N N 175 
+ILE CG1 CD1  sing N N 176 
+ILE CG1 HG12 sing N N 177 
+ILE CG1 HG13 sing N N 178 
+ILE CG2 HG21 sing N N 179 
+ILE CG2 HG22 sing N N 180 
+ILE CG2 HG23 sing N N 181 
+ILE CD1 HD11 sing N N 182 
+ILE CD1 HD12 sing N N 183 
+ILE CD1 HD13 sing N N 184 
+ILE OXT HXT  sing N N 185 
+LEU N   CA   sing N N 186 
+LEU N   H    sing N N 187 
+LEU N   H2   sing N N 188 
+LEU CA  C    sing N N 189 
+LEU CA  CB   sing N N 190 
+LEU CA  HA   sing N N 191 
+LEU C   O    doub N N 192 
+LEU C   OXT  sing N N 193 
+LEU CB  CG   sing N N 194 
+LEU CB  HB2  sing N N 195 
+LEU CB  HB3  sing N N 196 
+LEU CG  CD1  sing N N 197 
+LEU CG  CD2  sing N N 198 
+LEU CG  HG   sing N N 199 
+LEU CD1 HD11 sing N N 200 
+LEU CD1 HD12 sing N N 201 
+LEU CD1 HD13 sing N N 202 
+LEU CD2 HD21 sing N N 203 
+LEU CD2 HD22 sing N N 204 
+LEU CD2 HD23 sing N N 205 
+LEU OXT HXT  sing N N 206 
+LYS N   CA   sing N N 207 
+LYS N   H    sing N N 208 
+LYS N   H2   sing N N 209 
+LYS CA  C    sing N N 210 
+LYS CA  CB   sing N N 211 
+LYS CA  HA   sing N N 212 
+LYS C   O    doub N N 213 
+LYS C   OXT  sing N N 214 
+LYS CB  CG   sing N N 215 
+LYS CB  HB2  sing N N 216 
+LYS CB  HB3  sing N N 217 
+LYS CG  CD   sing N N 218 
+LYS CG  HG2  sing N N 219 
+LYS CG  HG3  sing N N 220 
+LYS CD  CE   sing N N 221 
+LYS CD  HD2  sing N N 222 
+LYS CD  HD3  sing N N 223 
+LYS CE  NZ   sing N N 224 
+LYS CE  HE2  sing N N 225 
+LYS CE  HE3  sing N N 226 
+LYS NZ  HZ1  sing N N 227 
+LYS NZ  HZ2  sing N N 228 
+LYS NZ  HZ3  sing N N 229 
+LYS OXT HXT  sing N N 230 
+MET N   CA   sing N N 231 
+MET N   H    sing N N 232 
+MET N   H2   sing N N 233 
+MET CA  C    sing N N 234 
+MET CA  CB   sing N N 235 
+MET CA  HA   sing N N 236 
+MET C   O    doub N N 237 
+MET C   OXT  sing N N 238 
+MET CB  CG   sing N N 239 
+MET CB  HB2  sing N N 240 
+MET CB  HB3  sing N N 241 
+MET CG  SD   sing N N 242 
+MET CG  HG2  sing N N 243 
+MET CG  HG3  sing N N 244 
+MET SD  CE   sing N N 245 
+MET CE  HE1  sing N N 246 
+MET CE  HE2  sing N N 247 
+MET CE  HE3  sing N N 248 
+MET OXT HXT  sing N N 249 
+NAG C1  C2   sing N N 250 
+NAG C1  O1   sing N N 251 
+NAG C1  O5   sing N N 252 
+NAG C1  H1   sing N N 253 
+NAG C2  C3   sing N N 254 
+NAG C2  N2   sing N N 255 
+NAG C2  H2   sing N N 256 
+NAG C3  C4   sing N N 257 
+NAG C3  O3   sing N N 258 
+NAG C3  H3   sing N N 259 
+NAG C4  C5   sing N N 260 
+NAG C4  O4   sing N N 261 
+NAG C4  H4   sing N N 262 
+NAG C5  C6   sing N N 263 
+NAG C5  O5   sing N N 264 
+NAG C5  H5   sing N N 265 
+NAG C6  O6   sing N N 266 
+NAG C6  H61  sing N N 267 
+NAG C6  H62  sing N N 268 
+NAG C7  C8   sing N N 269 
+NAG C7  N2   sing N N 270 
+NAG C7  O7   doub N N 271 
+NAG C8  H81  sing N N 272 
+NAG C8  H82  sing N N 273 
+NAG C8  H83  sing N N 274 
+NAG N2  HN2  sing N N 275 
+NAG O1  HO1  sing N N 276 
+NAG O3  HO3  sing N N 277 
+NAG O4  HO4  sing N N 278 
+NAG O6  HO6  sing N N 279 
+NDG C1  C2   sing N N 280 
+NDG C1  O5   sing N N 281 
+NDG C1  O1   sing N N 282 
+NDG C1  H1   sing N N 283 
+NDG C2  C3   sing N N 284 
+NDG C2  N2   sing N N 285 
+NDG C2  H2   sing N N 286 
+NDG C3  C4   sing N N 287 
+NDG C3  O3   sing N N 288 
+NDG C3  H3   sing N N 289 
+NDG C4  C5   sing N N 290 
+NDG C4  O4   sing N N 291 
+NDG C4  H4   sing N N 292 
+NDG C5  C6   sing N N 293 
+NDG C5  O5   sing N N 294 
+NDG C5  H5   sing N N 295 
+NDG C6  O6   sing N N 296 
+NDG C6  H61  sing N N 297 
+NDG C6  H62  sing N N 298 
+NDG C7  C8   sing N N 299 
+NDG C7  O7   doub N N 300 
+NDG C7  N2   sing N N 301 
+NDG C8  H81  sing N N 302 
+NDG C8  H82  sing N N 303 
+NDG C8  H83  sing N N 304 
+NDG O3  HO3  sing N N 305 
+NDG O4  HO4  sing N N 306 
+NDG O6  HO6  sing N N 307 
+NDG N2  HN2  sing N N 308 
+NDG O1  HO1  sing N N 309 
+PHE N   CA   sing N N 310 
+PHE N   H    sing N N 311 
+PHE N   H2   sing N N 312 
+PHE CA  C    sing N N 313 
+PHE CA  CB   sing N N 314 
+PHE CA  HA   sing N N 315 
+PHE C   O    doub N N 316 
+PHE C   OXT  sing N N 317 
+PHE CB  CG   sing N N 318 
+PHE CB  HB2  sing N N 319 
+PHE CB  HB3  sing N N 320 
+PHE CG  CD1  doub Y N 321 
+PHE CG  CD2  sing Y N 322 
+PHE CD1 CE1  sing Y N 323 
+PHE CD1 HD1  sing N N 324 
+PHE CD2 CE2  doub Y N 325 
+PHE CD2 HD2  sing N N 326 
+PHE CE1 CZ   doub Y N 327 
+PHE CE1 HE1  sing N N 328 
+PHE CE2 CZ   sing Y N 329 
+PHE CE2 HE2  sing N N 330 
+PHE CZ  HZ   sing N N 331 
+PHE OXT HXT  sing N N 332 
+PRO N   CA   sing N N 333 
+PRO N   CD   sing N N 334 
+PRO N   H    sing N N 335 
+PRO CA  C    sing N N 336 
+PRO CA  CB   sing N N 337 
+PRO CA  HA   sing N N 338 
+PRO C   O    doub N N 339 
+PRO C   OXT  sing N N 340 
+PRO CB  CG   sing N N 341 
+PRO CB  HB2  sing N N 342 
+PRO CB  HB3  sing N N 343 
+PRO CG  CD   sing N N 344 
+PRO CG  HG2  sing N N 345 
+PRO CG  HG3  sing N N 346 
+PRO CD  HD2  sing N N 347 
+PRO CD  HD3  sing N N 348 
+PRO OXT HXT  sing N N 349 
+SER N   CA   sing N N 350 
+SER N   H    sing N N 351 
+SER N   H2   sing N N 352 
+SER CA  C    sing N N 353 
+SER CA  CB   sing N N 354 
+SER CA  HA   sing N N 355 
+SER C   O    doub N N 356 
+SER C   OXT  sing N N 357 
+SER CB  OG   sing N N 358 
+SER CB  HB2  sing N N 359 
+SER CB  HB3  sing N N 360 
+SER OG  HG   sing N N 361 
+SER OXT HXT  sing N N 362 
+SO4 S   O1   doub N N 363 
+SO4 S   O2   doub N N 364 
+SO4 S   O3   sing N N 365 
+SO4 S   O4   sing N N 366 
+THR N   CA   sing N N 367 
+THR N   H    sing N N 368 
+THR N   H2   sing N N 369 
+THR CA  C    sing N N 370 
+THR CA  CB   sing N N 371 
+THR CA  HA   sing N N 372 
+THR C   O    doub N N 373 
+THR C   OXT  sing N N 374 
+THR CB  OG1  sing N N 375 
+THR CB  CG2  sing N N 376 
+THR CB  HB   sing N N 377 
+THR OG1 HG1  sing N N 378 
+THR CG2 HG21 sing N N 379 
+THR CG2 HG22 sing N N 380 
+THR CG2 HG23 sing N N 381 
+THR OXT HXT  sing N N 382 
+TRP N   CA   sing N N 383 
+TRP N   H    sing N N 384 
+TRP N   H2   sing N N 385 
+TRP CA  C    sing N N 386 
+TRP CA  CB   sing N N 387 
+TRP CA  HA   sing N N 388 
+TRP C   O    doub N N 389 
+TRP C   OXT  sing N N 390 
+TRP CB  CG   sing N N 391 
+TRP CB  HB2  sing N N 392 
+TRP CB  HB3  sing N N 393 
+TRP CG  CD1  doub Y N 394 
+TRP CG  CD2  sing Y N 395 
+TRP CD1 NE1  sing Y N 396 
+TRP CD1 HD1  sing N N 397 
+TRP CD2 CE2  doub Y N 398 
+TRP CD2 CE3  sing Y N 399 
+TRP NE1 CE2  sing Y N 400 
+TRP NE1 HE1  sing N N 401 
+TRP CE2 CZ2  sing Y N 402 
+TRP CE3 CZ3  doub Y N 403 
+TRP CE3 HE3  sing N N 404 
+TRP CZ2 CH2  doub Y N 405 
+TRP CZ2 HZ2  sing N N 406 
+TRP CZ3 CH2  sing Y N 407 
+TRP CZ3 HZ3  sing N N 408 
+TRP CH2 HH2  sing N N 409 
+TRP OXT HXT  sing N N 410 
+TYR N   CA   sing N N 411 
+TYR N   H    sing N N 412 
+TYR N   H2   sing N N 413 
+TYR CA  C    sing N N 414 
+TYR CA  CB   sing N N 415 
+TYR CA  HA   sing N N 416 
+TYR C   O    doub N N 417 
+TYR C   OXT  sing N N 418 
+TYR CB  CG   sing N N 419 
+TYR CB  HB2  sing N N 420 
+TYR CB  HB3  sing N N 421 
+TYR CG  CD1  doub Y N 422 
+TYR CG  CD2  sing Y N 423 
+TYR CD1 CE1  sing Y N 424 
+TYR CD1 HD1  sing N N 425 
+TYR CD2 CE2  doub Y N 426 
+TYR CD2 HD2  sing N N 427 
+TYR CE1 CZ   doub Y N 428 
+TYR CE1 HE1  sing N N 429 
+TYR CE2 CZ   sing Y N 430 
+TYR CE2 HE2  sing N N 431 
+TYR CZ  OH   sing N N 432 
+TYR OH  HH   sing N N 433 
+TYR OXT HXT  sing N N 434 
+VAL N   CA   sing N N 435 
+VAL N   H    sing N N 436 
+VAL N   H2   sing N N 437 
+VAL CA  C    sing N N 438 
+VAL CA  CB   sing N N 439 
+VAL CA  HA   sing N N 440 
+VAL C   O    doub N N 441 
+VAL C   OXT  sing N N 442 
+VAL CB  CG1  sing N N 443 
+VAL CB  CG2  sing N N 444 
+VAL CB  HB   sing N N 445 
+VAL CG1 HG11 sing N N 446 
+VAL CG1 HG12 sing N N 447 
+VAL CG1 HG13 sing N N 448 
+VAL CG2 HG21 sing N N 449 
+VAL CG2 HG22 sing N N 450 
+VAL CG2 HG23 sing N N 451 
+VAL OXT HXT  sing N N 452 
+# 
+loop_
+_pdbx_entity_branch_list.entity_id 
+_pdbx_entity_branch_list.comp_id 
+_pdbx_entity_branch_list.num 
+_pdbx_entity_branch_list.hetero 
+2 NAG 1 y 
+2 NDG 1 y 
+2 NAG 2 n 
+2 NAG 3 n 
+2 NAG 4 n 
+# 
+_pdbx_initial_refinement_model.id               1 
+_pdbx_initial_refinement_model.entity_id_list   ? 
+_pdbx_initial_refinement_model.type             'experimental model' 
+_pdbx_initial_refinement_model.source_name      PDB 
+_pdbx_initial_refinement_model.accession_code   4HMC 
+_pdbx_initial_refinement_model.details          ? 
+# 
+_atom_sites.entry_id                    4MB4 
+_atom_sites.fract_transf_matrix[1][1]   0.014855 
+_atom_sites.fract_transf_matrix[1][2]   0.008576 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.017153 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.003910 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C  
+N  
+NA 
+O  
+S  
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N  N   . GLY A 1 1   ? -3.275  27.216  1.370   1.00 33.48 ? 23   GLY A N   1 
+ATOM   2    C  CA  . GLY A 1 1   ? -2.788  25.836  1.411   1.00 34.60 ? 23   GLY A CA  1 
+ATOM   3    C  C   . GLY A 1 1   ? -3.622  24.812  2.192   1.00 34.57 ? 23   GLY A C   1 
+ATOM   4    O  O   . GLY A 1 1   ? -4.725  25.078  2.704   1.00 37.06 ? 23   GLY A O   1 
+ATOM   5    N  N   . THR A 1 2   ? -3.070  23.612  2.347   1.00 33.33 ? 24   THR A N   1 
+ATOM   6    C  CA  . THR A 1 2   ? -3.863  22.568  2.976   1.00 32.33 ? 24   THR A CA  1 
+ATOM   7    C  C   . THR A 1 2   ? -3.432  22.387  4.448   1.00 27.40 ? 24   THR A C   1 
+ATOM   8    O  O   . THR A 1 2   ? -2.476  23.116  4.935   1.00 22.83 ? 24   THR A O   1 
+ATOM   9    C  CB  . THR A 1 2   ? -3.700  21.274  2.239   1.00 37.41 ? 24   THR A CB  1 
+ATOM   10   O  OG1 . THR A 1 2   ? -2.306  20.908  2.288   1.00 40.34 ? 24   THR A OG1 1 
+ATOM   11   C  CG2 . THR A 1 2   ? -4.121  21.437  0.870   1.00 40.34 ? 24   THR A CG2 1 
+ATOM   12   N  N   . ILE A 1 3   ? -4.187  21.540  5.172   1.00 26.73 ? 25   ILE A N   1 
+ATOM   13   C  CA  . ILE A 1 3   ? -3.837  21.269  6.584   1.00 22.55 ? 25   ILE A CA  1 
+ATOM   14   C  C   . ILE A 1 3   ? -2.503  20.532  6.650   1.00 18.51 ? 25   ILE A C   1 
+ATOM   15   O  O   . ILE A 1 3   ? -2.347  19.416  6.105   1.00 22.25 ? 25   ILE A O   1 
+ATOM   16   C  CB  . ILE A 1 3   ? -4.920  20.538  7.350   1.00 23.41 ? 25   ILE A CB  1 
+ATOM   17   C  CG1 . ILE A 1 3   ? -6.149  21.456  7.418   1.00 28.22 ? 25   ILE A CG1 1 
+ATOM   18   C  CG2 . ILE A 1 3   ? -4.383  20.083  8.719   1.00 25.14 ? 25   ILE A CG2 1 
+ATOM   19   C  CD1 . ILE A 1 3   ? -7.202  21.061  8.309   1.00 31.13 ? 25   ILE A CD1 1 
+ATOM   20   N  N   . THR A 1 4   ? -1.532  21.209  7.221   1.00 16.49 ? 26   THR A N   1 
+ATOM   21   C  CA  . THR A 1 4   ? -0.128  20.813  7.194   1.00 17.05 ? 26   THR A CA  1 
+ATOM   22   C  C   . THR A 1 4   ? 0.279   20.486  8.651   1.00 15.96 ? 26   THR A C   1 
+ATOM   23   O  O   . THR A 1 4   ? 0.256   21.386  9.520   1.00 15.89 ? 26   THR A O   1 
+ATOM   24   C  CB  . THR A 1 4   ? 0.688   22.013  6.680   1.00 18.80 ? 26   THR A CB  1 
+ATOM   25   O  OG1 . THR A 1 4   ? 0.329   22.345  5.312   1.00 19.41 ? 26   THR A OG1 1 
+ATOM   26   C  CG2 . THR A 1 4   ? 2.142   21.710  6.720   1.00 17.54 ? 26   THR A CG2 1 
+ATOM   27   N  N   . SER A 1 5   ? 0.632   19.234  8.869   1.00 17.47 ? 27   SER A N   1 
+ATOM   28   C  CA  A SER A 1 5   ? 0.924   18.689  10.180  0.47 16.45 ? 27   SER A CA  1 
+ATOM   29   C  CA  B SER A 1 5   ? 0.966   18.813  10.208  0.53 16.46 ? 27   SER A CA  1 
+ATOM   30   C  C   . SER A 1 5   ? 2.416   18.361  10.306  1.00 16.78 ? 27   SER A C   1 
+ATOM   31   O  O   . SER A 1 5   ? 3.099   18.195  9.316   1.00 21.39 ? 27   SER A O   1 
+ATOM   32   C  CB  A SER A 1 5   ? 0.052   17.426  10.374  0.47 20.38 ? 27   SER A CB  1 
+ATOM   33   C  CB  B SER A 1 5   ? -0.018  17.742  10.705  0.53 21.11 ? 27   SER A CB  1 
+ATOM   34   O  OG  A SER A 1 5   ? 0.483   16.584  11.408  0.47 25.20 ? 27   SER A OG  1 
+ATOM   35   O  OG  B SER A 1 5   ? 0.053   16.584  9.935   0.53 23.78 ? 27   SER A OG  1 
+ATOM   36   N  N   . GLN A 1 6   ? 2.924   18.245  11.531  1.00 16.49 ? 28   GLN A N   1 
+ATOM   37   C  CA  . GLN A 1 6   ? 4.291   17.916  11.728  1.00 16.88 ? 28   GLN A CA  1 
+ATOM   38   C  C   . GLN A 1 6   ? 4.484   16.485  12.279  1.00 20.92 ? 28   GLN A C   1 
+ATOM   39   O  O   . GLN A 1 6   ? 4.024   16.142  13.371  1.00 25.00 ? 28   GLN A O   1 
+ATOM   40   C  CB  . GLN A 1 6   ? 4.850   18.918  12.773  1.00 18.64 ? 28   GLN A CB  1 
+ATOM   41   C  CG  . GLN A 1 6   ? 4.828   20.347  12.368  1.00 16.82 ? 28   GLN A CG  1 
+ATOM   42   C  CD  . GLN A 1 6   ? 5.549   20.580  10.994  1.00 16.44 ? 28   GLN A CD  1 
+ATOM   43   O  OE1 . GLN A 1 6   ? 6.681   20.174  10.783  1.00 19.63 ? 28   GLN A OE1 1 
+ATOM   44   N  NE2 . GLN A 1 6   ? 4.884   21.343  10.116  1.00 14.69 ? 28   GLN A NE2 1 
+ATOM   45   N  N   . ASP A 1 7   ? 5.223   15.709  11.508  1.00 21.25 ? 29   ASP A N   1 
+ATOM   46   C  CA  A ASP A 1 7   ? 5.471   14.366  11.905  0.52 21.88 ? 29   ASP A CA  1 
+ATOM   47   C  CA  B ASP A 1 7   ? 5.547   14.318  11.740  0.48 22.44 ? 29   ASP A CA  1 
+ATOM   48   C  C   . ASP A 1 7   ? 6.746   14.209  12.718  1.00 20.19 ? 29   ASP A C   1 
+ATOM   49   O  O   . ASP A 1 7   ? 6.917   13.199  13.440  1.00 22.39 ? 29   ASP A O   1 
+ATOM   50   C  CB  A ASP A 1 7   ? 5.537   13.503  10.674  0.52 23.58 ? 29   ASP A CB  1 
+ATOM   51   C  CB  B ASP A 1 7   ? 5.990   13.584  10.422  0.48 23.86 ? 29   ASP A CB  1 
+ATOM   52   C  CG  A ASP A 1 7   ? 4.199   12.973  10.281  0.52 26.21 ? 29   ASP A CG  1 
+ATOM   53   C  CG  B ASP A 1 7   ? 4.917   13.528  9.294   0.48 25.79 ? 29   ASP A CG  1 
+ATOM   54   O  OD1 A ASP A 1 7   ? 3.223   13.229  11.047  0.52 26.02 ? 29   ASP A OD1 1 
+ATOM   55   O  OD1 B ASP A 1 7   ? 3.731   13.810  9.533   0.48 25.35 ? 29   ASP A OD1 1 
+ATOM   56   O  OD2 A ASP A 1 7   ? 4.163   12.281  9.236   0.52 26.83 ? 29   ASP A OD2 1 
+ATOM   57   O  OD2 B ASP A 1 7   ? 5.274   13.143  8.125   0.48 30.27 ? 29   ASP A OD2 1 
+ATOM   58   N  N   . ASP A 1 8   ? 7.636   15.202  12.664  1.00 17.63 ? 30   ASP A N   1 
+ATOM   59   C  CA  . ASP A 1 8   ? 8.935   15.027  13.296  1.00 17.03 ? 30   ASP A CA  1 
+ATOM   60   C  C   . ASP A 1 8   ? 9.053   16.012  14.476  1.00 14.71 ? 30   ASP A C   1 
+ATOM   61   O  O   . ASP A 1 8   ? 8.029   16.564  14.941  1.00 15.34 ? 30   ASP A O   1 
+ATOM   62   C  CB  . ASP A 1 8   ? 10.107  15.221  12.296  1.00 21.80 ? 30   ASP A CB  1 
+ATOM   63   C  CG  . ASP A 1 8   ? 10.178  14.132  11.251  1.00 29.36 ? 30   ASP A CG  1 
+ATOM   64   O  OD1 . ASP A 1 8   ? 9.844   12.963  11.575  1.00 32.36 ? 30   ASP A OD1 1 
+ATOM   65   O  OD2 . ASP A 1 8   ? 10.603  14.418  10.107  1.00 32.74 ? 30   ASP A OD2 1 
+ATOM   66   N  N   . ASN A 1 9   ? 10.263  16.260  14.944  1.00 14.71 ? 31   ASN A N   1 
+ATOM   67   C  CA  . ASN A 1 9   ? 10.398  17.176  16.070  1.00 14.27 ? 31   ASN A CA  1 
+ATOM   68   C  C   . ASN A 1 9   ? 9.931   18.568  15.693  1.00 11.68 ? 31   ASN A C   1 
+ATOM   69   O  O   . ASN A 1 9   ? 9.983   19.023  14.519  1.00 13.60 ? 31   ASN A O   1 
+ATOM   70   C  CB  . ASN A 1 9   ? 11.819  17.293  16.548  1.00 14.53 ? 31   ASN A CB  1 
+ATOM   71   C  CG  . ASN A 1 9   ? 12.219  16.157  17.498  1.00 17.68 ? 31   ASN A CG  1 
+ATOM   72   O  OD1 . ASN A 1 9   ? 11.470  15.185  17.736  1.00 16.69 ? 31   ASN A OD1 1 
+ATOM   73   N  ND2 . ASN A 1 9   ? 13.433  16.283  18.066  1.00 19.52 ? 31   ASN A ND2 1 
+ATOM   74   N  N   . VAL A 1 10  ? 9.558   19.325  16.716  1.00 12.67 ? 32   VAL A N   1 
+ATOM   75   C  CA  . VAL A 1 10  ? 9.061   20.682  16.518  1.00 12.64 ? 32   VAL A CA  1 
+ATOM   76   C  C   . VAL A 1 10  ? 9.836   21.687  17.301  1.00 13.49 ? 32   VAL A C   1 
+ATOM   77   O  O   . VAL A 1 10  ? 10.298  21.392  18.447  1.00 12.90 ? 32   VAL A O   1 
+ATOM   78   C  CB  . VAL A 1 10  ? 7.574   20.787  16.840  1.00 12.82 ? 32   VAL A CB  1 
+ATOM   79   C  CG1 . VAL A 1 10  ? 6.740   19.907  15.847  1.00 13.29 ? 32   VAL A CG1 1 
+ATOM   80   C  CG2 . VAL A 1 10  ? 7.284   20.343  18.301  1.00 12.61 ? 32   VAL A CG2 1 
+ATOM   81   N  N   . VAL A 1 11  ? 9.981   22.858  16.713  1.00 12.13 ? 33   VAL A N   1 
+ATOM   82   C  CA  . VAL A 1 11  ? 10.367  24.072  17.441  1.00 12.01 ? 33   VAL A CA  1 
+ATOM   83   C  C   . VAL A 1 11  ? 9.199   25.023  17.271  1.00 12.13 ? 33   VAL A C   1 
+ATOM   84   O  O   . VAL A 1 11  ? 8.915   25.520  16.160  1.00 13.10 ? 33   VAL A O   1 
+ATOM   85   C  CB  . VAL A 1 11  ? 11.682  24.711  16.949  1.00 12.06 ? 33   VAL A CB  1 
+ATOM   86   C  CG1 . VAL A 1 11  ? 11.955  25.967  17.800  1.00 15.72 ? 33   VAL A CG1 1 
+ATOM   87   C  CG2 . VAL A 1 11  ? 12.836  23.694  17.012  1.00 13.55 ? 33   VAL A CG2 1 
+ATOM   88   N  N   . VAL A 1 12  ? 8.448   25.170  18.320  1.00 10.98 ? 34   VAL A N   1 
+ATOM   89   C  CA  . VAL A 1 12  ? 7.184   25.915  18.319  1.00 11.54 ? 34   VAL A CA  1 
+ATOM   90   C  C   . VAL A 1 12  ? 7.457   27.347  18.790  1.00 12.25 ? 34   VAL A C   1 
+ATOM   91   O  O   . VAL A 1 12  ? 8.093   27.562  19.819  1.00 11.47 ? 34   VAL A O   1 
+ATOM   92   C  CB  . VAL A 1 12  ? 6.152   25.277  19.326  1.00 11.60 ? 34   VAL A CB  1 
+ATOM   93   C  CG1 . VAL A 1 12  ? 4.828   26.046  19.322  1.00 11.96 ? 34   VAL A CG1 1 
+ATOM   94   C  CG2 . VAL A 1 12  ? 5.878   23.813  19.009  1.00 13.89 ? 34   VAL A CG2 1 
+ATOM   95   N  N   . GLY A 1 13  ? 6.923   28.317  18.041  1.00 11.56 ? 35   GLY A N   1 
+ATOM   96   C  CA  . GLY A 1 13  ? 7.021   29.711  18.460  1.00 12.19 ? 35   GLY A CA  1 
+ATOM   97   C  C   . GLY A 1 13  ? 5.721   30.431  18.378  1.00 11.90 ? 35   GLY A C   1 
+ATOM   98   O  O   . GLY A 1 13  ? 5.016   30.324  17.360  1.00 12.28 ? 35   GLY A O   1 
+ATOM   99   N  N   . TYR A 1 14  ? 5.338   31.127  19.449  1.00 12.73 ? 36   TYR A N   1 
+ATOM   100  C  CA  . TYR A 1 14  ? 4.105   31.902  19.399  1.00 11.48 ? 36   TYR A CA  1 
+ATOM   101  C  C   . TYR A 1 14  ? 4.354   33.230  18.673  1.00 11.91 ? 36   TYR A C   1 
+ATOM   102  O  O   . TYR A 1 14  ? 5.430   33.803  18.739  1.00 12.70 ? 36   TYR A O   1 
+ATOM   103  C  CB  . TYR A 1 14  ? 3.598   32.201  20.849  1.00 12.75 ? 36   TYR A CB  1 
+ATOM   104  C  CG  . TYR A 1 14  ? 3.001   30.957  21.502  1.00 11.44 ? 36   TYR A CG  1 
+ATOM   105  C  CD1 . TYR A 1 14  ? 1.652   30.707  21.508  1.00 11.85 ? 36   TYR A CD1 1 
+ATOM   106  C  CD2 . TYR A 1 14  ? 3.819   30.006  22.052  1.00 14.07 ? 36   TYR A CD2 1 
+ATOM   107  C  CE1 . TYR A 1 14  ? 1.123   29.545  22.121  1.00 12.08 ? 36   TYR A CE1 1 
+ATOM   108  C  CE2 . TYR A 1 14  ? 3.341   28.854  22.653  1.00 13.30 ? 36   TYR A CE2 1 
+ATOM   109  C  CZ  . TYR A 1 14  ? 1.991   28.607  22.652  1.00 12.45 ? 36   TYR A CZ  1 
+ATOM   110  O  OH  . TYR A 1 14  ? 1.481   27.455  23.201  1.00 14.19 ? 36   TYR A OH  1 
+ATOM   111  N  N   . TRP A 1 15  ? 3.277   33.707  18.030  1.00 11.03 ? 37   TRP A N   1 
+ATOM   112  C  CA  . TRP A 1 15  ? 3.290   34.935  17.226  1.00 10.59 ? 37   TRP A CA  1 
+ATOM   113  C  C   . TRP A 1 15  ? 2.225   35.908  17.790  1.00 12.43 ? 37   TRP A C   1 
+ATOM   114  O  O   . TRP A 1 15  ? 1.048   35.552  17.853  1.00 13.80 ? 37   TRP A O   1 
+ATOM   115  C  CB  . TRP A 1 15  ? 3.005   34.573  15.729  1.00 13.52 ? 37   TRP A CB  1 
+ATOM   116  C  CG  . TRP A 1 15  ? 2.978   35.724  14.783  1.00 12.75 ? 37   TRP A CG  1 
+ATOM   117  C  CD1 . TRP A 1 15  ? 4.031   36.189  14.058  1.00 13.59 ? 37   TRP A CD1 1 
+ATOM   118  C  CD2 . TRP A 1 15  ? 1.825   36.465  14.345  1.00 13.46 ? 37   TRP A CD2 1 
+ATOM   119  N  NE1 . TRP A 1 15  ? 3.597   37.191  13.191  1.00 14.04 ? 37   TRP A NE1 1 
+ATOM   120  C  CE2 . TRP A 1 15  ? 2.257   37.369  13.355  1.00 14.21 ? 37   TRP A CE2 1 
+ATOM   121  C  CE3 . TRP A 1 15  ? 0.510   36.500  14.745  1.00 15.62 ? 37   TRP A CE3 1 
+ATOM   122  C  CZ2 . TRP A 1 15  ? 1.373   38.291  12.735  1.00 14.39 ? 37   TRP A CZ2 1 
+ATOM   123  C  CZ3 . TRP A 1 15  ? -0.368  37.382  14.112  1.00 15.33 ? 37   TRP A CZ3 1 
+ATOM   124  C  CH2 . TRP A 1 15  ? 0.085   38.240  13.077  1.00 16.10 ? 37   TRP A CH2 1 
+ATOM   125  N  N   . HIS A 1 16  ? 2.678   37.083  18.231  1.00 12.88 ? 38   HIS A N   1 
+ATOM   126  C  CA  . HIS A 1 16  ? 1.793   38.042  18.858  1.00 15.29 ? 38   HIS A CA  1 
+ATOM   127  C  C   . HIS A 1 16  ? 0.852   38.719  17.820  1.00 14.81 ? 38   HIS A C   1 
+ATOM   128  O  O   . HIS A 1 16  ? 1.311   39.373  16.898  1.00 14.46 ? 38   HIS A O   1 
+ATOM   129  C  CB  . HIS A 1 16  ? 2.565   39.189  19.480  1.00 13.65 ? 38   HIS A CB  1 
+ATOM   130  C  CG  . HIS A 1 16  ? 3.558   38.849  20.525  1.00 13.92 ? 38   HIS A CG  1 
+ATOM   131  N  ND1 . HIS A 1 16  ? 4.320   39.820  21.138  1.00 15.00 ? 38   HIS A ND1 1 
+ATOM   132  C  CD2 . HIS A 1 16  ? 3.957   37.667  21.054  1.00 14.08 ? 38   HIS A CD2 1 
+ATOM   133  C  CE1 . HIS A 1 16  ? 5.097   39.251  22.056  1.00 14.19 ? 38   HIS A CE1 1 
+ATOM   134  N  NE2 . HIS A 1 16  ? 4.932   37.940  21.981  1.00 14.08 ? 38   HIS A NE2 1 
+ATOM   135  N  N   . ASN A 1 17  ? -0.457  38.646  18.045  1.00 14.05 ? 39   ASN A N   1 
+ATOM   136  C  CA  . ASN A 1 17  ? -1.409  39.421  17.278  1.00 15.32 ? 39   ASN A CA  1 
+ATOM   137  C  C   . ASN A 1 17  ? -1.495  40.835  17.878  1.00 16.47 ? 39   ASN A C   1 
+ATOM   138  O  O   . ASN A 1 17  ? -2.580  41.312  18.143  1.00 16.45 ? 39   ASN A O   1 
+ATOM   139  C  CB  . ASN A 1 17  ? -2.760  38.723  17.332  1.00 15.84 ? 39   ASN A CB  1 
+ATOM   140  C  CG  . ASN A 1 17  ? -3.806  39.394  16.445  1.00 14.90 ? 39   ASN A CG  1 
+ATOM   141  O  OD1 . ASN A 1 17  ? -3.459  39.855  15.327  1.00 16.31 ? 39   ASN A OD1 1 
+ATOM   142  N  ND2 . ASN A 1 17  ? -5.071  39.383  16.872  1.00 16.75 ? 39   ASN A ND2 1 
+ATOM   143  N  N   . TRP A 1 18  ? -0.356  41.487  18.074  1.00 15.89 ? 40   TRP A N   1 
+ATOM   144  C  CA  . TRP A 1 18  ? -0.308  42.882  18.542  1.00 15.24 ? 40   TRP A CA  1 
+ATOM   145  C  C   . TRP A 1 18  ? 1.118   43.413  18.388  1.00 16.32 ? 40   TRP A C   1 
+ATOM   146  O  O   . TRP A 1 18  ? 2.043   42.589  18.155  1.00 15.85 ? 40   TRP A O   1 
+ATOM   147  C  CB  . TRP A 1 18  ? -0.776  42.987  20.012  1.00 14.22 ? 40   TRP A CB  1 
+ATOM   148  C  CG  . TRP A 1 18  ? 0.083   42.214  20.994  1.00 16.28 ? 40   TRP A CG  1 
+ATOM   149  C  CD1 . TRP A 1 18  ? 1.265   42.644  21.582  1.00 18.81 ? 40   TRP A CD1 1 
+ATOM   150  C  CD2 . TRP A 1 18  ? -0.131  40.885  21.462  1.00 15.67 ? 40   TRP A CD2 1 
+ATOM   151  N  NE1 . TRP A 1 18  ? 1.759   41.666  22.406  1.00 17.69 ? 40   TRP A NE1 1 
+ATOM   152  C  CE2 . TRP A 1 18  ? 0.922   40.569  22.336  1.00 16.50 ? 40   TRP A CE2 1 
+ATOM   153  C  CE3 . TRP A 1 18  ? -1.148  39.984  21.275  1.00 16.36 ? 40   TRP A CE3 1 
+ATOM   154  C  CZ2 . TRP A 1 18  ? 0.986   39.340  22.976  1.00 17.24 ? 40   TRP A CZ2 1 
+ATOM   155  C  CZ3 . TRP A 1 18  ? -1.073  38.745  21.851  1.00 16.44 ? 40   TRP A CZ3 1 
+ATOM   156  C  CH2 . TRP A 1 18  ? -0.015  38.432  22.702  1.00 17.88 ? 40   TRP A CH2 1 
+ATOM   157  N  N   . CYS A 1 19  ? 1.294   44.742  18.548  1.00 17.19 ? 41   CYS A N   1 
+ATOM   158  C  CA  . CYS A 1 19  ? 2.579   45.402  18.358  1.00 17.84 ? 41   CYS A CA  1 
+ATOM   159  C  C   . CYS A 1 19  ? 3.120   45.974  19.671  1.00 17.10 ? 41   CYS A C   1 
+ATOM   160  O  O   . CYS A 1 19  ? 2.351   46.437  20.492  1.00 19.84 ? 41   CYS A O   1 
+ATOM   161  C  CB  . CYS A 1 19  ? 2.430   46.542  17.344  1.00 19.89 ? 41   CYS A CB  1 
+ATOM   162  S  SG  . CYS A 1 19  ? 1.752   46.036  15.715  1.00 21.21 ? 41   CYS A SG  1 
+ATOM   163  N  N   . ASP A 1 20  ? 4.440   46.002  19.790  1.00 18.42 ? 42   ASP A N   1 
+ATOM   164  C  CA  . ASP A 1 20  ? 5.162   46.708  20.818  1.00 19.14 ? 42   ASP A CA  1 
+ATOM   165  C  C   . ASP A 1 20  ? 4.728   46.278  22.228  1.00 17.31 ? 42   ASP A C   1 
+ATOM   166  O  O   . ASP A 1 20  ? 4.313   47.127  23.079  1.00 20.41 ? 42   ASP A O   1 
+ATOM   167  C  CB  . ASP A 1 20  ? 5.062   48.196  20.562  1.00 21.08 ? 42   ASP A CB  1 
+ATOM   168  C  CG  . ASP A 1 20  ? 5.784   48.620  19.276  1.00 25.62 ? 42   ASP A CG  1 
+ATOM   169  O  OD1 . ASP A 1 20  ? 6.755   47.912  18.868  1.00 24.00 ? 42   ASP A OD1 1 
+ATOM   170  O  OD2 . ASP A 1 20  ? 5.323   49.644  18.660  1.00 30.64 ? 42   ASP A OD2 1 
+ATOM   171  N  N   . GLY A 1 21  ? 4.796   44.966  22.459  1.00 17.97 ? 43   GLY A N   1 
+ATOM   172  C  CA  . GLY A 1 21  ? 4.532   44.439  23.776  1.00 18.52 ? 43   GLY A CA  1 
+ATOM   173  C  C   . GLY A 1 21  ? 5.657   44.761  24.734  1.00 19.10 ? 43   GLY A C   1 
+ATOM   174  O  O   . GLY A 1 21  ? 6.833   44.769  24.350  1.00 18.49 ? 43   GLY A O   1 
+ATOM   175  N  N   . ARG A 1 22  ? 5.307   45.140  25.969  1.00 19.45 ? 44   ARG A N   1 
+ATOM   176  C  CA  . ARG A 1 22  ? 6.340   45.458  26.952  1.00 19.90 ? 44   ARG A CA  1 
+ATOM   177  C  C   . ARG A 1 22  ? 6.925   44.215  27.638  1.00 16.94 ? 44   ARG A C   1 
+ATOM   178  O  O   . ARG A 1 22  ? 6.206   43.315  28.000  1.00 17.58 ? 44   ARG A O   1 
+ATOM   179  C  CB  . ARG A 1 22  ? 5.739   46.367  28.040  1.00 22.36 ? 44   ARG A CB  1 
+ATOM   180  C  CG  . ARG A 1 22  ? 6.760   46.998  28.961  1.00 28.69 ? 44   ARG A CG  1 
+ATOM   181  C  CD  . ARG A 1 22  ? 6.254   48.308  29.542  0.00 29.17 ? 44   ARG A CD  1 
+ATOM   182  N  NE  . ARG A 1 22  ? 7.352   49.218  29.859  0.00 29.72 ? 44   ARG A NE  1 
+ATOM   183  C  CZ  . ARG A 1 22  ? 8.047   49.195  30.992  0.00 30.16 ? 44   ARG A CZ  1 
+ATOM   184  N  NH1 . ARG A 1 22  ? 7.766   48.305  31.935  0.00 30.30 ? 44   ARG A NH1 1 
+ATOM   185  N  NH2 . ARG A 1 22  ? 9.029   50.066  31.182  0.00 30.30 ? 44   ARG A NH2 1 
+ATOM   186  N  N   . GLY A 1 23  ? 8.240   44.197  27.813  1.00 16.46 ? 45   GLY A N   1 
+ATOM   187  C  CA  . GLY A 1 23  ? 8.969   43.077  28.408  1.00 15.99 ? 45   GLY A CA  1 
+ATOM   188  C  C   . GLY A 1 23  ? 9.024   43.150  29.928  1.00 16.34 ? 45   GLY A C   1 
+ATOM   189  O  O   . GLY A 1 23  ? 8.896   44.234  30.544  1.00 17.99 ? 45   GLY A O   1 
+ATOM   190  N  N   . TYR A 1 24  ? 9.283   41.981  30.501  1.00 16.25 ? 46   TYR A N   1 
+ATOM   191  C  CA  . TYR A 1 24  ? 9.436   41.942  31.946  1.00 15.78 ? 46   TYR A CA  1 
+ATOM   192  C  C   . TYR A 1 24  ? 10.671  42.697  32.439  1.00 18.47 ? 46   TYR A C   1 
+ATOM   193  O  O   . TYR A 1 24  ? 10.755  42.965  33.657  1.00 19.85 ? 46   TYR A O   1 
+ATOM   194  C  CB  . TYR A 1 24  ? 9.527   40.479  32.404  1.00 16.80 ? 46   TYR A CB  1 
+ATOM   195  C  CG  . TYR A 1 24  ? 8.179   39.788  32.441  1.00 16.74 ? 46   TYR A CG  1 
+ATOM   196  C  CD1 . TYR A 1 24  ? 7.395   39.825  33.579  1.00 15.89 ? 46   TYR A CD1 1 
+ATOM   197  C  CD2 . TYR A 1 24  ? 7.683   39.116  31.323  1.00 15.77 ? 46   TYR A CD2 1 
+ATOM   198  C  CE1 . TYR A 1 24  ? 6.199   39.193  33.657  1.00 16.29 ? 46   TYR A CE1 1 
+ATOM   199  C  CE2 . TYR A 1 24  ? 6.490   38.501  31.382  1.00 15.55 ? 46   TYR A CE2 1 
+ATOM   200  C  CZ  . TYR A 1 24  ? 5.717   38.562  32.550  1.00 15.13 ? 46   TYR A CZ  1 
+ATOM   201  O  OH  . TYR A 1 24  ? 4.491   37.938  32.575  1.00 16.36 ? 46   TYR A OH  1 
+ATOM   202  N  N   . GLN A 1 25  ? 11.631  42.983  31.558  1.00 18.38 ? 47   GLN A N   1 
+ATOM   203  C  CA  . GLN A 1 25  ? 12.785  43.814  31.905  1.00 17.54 ? 47   GLN A CA  1 
+ATOM   204  C  C   . GLN A 1 25  ? 12.862  45.086  31.078  1.00 18.05 ? 47   GLN A C   1 
+ATOM   205  O  O   . GLN A 1 25  ? 13.953  45.680  30.885  1.00 19.34 ? 47   GLN A O   1 
+ATOM   206  C  CB  . GLN A 1 25  ? 14.122  43.026  31.857  1.00 20.25 ? 47   GLN A CB  1 
+ATOM   207  C  CG  . GLN A 1 25  ? 14.158  41.741  32.637  1.00 20.62 ? 47   GLN A CG  1 
+ATOM   208  C  CD  . GLN A 1 25  ? 14.087  41.986  34.078  1.00 23.12 ? 47   GLN A CD  1 
+ATOM   209  O  OE1 . GLN A 1 25  ? 14.414  43.088  34.541  1.00 25.52 ? 47   GLN A OE1 1 
+ATOM   210  N  NE2 . GLN A 1 25  ? 13.617  40.990  34.837  1.00 25.48 ? 47   GLN A NE2 1 
+ATOM   211  N  N   . GLY A 1 26  ? 11.696  45.544  30.659  1.00 19.42 ? 48   GLY A N   1 
+ATOM   212  C  CA  . GLY A 1 26  ? 11.612  46.827  30.010  1.00 20.72 ? 48   GLY A CA  1 
+ATOM   213  C  C   . GLY A 1 26  ? 11.892  46.856  28.516  1.00 18.25 ? 48   GLY A C   1 
+ATOM   214  O  O   . GLY A 1 26  ? 11.908  47.940  27.947  1.00 19.55 ? 48   GLY A O   1 
+ATOM   215  N  N   . GLY A 1 27  ? 12.098  45.681  27.905  1.00 17.99 ? 49   GLY A N   1 
+ATOM   216  C  CA  . GLY A 1 27  ? 12.286  45.604  26.472  1.00 19.60 ? 49   GLY A CA  1 
+ATOM   217  C  C   . GLY A 1 27  ? 10.991  45.739  25.681  1.00 17.21 ? 49   GLY A C   1 
+ATOM   218  O  O   . GLY A 1 27  ? 9.910   46.031  26.240  1.00 19.72 ? 49   GLY A O   1 
+ATOM   219  N  N   . ASN A 1 28  ? 11.128  45.477  24.364  1.00 16.87 ? 50   ASN A N   1 
+ATOM   220  C  CA  . ASN A 1 28  ? 10.016  45.658  23.462  1.00 17.05 ? 50   ASN A CA  1 
+ATOM   221  C  C   . ASN A 1 28  ? 9.919   44.553  22.445  1.00 17.89 ? 50   ASN A C   1 
+ATOM   222  O  O   . ASN A 1 28  ? 10.934  44.140  21.890  1.00 18.19 ? 50   ASN A O   1 
+ATOM   223  C  CB  . ASN A 1 28  ? 10.135  46.984  22.683  1.00 19.12 ? 50   ASN A CB  1 
+ATOM   224  C  CG  . ASN A 1 28  ? 8.914   47.224  21.794  1.00 17.87 ? 50   ASN A CG  1 
+ATOM   225  O  OD1 . ASN A 1 28  ? 7.820   47.537  22.333  1.00 21.37 ? 50   ASN A OD1 1 
+ATOM   226  N  ND2 . ASN A 1 28  ? 9.075   47.134  20.471  1.00 20.27 ? 50   ASN A ND2 1 
+ATOM   227  N  N   . ALA A 1 29  ? 8.704   44.033  22.227  1.00 15.79 ? 51   ALA A N   1 
+ATOM   228  C  CA  . ALA A 1 29  ? 8.474   42.984  21.213  1.00 17.05 ? 51   ALA A CA  1 
+ATOM   229  C  C   . ALA A 1 29  ? 7.695   43.565  20.056  1.00 16.14 ? 51   ALA A C   1 
+ATOM   230  O  O   . ALA A 1 29  ? 6.506   43.855  20.188  1.00 16.23 ? 51   ALA A O   1 
+ATOM   231  C  CB  . ALA A 1 29  ? 7.691   41.823  21.802  1.00 16.56 ? 51   ALA A CB  1 
+ATOM   232  N  N   . PRO A 1 30  ? 8.359   43.840  18.945  1.00 18.19 ? 52   PRO A N   1 
+ATOM   233  C  CA  . PRO A 1 30  ? 7.580   44.383  17.832  1.00 17.08 ? 52   PRO A CA  1 
+ATOM   234  C  C   . PRO A 1 30  ? 6.587   43.412  17.253  1.00 16.06 ? 52   PRO A C   1 
+ATOM   235  O  O   . PRO A 1 30  ? 6.821   42.230  17.407  1.00 16.30 ? 52   PRO A O   1 
+ATOM   236  C  CB  . PRO A 1 30  ? 8.659   44.659  16.793  1.00 17.49 ? 52   PRO A CB  1 
+ATOM   237  C  CG  . PRO A 1 30  ? 9.631   43.440  17.014  1.00 20.86 ? 52   PRO A CG  1 
+ATOM   238  C  CD  . PRO A 1 30  ? 9.704   43.413  18.533  1.00 19.99 ? 52   PRO A CD  1 
+ATOM   239  N  N   . CYS A 1 31  ? 5.518   43.861  16.577  1.00 16.16 ? 53   CYS A N   1 
+ATOM   240  C  CA  . CYS A 1 31  ? 4.817   42.910  15.686  1.00 16.72 ? 53   CYS A CA  1 
+ATOM   241  C  C   . CYS A 1 31  ? 5.756   42.626  14.527  1.00 15.78 ? 53   CYS A C   1 
+ATOM   242  O  O   . CYS A 1 31  ? 6.632   43.470  14.177  1.00 17.79 ? 53   CYS A O   1 
+ATOM   243  C  CB  . CYS A 1 31  ? 3.453   43.419  15.196  1.00 18.64 ? 53   CYS A CB  1 
+ATOM   244  S  SG  . CYS A 1 31  ? 3.441   45.131  14.682  1.00 22.01 ? 53   CYS A SG  1 
+ATOM   245  N  N   . VAL A 1 32  ? 5.592   41.428  13.976  1.00 15.21 ? 54   VAL A N   1 
+ATOM   246  C  CA  . VAL A 1 32  ? 6.376   40.992  12.824  1.00 15.46 ? 54   VAL A CA  1 
+ATOM   247  C  C   . VAL A 1 32  ? 5.468   40.325  11.843  1.00 14.35 ? 54   VAL A C   1 
+ATOM   248  O  O   . VAL A 1 32  ? 4.513   39.679  12.196  1.00 16.46 ? 54   VAL A O   1 
+ATOM   249  C  CB  . VAL A 1 32  ? 7.527   40.027  13.165  1.00 16.05 ? 54   VAL A CB  1 
+ATOM   250  C  CG1 . VAL A 1 32  ? 8.486   40.698  14.212  1.00 17.79 ? 54   VAL A CG1 1 
+ATOM   251  C  CG2 . VAL A 1 32  ? 6.992   38.739  13.639  1.00 15.51 ? 54   VAL A CG2 1 
+ATOM   252  N  N   . GLU A 1 33  ? 5.827   40.444  10.571  1.00 15.98 ? 55   GLU A N   1 
+ATOM   253  C  CA  . GLU A 1 33  ? 5.116   39.669  9.563   1.00 16.83 ? 55   GLU A CA  1 
+ATOM   254  C  C   . GLU A 1 33  ? 5.407   38.205  9.707   1.00 15.21 ? 55   GLU A C   1 
+ATOM   255  O  O   . GLU A 1 33  ? 6.553   37.827  10.044  1.00 16.62 ? 55   GLU A O   1 
+ATOM   256  C  CB  . GLU A 1 33  ? 5.444   40.129  8.104   1.00 18.91 ? 55   GLU A CB  1 
+ATOM   257  C  CG  . GLU A 1 33  ? 5.208   41.578  7.907   1.00 19.79 ? 55   GLU A CG  1 
+ATOM   258  C  CD  . GLU A 1 33  ? 5.221   41.989  6.424   1.00 25.28 ? 55   GLU A CD  1 
+ATOM   259  O  OE1 . GLU A 1 33  ? 4.667   41.352  5.531   1.00 23.37 ? 55   GLU A OE1 1 
+ATOM   260  O  OE2 . GLU A 1 33  ? 5.791   43.035  6.147   1.00 34.82 ? 55   GLU A OE2 1 
+ATOM   261  N  N   . LEU A 1 34  ? 4.421   37.360  9.396   1.00 15.40 ? 56   LEU A N   1 
+ATOM   262  C  CA  . LEU A 1 34  ? 4.707   35.913  9.463   1.00 16.88 ? 56   LEU A CA  1 
+ATOM   263  C  C   . LEU A 1 34  ? 5.834   35.500  8.574   1.00 16.21 ? 56   LEU A C   1 
+ATOM   264  O  O   . LEU A 1 34  ? 6.558   34.573  8.922   1.00 17.11 ? 56   LEU A O   1 
+ATOM   265  C  CB  . LEU A 1 34  ? 3.524   35.100  9.077   1.00 19.72 ? 56   LEU A CB  1 
+ATOM   266  C  CG  . LEU A 1 34  ? 2.420   34.887  10.034  1.00 22.75 ? 56   LEU A CG  1 
+ATOM   267  C  CD1 . LEU A 1 34  ? 1.325   34.062  9.334   1.00 24.19 ? 56   LEU A CD1 1 
+ATOM   268  C  CD2 . LEU A 1 34  ? 2.894   34.057  11.290  1.00 20.98 ? 56   LEU A CD2 1 
+ATOM   269  N  N   . LYS A 1 35  ? 5.940   36.098  7.375   1.00 15.94 ? 57   LYS A N   1 
+ATOM   270  C  CA  . LYS A 1 35  ? 6.940   35.711  6.408   1.00 19.05 ? 57   LYS A CA  1 
+ATOM   271  C  C   . LYS A 1 35  ? 8.352   36.015  6.861   1.00 18.40 ? 57   LYS A C   1 
+ATOM   272  O  O   . LYS A 1 35  ? 9.318   35.546  6.286   1.00 24.59 ? 57   LYS A O   1 
+ATOM   273  C  CB  . LYS A 1 35  ? 6.695   36.394  5.043   1.00 18.56 ? 57   LYS A CB  1 
+ATOM   274  C  CG  . LYS A 1 35  ? 6.896   37.883  5.070   1.00 21.13 ? 57   LYS A CG  1 
+ATOM   275  C  CD  . LYS A 1 35  ? 6.701   38.493  3.623   1.00 25.13 ? 57   LYS A CD  1 
+ATOM   276  C  CE  . LYS A 1 35  ? 7.083   39.959  3.731   1.00 29.12 ? 57   LYS A CE  1 
+ATOM   277  N  NZ  . LYS A 1 35  ? 6.996   40.573  2.354   1.00 32.02 ? 57   LYS A NZ  1 
+ATOM   278  N  N   . THR A 1 36  ? 8.491   36.713  7.985   1.00 15.72 ? 58   THR A N   1 
+ATOM   279  C  CA  . THR A 1 36  ? 9.802   37.038  8.491   1.00 17.90 ? 58   THR A CA  1 
+ATOM   280  C  C   . THR A 1 36  ? 10.256  36.097  9.605   1.00 16.18 ? 58   THR A C   1 
+ATOM   281  O  O   . THR A 1 36  ? 11.409  36.150  10.037  1.00 17.37 ? 58   THR A O   1 
+ATOM   282  C  CB  . THR A 1 36  ? 9.927   38.488  8.956   1.00 21.03 ? 58   THR A CB  1 
+ATOM   283  O  OG1 . THR A 1 36  ? 9.295   38.690  10.203  1.00 24.23 ? 58   THR A OG1 1 
+ATOM   284  C  CG2 . THR A 1 36  ? 9.353   39.434  7.962   1.00 19.44 ? 58   THR A CG2 1 
+ATOM   285  N  N   . VAL A 1 37  ? 9.363   35.250  10.089  1.00 14.56 ? 59   VAL A N   1 
+ATOM   286  C  CA  . VAL A 1 37  ? 9.707   34.331  11.182  1.00 14.05 ? 59   VAL A CA  1 
+ATOM   287  C  C   . VAL A 1 37  ? 10.731  33.291  10.678  1.00 11.77 ? 59   VAL A C   1 
+ATOM   288  O  O   . VAL A 1 37  ? 10.640  32.780  9.533   1.00 15.93 ? 59   VAL A O   1 
+ATOM   289  C  CB  . VAL A 1 37  ? 8.488   33.635  11.668  1.00 15.90 ? 59   VAL A CB  1 
+ATOM   290  C  CG1 . VAL A 1 37  ? 8.814   32.577  12.735  1.00 15.21 ? 59   VAL A CG1 1 
+ATOM   291  C  CG2 . VAL A 1 37  ? 7.476   34.647  12.237  1.00 16.55 ? 59   VAL A CG2 1 
+ATOM   292  N  N   . ASN A 1 38  ? 11.754  33.017  11.480  1.00 14.31 ? 60   ASN A N   1 
+ATOM   293  C  CA  . ASN A 1 38  ? 12.824  32.111  11.075  1.00 12.52 ? 60   ASN A CA  1 
+ATOM   294  C  C   . ASN A 1 38  ? 12.225  30.751  10.648  1.00 11.33 ? 60   ASN A C   1 
+ATOM   295  O  O   . ASN A 1 38  ? 11.383  30.183  11.348  1.00 13.17 ? 60   ASN A O   1 
+ATOM   296  C  CB  . ASN A 1 38  ? 13.818  31.878  12.264  1.00 14.22 ? 60   ASN A CB  1 
+ATOM   297  C  CG  . ASN A 1 38  ? 15.030  31.090  11.858  1.00 14.32 ? 60   ASN A CG  1 
+ATOM   298  O  OD1 . ASN A 1 38  ? 14.970  29.905  11.540  1.00 15.12 ? 60   ASN A OD1 1 
+ATOM   299  N  ND2 . ASN A 1 38  ? 16.159  31.770  11.839  1.00 16.19 ? 60   ASN A ND2 1 
+ATOM   300  N  N   . PRO A 1 39  ? 12.717  30.192  9.534   1.00 14.81 ? 61   PRO A N   1 
+ATOM   301  C  CA  . PRO A 1 39  ? 12.175  28.956  9.040   1.00 15.88 ? 61   PRO A CA  1 
+ATOM   302  C  C   . PRO A 1 39  ? 12.245  27.783  9.988   1.00 13.56 ? 61   PRO A C   1 
+ATOM   303  O  O   . PRO A 1 39  ? 11.462  26.818  9.808   1.00 15.04 ? 61   PRO A O   1 
+ATOM   304  C  CB  . PRO A 1 39  ? 13.054  28.661  7.812   1.00 18.48 ? 61   PRO A CB  1 
+ATOM   305  C  CG  . PRO A 1 39  ? 13.590  29.902  7.403   1.00 19.61 ? 61   PRO A CG  1 
+ATOM   306  C  CD  . PRO A 1 39  ? 13.690  30.778  8.602   1.00 17.10 ? 61   PRO A CD  1 
+ATOM   307  N  N   . GLN A 1 40  ? 13.166  27.851  10.973  1.00 11.98 ? 62   GLN A N   1 
+ATOM   308  C  CA  . GLN A 1 40  ? 13.336  26.767  11.876  1.00 13.20 ? 62   GLN A CA  1 
+ATOM   309  C  C   . GLN A 1 40  ? 12.217  26.682  12.913  1.00 11.94 ? 62   GLN A C   1 
+ATOM   310  O  O   . GLN A 1 40  ? 12.132  25.681  13.633  1.00 12.89 ? 62   GLN A O   1 
+ATOM   311  C  CB  . GLN A 1 40  ? 14.740  26.797  12.524  1.00 14.13 ? 62   GLN A CB  1 
+ATOM   312  C  CG  . GLN A 1 40  ? 15.895  26.612  11.581  1.00 13.66 ? 62   GLN A CG  1 
+ATOM   313  C  CD  . GLN A 1 40  ? 17.168  26.296  12.297  1.00 14.91 ? 62   GLN A CD  1 
+ATOM   314  O  OE1 . GLN A 1 40  ? 17.227  25.314  13.052  1.00 15.47 ? 62   GLN A OE1 1 
+ATOM   315  N  NE2 . GLN A 1 40  ? 18.194  27.150  12.104  1.00 15.78 ? 62   GLN A NE2 1 
+ATOM   316  N  N   . TYR A 1 41  ? 11.371  27.698  13.030  1.00 12.12 ? 63   TYR A N   1 
+ATOM   317  C  CA  . TYR A 1 41  ? 10.106  27.579  13.795  1.00 11.37 ? 63   TYR A CA  1 
+ATOM   318  C  C   . TYR A 1 41  ? 9.122   26.898  12.844  1.00 12.52 ? 63   TYR A C   1 
+ATOM   319  O  O   . TYR A 1 41  ? 8.598   27.539  11.936  1.00 13.09 ? 63   TYR A O   1 
+ATOM   320  C  CB  . TYR A 1 41  ? 9.571   28.956  14.217  1.00 11.95 ? 63   TYR A CB  1 
+ATOM   321  C  CG  . TYR A 1 41  ? 10.441  29.578  15.316  1.00 11.60 ? 63   TYR A CG  1 
+ATOM   322  C  CD1 . TYR A 1 41  ? 10.355  29.161  16.634  1.00 12.30 ? 63   TYR A CD1 1 
+ATOM   323  C  CD2 . TYR A 1 41  ? 11.216  30.696  15.060  1.00 13.61 ? 63   TYR A CD2 1 
+ATOM   324  C  CE1 . TYR A 1 41  ? 11.169  29.735  17.611  1.00 11.72 ? 63   TYR A CE1 1 
+ATOM   325  C  CE2 . TYR A 1 41  ? 11.967  31.315  16.064  1.00 11.71 ? 63   TYR A CE2 1 
+ATOM   326  C  CZ  . TYR A 1 41  ? 11.934  30.823  17.331  1.00 11.61 ? 63   TYR A CZ  1 
+ATOM   327  O  OH  . TYR A 1 41  ? 12.703  31.340  18.366  1.00 13.32 ? 63   TYR A OH  1 
+ATOM   328  N  N   . ASN A 1 42  ? 9.047   25.576  12.949  1.00 12.10 ? 64   ASN A N   1 
+ATOM   329  C  CA  . ASN A 1 42  ? 8.155   24.780  12.095  1.00 12.57 ? 64   ASN A CA  1 
+ATOM   330  C  C   . ASN A 1 42  ? 6.711   24.698  12.561  1.00 11.80 ? 64   ASN A C   1 
+ATOM   331  O  O   . ASN A 1 42  ? 5.833   24.187  11.839  1.00 13.35 ? 64   ASN A O   1 
+ATOM   332  C  CB  . ASN A 1 42  ? 8.729   23.409  11.717  1.00 10.91 ? 64   ASN A CB  1 
+ATOM   333  C  CG  . ASN A 1 42  ? 8.968   22.504  12.889  1.00 13.34 ? 64   ASN A CG  1 
+ATOM   334  O  OD1 . ASN A 1 42  ? 9.297   22.955  13.971  1.00 15.58 ? 64   ASN A OD1 1 
+ATOM   335  N  ND2 . ASN A 1 42  ? 8.876   21.227  12.659  1.00 15.00 ? 64   ASN A ND2 1 
+ATOM   336  N  N   . VAL A 1 43  ? 6.416   25.253  13.764  1.00 11.51 ? 65   VAL A N   1 
+ATOM   337  C  CA  . VAL A 1 43  ? 5.056   25.459  14.213  1.00 13.03 ? 65   VAL A CA  1 
+ATOM   338  C  C   . VAL A 1 43  ? 4.977   26.882  14.748  1.00 12.92 ? 65   VAL A C   1 
+ATOM   339  O  O   . VAL A 1 43  ? 5.766   27.246  15.607  1.00 12.63 ? 65   VAL A O   1 
+ATOM   340  C  CB  . VAL A 1 43  ? 4.670   24.501  15.357  1.00 12.01 ? 65   VAL A CB  1 
+ATOM   341  C  CG1 . VAL A 1 43  ? 3.241   24.713  15.818  1.00 13.84 ? 65   VAL A CG1 1 
+ATOM   342  C  CG2 . VAL A 1 43  ? 4.908   23.046  14.953  1.00 11.68 ? 65   VAL A CG2 1 
+ATOM   343  N  N   . VAL A 1 44  ? 4.069   27.684  14.199  1.00 12.00 ? 66   VAL A N   1 
+ATOM   344  C  CA  . VAL A 1 44  ? 3.911   29.085  14.616  1.00 11.10 ? 66   VAL A CA  1 
+ATOM   345  C  C   . VAL A 1 44  ? 2.487   29.271  15.094  1.00 13.10 ? 66   VAL A C   1 
+ATOM   346  O  O   . VAL A 1 44  ? 1.555   28.915  14.396  1.00 14.15 ? 66   VAL A O   1 
+ATOM   347  C  CB  . VAL A 1 44  ? 4.229   30.041  13.443  1.00 12.59 ? 66   VAL A CB  1 
+ATOM   348  C  CG1 . VAL A 1 44  ? 4.002   31.500  13.891  1.00 14.95 ? 66   VAL A CG1 1 
+ATOM   349  C  CG2 . VAL A 1 44  ? 5.623   29.851  12.960  1.00 12.52 ? 66   VAL A CG2 1 
+ATOM   350  N  N   . ASN A 1 45  ? 2.338   29.752  16.338  1.00 11.33 ? 67   ASN A N   1 
+ATOM   351  C  CA  . ASN A 1 45  ? 1.041   29.775  16.987  1.00 11.50 ? 67   ASN A CA  1 
+ATOM   352  C  C   . ASN A 1 45  ? 0.510   31.198  17.042  1.00 11.81 ? 67   ASN A C   1 
+ATOM   353  O  O   . ASN A 1 45  ? 1.024   32.045  17.787  1.00 13.20 ? 67   ASN A O   1 
+ATOM   354  C  CB  . ASN A 1 45  ? 1.143   29.170  18.401  1.00 11.80 ? 67   ASN A CB  1 
+ATOM   355  C  CG  . ASN A 1 45  ? 1.382   27.673  18.366  1.00 13.06 ? 67   ASN A CG  1 
+ATOM   356  O  OD1 . ASN A 1 45  ? 1.407   27.041  17.303  1.00 13.45 ? 67   ASN A OD1 1 
+ATOM   357  N  ND2 . ASN A 1 45  ? 1.515   27.086  19.539  1.00 13.28 ? 67   ASN A ND2 1 
+ATOM   358  N  N   . ILE A 1 46  ? -0.546  31.466  16.295  1.00 13.38 ? 68   ILE A N   1 
+ATOM   359  C  CA  . ILE A 1 46  ? -1.156  32.803  16.253  1.00 12.43 ? 68   ILE A CA  1 
+ATOM   360  C  C   . ILE A 1 46  ? -1.879  33.097  17.602  1.00 12.98 ? 68   ILE A C   1 
+ATOM   361  O  O   . ILE A 1 46  ? -2.721  32.356  18.007  1.00 13.34 ? 68   ILE A O   1 
+ATOM   362  C  CB  . ILE A 1 46  ? -2.171  32.843  15.111  1.00 14.43 ? 68   ILE A CB  1 
+ATOM   363  C  CG1 . ILE A 1 46  ? -1.533  32.458  13.754  1.00 14.98 ? 68   ILE A CG1 1 
+ATOM   364  C  CG2 . ILE A 1 46  ? -2.856  34.165  15.030  1.00 15.85 ? 68   ILE A CG2 1 
+ATOM   365  C  CD1 . ILE A 1 46  ? -0.318  33.250  13.356  1.00 15.69 ? 68   ILE A CD1 1 
+ATOM   366  N  N   . SER A 1 47  ? -1.527  34.188  18.266  1.00 12.87 ? 69   SER A N   1 
+ATOM   367  C  CA  . SER A 1 47  ? -1.948  34.370  19.657  1.00 12.90 ? 69   SER A CA  1 
+ATOM   368  C  C   . SER A 1 47  ? -2.742  35.658  19.714  1.00 13.56 ? 69   SER A C   1 
+ATOM   369  O  O   . SER A 1 47  ? -2.159  36.716  19.522  1.00 14.90 ? 69   SER A O   1 
+ATOM   370  C  CB  . SER A 1 47  ? -0.681  34.519  20.477  1.00 14.63 ? 69   SER A CB  1 
+ATOM   371  O  OG  . SER A 1 47  ? 0.140   33.380  20.331  1.00 13.34 ? 69   SER A OG  1 
+ATOM   372  N  N   . PHE A 1 48  ? -4.022  35.629  20.013  1.00 14.36 ? 70   PHE A N   1 
+ATOM   373  C  CA  . PHE A 1 48  ? -4.820  34.526  20.507  1.00 15.66 ? 70   PHE A CA  1 
+ATOM   374  C  C   . PHE A 1 48  ? -6.254  34.619  20.013  1.00 15.29 ? 70   PHE A C   1 
+ATOM   375  O  O   . PHE A 1 48  ? -6.766  35.682  19.752  1.00 16.52 ? 70   PHE A O   1 
+ATOM   376  C  CB  . PHE A 1 48  ? -4.919  34.546  22.056  1.00 13.49 ? 70   PHE A CB  1 
+ATOM   377  C  CG  . PHE A 1 48  ? -3.617  34.290  22.732  1.00 12.96 ? 70   PHE A CG  1 
+ATOM   378  C  CD1 . PHE A 1 48  ? -3.166  33.003  22.895  1.00 14.64 ? 70   PHE A CD1 1 
+ATOM   379  C  CD2 . PHE A 1 48  ? -2.906  35.327  23.264  1.00 13.47 ? 70   PHE A CD2 1 
+ATOM   380  C  CE1 . PHE A 1 48  ? -1.969  32.763  23.521  1.00 13.22 ? 70   PHE A CE1 1 
+ATOM   381  C  CE2 . PHE A 1 48  ? -1.694  35.103  23.966  1.00 14.12 ? 70   PHE A CE2 1 
+ATOM   382  C  CZ  . PHE A 1 48  ? -1.251  33.785  24.092  1.00 13.58 ? 70   PHE A CZ  1 
+ATOM   383  N  N   . MET A 1 49  ? -6.885  33.478  19.930  1.00 15.30 ? 71   MET A N   1 
+ATOM   384  C  CA  . MET A 1 49  ? -8.316  33.336  19.862  1.00 16.38 ? 71   MET A CA  1 
+ATOM   385  C  C   . MET A 1 49  ? -8.934  33.457  21.288  1.00 16.45 ? 71   MET A C   1 
+ATOM   386  O  O   . MET A 1 49  ? -8.435  32.845  22.232  1.00 15.43 ? 71   MET A O   1 
+ATOM   387  C  CB  . MET A 1 49  ? -8.630  31.966  19.282  1.00 19.06 ? 71   MET A CB  1 
+ATOM   388  C  CG  . MET A 1 49  ? -10.080 31.573  19.215  1.00 18.08 ? 71   MET A CG  1 
+ATOM   389  S  SD  . MET A 1 49  ? -10.273 29.943  18.457  1.00 18.99 ? 71   MET A SD  1 
+ATOM   390  C  CE  . MET A 1 49  ? -12.052 29.742  18.512  1.00 18.67 ? 71   MET A CE  1 
+ATOM   391  N  N   . LYS A 1 50  ? -9.958  34.261  21.430  1.00 18.69 ? 72   LYS A N   1 
+ATOM   392  C  CA  . LYS A 1 50  ? -10.440 34.623  22.763  1.00 18.04 ? 72   LYS A CA  1 
+ATOM   393  C  C   . LYS A 1 50  ? -11.800 35.322  22.573  1.00 19.08 ? 72   LYS A C   1 
+ATOM   394  O  O   . LYS A 1 50  ? -12.263 35.506  21.437  1.00 19.55 ? 72   LYS A O   1 
+ATOM   395  C  CB  . LYS A 1 50  ? -9.427  35.536  23.444  1.00 17.51 ? 72   LYS A CB  1 
+ATOM   396  C  CG  . LYS A 1 50  ? -9.317  36.905  22.824  1.00 19.26 ? 72   LYS A CG  1 
+ATOM   397  C  CD  . LYS A 1 50  ? -8.351  37.772  23.627  1.00 21.97 ? 72   LYS A CD  1 
+ATOM   398  C  CE  . LYS A 1 50  ? -8.271  39.177  23.015  1.00 26.01 ? 72   LYS A CE  1 
+ATOM   399  N  NZ  . LYS A 1 50  ? -7.506  40.085  23.892  1.00 26.96 ? 72   LYS A NZ  1 
+ATOM   400  N  N   . VAL A 1 51  ? -12.446 35.759  23.648  1.00 20.06 ? 73   VAL A N   1 
+ATOM   401  C  CA  . VAL A 1 51  ? -13.641 36.590  23.526  1.00 24.15 ? 73   VAL A CA  1 
+ATOM   402  C  C   . VAL A 1 51  ? -13.164 37.997  23.467  1.00 25.75 ? 73   VAL A C   1 
+ATOM   403  O  O   . VAL A 1 51  ? -12.556 38.498  24.417  1.00 26.92 ? 73   VAL A O   1 
+ATOM   404  C  CB  . VAL A 1 51  ? -14.565 36.409  24.727  1.00 27.67 ? 73   VAL A CB  1 
+ATOM   405  C  CG1 . VAL A 1 51  ? -15.761 37.344  24.633  1.00 28.46 ? 73   VAL A CG1 1 
+ATOM   406  C  CG2 . VAL A 1 51  ? -15.081 34.988  24.764  1.00 29.43 ? 73   VAL A CG2 1 
+ATOM   407  N  N   . TYR A 1 52  ? -13.443 38.636  22.351  1.00 28.91 ? 74   TYR A N   1 
+ATOM   408  C  CA  . TYR A 1 52  ? -13.091 40.049  22.151  1.00 35.21 ? 74   TYR A CA  1 
+ATOM   409  C  C   . TYR A 1 52  ? -14.116 40.972  22.821  1.00 42.71 ? 74   TYR A C   1 
+ATOM   410  O  O   . TYR A 1 52  ? -13.742 41.911  23.547  1.00 45.30 ? 74   TYR A O   1 
+ATOM   411  C  CB  . TYR A 1 52  ? -12.928 40.323  20.648  1.00 33.04 ? 74   TYR A CB  1 
+ATOM   412  C  CG  . TYR A 1 52  ? -11.658 39.756  20.063  1.00 30.75 ? 74   TYR A CG  1 
+ATOM   413  C  CD1 . TYR A 1 52  ? -10.541 40.555  19.853  1.00 29.78 ? 74   TYR A CD1 1 
+ATOM   414  C  CD2 . TYR A 1 52  ? -11.529 38.392  19.789  1.00 30.94 ? 74   TYR A CD2 1 
+ATOM   415  C  CE1 . TYR A 1 52  ? -9.331  40.026  19.335  1.00 29.92 ? 74   TYR A CE1 1 
+ATOM   416  C  CE2 . TYR A 1 52  ? -10.321 37.838  19.330  1.00 30.33 ? 74   TYR A CE2 1 
+ATOM   417  C  CZ  . TYR A 1 52  ? -9.215  38.652  19.071  1.00 32.23 ? 74   TYR A CZ  1 
+ATOM   418  O  OH  . TYR A 1 52  ? -7.990  38.116  18.616  1.00 34.27 ? 74   TYR A OH  1 
+ATOM   419  N  N   . ASP A 1 53  ? -15.394 40.635  22.696  1.00 45.46 ? 75   ASP A N   1 
+ATOM   420  C  CA  . ASP A 1 53  ? -16.426 41.402  23.397  1.00 47.49 ? 75   ASP A CA  1 
+ATOM   421  C  C   . ASP A 1 53  ? -17.640 40.568  23.739  1.00 46.08 ? 75   ASP A C   1 
+ATOM   422  O  O   . ASP A 1 53  ? -18.198 39.912  22.845  1.00 40.76 ? 75   ASP A O   1 
+ATOM   423  C  CB  . ASP A 1 53  ? -16.826 42.543  22.517  1.00 49.47 ? 75   ASP A CB  1 
+ATOM   424  C  CG  . ASP A 1 53  ? -17.981 43.352  23.104  1.00 51.79 ? 75   ASP A CG  1 
+ATOM   425  O  OD1 . ASP A 1 53  ? -18.313 43.182  24.318  1.00 50.90 ? 75   ASP A OD1 1 
+ATOM   426  O  OD2 . ASP A 1 53  ? -18.512 44.168  22.321  1.00 53.23 ? 75   ASP A OD2 1 
+ATOM   427  N  N   . ILE A 1 54  ? -18.036 40.594  25.016  1.00 51.49 ? 76   ILE A N   1 
+ATOM   428  C  CA  . ILE A 1 54  ? -19.071 39.682  25.500  1.00 54.58 ? 76   ILE A CA  1 
+ATOM   429  C  C   . ILE A 1 54  ? -20.375 39.927  24.772  1.00 54.11 ? 76   ILE A C   1 
+ATOM   430  O  O   . ILE A 1 54  ? -21.240 39.069  24.753  1.00 53.45 ? 76   ILE A O   1 
+ATOM   431  C  CB  . ILE A 1 54  ? -19.286 39.721  27.044  1.00 58.19 ? 76   ILE A CB  1 
+ATOM   432  C  CG1 . ILE A 1 54  ? -19.773 41.089  27.510  1.00 59.83 ? 76   ILE A CG1 1 
+ATOM   433  C  CG2 . ILE A 1 54  ? -18.011 39.360  27.764  1.00 59.59 ? 76   ILE A CG2 1 
+ATOM   434  C  CD1 . ILE A 1 54  ? -20.064 41.140  28.996  1.00 61.05 ? 76   ILE A CD1 1 
+ATOM   435  N  N   . ALA A 1 55  ? -20.505 41.075  24.136  1.00 54.54 ? 77   ALA A N   1 
+ATOM   436  C  CA  . ALA A 1 55  ? -21.713 41.371  23.376  1.00 53.43 ? 77   ALA A CA  1 
+ATOM   437  C  C   . ALA A 1 55  ? -21.782 40.583  22.063  1.00 51.05 ? 77   ALA A C   1 
+ATOM   438  O  O   . ALA A 1 55  ? -22.749 40.666  21.351  1.00 51.08 ? 77   ALA A O   1 
+ATOM   439  C  CB  . ALA A 1 55  ? -21.825 42.856  23.116  1.00 55.45 ? 77   ALA A CB  1 
+ATOM   440  N  N   . GLU A 1 56  ? -20.754 39.799  21.739  1.00 47.58 ? 78   GLU A N   1 
+ATOM   441  C  CA  . GLU A 1 56  ? -20.798 38.888  20.574  1.00 44.93 ? 78   GLU A CA  1 
+ATOM   442  C  C   . GLU A 1 56  ? -21.113 37.469  21.019  1.00 40.36 ? 78   GLU A C   1 
+ATOM   443  O  O   . GLU A 1 56  ? -21.086 36.538  20.213  1.00 38.44 ? 78   GLU A O   1 
+ATOM   444  C  CB  . GLU A 1 56  ? -19.444 38.802  19.918  1.00 47.29 ? 78   GLU A CB  1 
+ATOM   445  C  CG  . GLU A 1 56  ? -19.095 39.884  18.975  1.00 50.62 ? 78   GLU A CG  1 
+ATOM   446  C  CD  . GLU A 1 56  ? -17.628 39.790  18.626  1.00 55.43 ? 78   GLU A CD  1 
+ATOM   447  O  OE1 . GLU A 1 56  ? -16.831 40.419  19.371  1.00 56.76 ? 78   GLU A OE1 1 
+ATOM   448  O  OE2 . GLU A 1 56  ? -17.271 39.053  17.660  1.00 55.69 ? 78   GLU A OE2 1 
+ATOM   449  N  N   . GLY A 1 57  ? -21.361 37.313  22.311  1.00 37.93 ? 79   GLY A N   1 
+ATOM   450  C  CA  . GLY A 1 57  ? -21.646 36.032  22.886  1.00 36.30 ? 79   GLY A CA  1 
+ATOM   451  C  C   . GLY A 1 57  ? -20.427 35.381  23.536  1.00 32.82 ? 79   GLY A C   1 
+ATOM   452  O  O   . GLY A 1 57  ? -19.317 35.938  23.623  1.00 31.97 ? 79   GLY A O   1 
+ATOM   453  N  N   . ARG A 1 58  ? -20.645 34.158  23.979  1.00 30.75 ? 80   ARG A N   1 
+ATOM   454  C  CA  . ARG A 1 58  ? -19.672 33.385  24.733  1.00 30.53 ? 80   ARG A CA  1 
+ATOM   455  C  C   . ARG A 1 58  ? -18.593 32.718  23.891  1.00 27.46 ? 80   ARG A C   1 
+ATOM   456  O  O   . ARG A 1 58  ? -17.543 32.350  24.437  1.00 25.88 ? 80   ARG A O   1 
+ATOM   457  C  CB  . ARG A 1 58  ? -20.383 32.250  25.482  1.00 31.99 ? 80   ARG A CB  1 
+ATOM   458  C  CG  . ARG A 1 58  ? -21.344 32.715  26.486  1.00 35.22 ? 80   ARG A CG  1 
+ATOM   459  C  CD  . ARG A 1 58  ? -21.800 31.608  27.336  1.00 35.07 ? 80   ARG A CD  1 
+ATOM   460  N  NE  . ARG A 1 58  ? -22.565 30.626  26.606  1.00 33.19 ? 80   ARG A NE  1 
+ATOM   461  C  CZ  . ARG A 1 58  ? -23.850 30.742  26.317  1.00 35.71 ? 80   ARG A CZ  1 
+ATOM   462  N  NH1 . ARG A 1 58  ? -24.518 31.846  26.649  1.00 38.68 ? 80   ARG A NH1 1 
+ATOM   463  N  NH2 . ARG A 1 58  ? -24.457 29.776  25.644  1.00 37.61 ? 80   ARG A NH2 1 
+ATOM   464  N  N   . ILE A 1 59  ? -18.856 32.517  22.586  1.00 26.49 ? 81   ILE A N   1 
+ATOM   465  C  CA  . ILE A 1 59  ? -17.927 31.741  21.774  1.00 25.38 ? 81   ILE A CA  1 
+ATOM   466  C  C   . ILE A 1 59  ? -16.728 32.603  21.367  1.00 22.92 ? 81   ILE A C   1 
+ATOM   467  O  O   . ILE A 1 59  ? -16.872 33.653  20.716  1.00 23.95 ? 81   ILE A O   1 
+ATOM   468  C  CB  . ILE A 1 59  ? -18.572 31.193  20.483  1.00 25.40 ? 81   ILE A CB  1 
+ATOM   469  C  CG1 . ILE A 1 59  ? -19.866 30.445  20.805  1.00 27.13 ? 81   ILE A CG1 1 
+ATOM   470  C  CG2 . ILE A 1 59  ? -17.531 30.346  19.744  1.00 24.16 ? 81   ILE A CG2 1 
+ATOM   471  C  CD1 . ILE A 1 59  ? -19.684 29.326  21.736  1.00 27.58 ? 81   ILE A CD1 1 
+ATOM   472  N  N   . PRO A 1 60  ? -15.521 32.149  21.710  1.00 20.34 ? 82   PRO A N   1 
+ATOM   473  C  CA  . PRO A 1 60  ? -14.363 32.956  21.322  1.00 21.08 ? 82   PRO A CA  1 
+ATOM   474  C  C   . PRO A 1 60  ? -14.111 32.953  19.792  1.00 21.75 ? 82   PRO A C   1 
+ATOM   475  O  O   . PRO A 1 60  ? -14.611 32.091  19.100  1.00 20.30 ? 82   PRO A O   1 
+ATOM   476  C  CB  . PRO A 1 60  ? -13.183 32.246  21.996  1.00 22.92 ? 82   PRO A CB  1 
+ATOM   477  C  CG  . PRO A 1 60  ? -13.682 30.884  22.307  1.00 22.85 ? 82   PRO A CG  1 
+ATOM   478  C  CD  . PRO A 1 60  ? -15.147 30.976  22.513  1.00 21.54 ? 82   PRO A CD  1 
+ATOM   479  N  N   . THR A 1 61  ? -13.271 33.867  19.338  1.00 20.38 ? 83   THR A N   1 
+ATOM   480  C  CA  . THR A 1 61  ? -13.028 34.028  17.892  1.00 18.41 ? 83   THR A CA  1 
+ATOM   481  C  C   . THR A 1 61  ? -11.627 34.598  17.712  1.00 19.53 ? 83   THR A C   1 
+ATOM   482  O  O   . THR A 1 61  ? -10.895 34.777  18.704  1.00 17.14 ? 83   THR A O   1 
+ATOM   483  C  CB  . THR A 1 61  ? -14.146 34.882  17.227  1.00 22.32 ? 83   THR A CB  1 
+ATOM   484  O  OG1 . THR A 1 61  ? -14.007 34.836  15.807  1.00 22.07 ? 83   THR A OG1 1 
+ATOM   485  C  CG2 . THR A 1 61  ? -14.071 36.296  17.742  1.00 22.86 ? 83   THR A CG2 1 
+ATOM   486  N  N   . PHE A 1 62  ? -11.240 34.898  16.474  1.00 19.31 ? 84   PHE A N   1 
+ATOM   487  C  CA  . PHE A 1 62  ? -9.963  35.521  16.186  1.00 18.90 ? 84   PHE A CA  1 
+ATOM   488  C  C   . PHE A 1 62  ? -10.219 36.723  15.288  1.00 19.31 ? 84   PHE A C   1 
+ATOM   489  O  O   . PHE A 1 62  ? -10.953 36.618  14.286  1.00 22.29 ? 84   PHE A O   1 
+ATOM   490  C  CB  . PHE A 1 62  ? -9.006  34.554  15.466  1.00 18.98 ? 84   PHE A CB  1 
+ATOM   491  C  CG  . PHE A 1 62  ? -7.747  35.211  15.066  1.00 17.08 ? 84   PHE A CG  1 
+ATOM   492  C  CD1 . PHE A 1 62  ? -6.825  35.550  16.022  1.00 18.92 ? 84   PHE A CD1 1 
+ATOM   493  C  CD2 . PHE A 1 62  ? -7.470  35.519  13.734  1.00 19.90 ? 84   PHE A CD2 1 
+ATOM   494  C  CE1 . PHE A 1 62  ? -5.660  36.179  15.673  1.00 17.63 ? 84   PHE A CE1 1 
+ATOM   495  C  CE2 . PHE A 1 62  ? -6.283  36.192  13.409  1.00 19.46 ? 84   PHE A CE2 1 
+ATOM   496  C  CZ  . PHE A 1 62  ? -5.387  36.489  14.385  1.00 18.35 ? 84   PHE A CZ  1 
+ATOM   497  N  N   . LYS A 1 63  ? -9.585  37.829  15.665  1.00 19.35 ? 85   LYS A N   1 
+ATOM   498  C  CA  . LYS A 1 63  ? -9.643  39.083  14.962  1.00 18.52 ? 85   LYS A CA  1 
+ATOM   499  C  C   . LYS A 1 63  ? -8.233  39.617  14.817  1.00 19.50 ? 85   LYS A C   1 
+ATOM   500  O  O   . LYS A 1 63  ? -7.582  40.036  15.766  1.00 19.50 ? 85   LYS A O   1 
+ATOM   501  C  CB  . LYS A 1 63  ? -10.530 40.154  15.686  1.00 21.19 ? 85   LYS A CB  1 
+ATOM   502  C  CG  . LYS A 1 63  ? -11.923 39.674  15.937  1.00 24.50 ? 85   LYS A CG  1 
+ATOM   503  C  CD  . LYS A 1 63  ? -12.776 40.744  16.611  1.00 27.82 ? 85   LYS A CD  1 
+ATOM   504  C  CE  . LYS A 1 63  ? -14.217 40.271  16.950  1.00 28.52 ? 85   LYS A CE  1 
+ATOM   505  N  NZ  A LYS A 1 63  ? -15.071 41.485  17.162  0.48 27.07 ? 85   LYS A NZ  1 
+ATOM   506  N  NZ  B LYS A 1 63  ? -14.877 39.912  15.637  0.52 31.29 ? 85   LYS A NZ  1 
+ATOM   507  N  N   . LEU A 1 64  ? -7.779  39.642  13.568  1.00 21.02 ? 86   LEU A N   1 
+ATOM   508  C  CA  . LEU A 1 64  ? -6.469  40.131  13.255  1.00 17.18 ? 86   LEU A CA  1 
+ATOM   509  C  C   . LEU A 1 64  ? -6.296  41.574  13.643  1.00 18.26 ? 86   LEU A C   1 
+ATOM   510  O  O   . LEU A 1 64  ? -7.153  42.402  13.330  1.00 21.36 ? 86   LEU A O   1 
+ATOM   511  C  CB  . LEU A 1 64  ? -6.182  39.902  11.745  1.00 19.63 ? 86   LEU A CB  1 
+ATOM   512  C  CG  . LEU A 1 64  ? -4.840  40.348  11.187  1.00 20.68 ? 86   LEU A CG  1 
+ATOM   513  C  CD1 . LEU A 1 64  ? -3.684  39.562  11.730  1.00 19.34 ? 86   LEU A CD1 1 
+ATOM   514  C  CD2 . LEU A 1 64  ? -4.821  40.227  9.627   1.00 20.40 ? 86   LEU A CD2 1 
+ATOM   515  N  N   . ASP A 1 65  ? -5.187  41.875  14.271  1.00 17.52 ? 87   ASP A N   1 
+ATOM   516  C  CA  . ASP A 1 65  ? -4.915  43.282  14.655  1.00 18.50 ? 87   ASP A CA  1 
+ATOM   517  C  C   . ASP A 1 65  ? -4.445  44.063  13.414  1.00 18.48 ? 87   ASP A C   1 
+ATOM   518  O  O   . ASP A 1 65  ? -3.367  43.811  12.878  1.00 18.39 ? 87   ASP A O   1 
+ATOM   519  C  CB  . ASP A 1 65  ? -3.832  43.314  15.767  1.00 18.69 ? 87   ASP A CB  1 
+ATOM   520  C  CG  . ASP A 1 65  ? -3.535  44.745  16.271  1.00 20.89 ? 87   ASP A CG  1 
+ATOM   521  O  OD1 . ASP A 1 65  ? -3.763  45.767  15.539  1.00 21.67 ? 87   ASP A OD1 1 
+ATOM   522  O  OD2 . ASP A 1 65  ? -3.074  44.882  17.444  1.00 22.58 ? 87   ASP A OD2 1 
+ATOM   523  N  N   . PRO A 1 66  ? -5.220  45.064  12.984  1.00 20.42 ? 88   PRO A N   1 
+ATOM   524  C  CA  . PRO A 1 66  ? -4.884  45.670  11.698  1.00 20.98 ? 88   PRO A CA  1 
+ATOM   525  C  C   . PRO A 1 66  ? -3.627  46.498  11.713  1.00 21.60 ? 88   PRO A C   1 
+ATOM   526  O  O   . PRO A 1 66  ? -3.079  46.858  10.663  1.00 24.23 ? 88   PRO A O   1 
+ATOM   527  C  CB  . PRO A 1 66  ? -6.115  46.550  11.385  1.00 23.65 ? 88   PRO A CB  1 
+ATOM   528  C  CG  . PRO A 1 66  ? -7.178  45.981  12.102  1.00 24.55 ? 88   PRO A CG  1 
+ATOM   529  C  CD  . PRO A 1 66  ? -6.583  45.428  13.404  1.00 21.46 ? 88   PRO A CD  1 
+ATOM   530  N  N   . THR A 1 67  ? -3.175  46.835  12.907  1.00 21.30 ? 89   THR A N   1 
+ATOM   531  C  CA  . THR A 1 67  ? -2.005  47.687  13.007  1.00 23.16 ? 89   THR A CA  1 
+ATOM   532  C  C   . THR A 1 67  ? -0.752  46.919  12.685  1.00 21.78 ? 89   THR A C   1 
+ATOM   533  O  O   . THR A 1 67  ? 0.296   47.519  12.565  1.00 24.25 ? 89   THR A O   1 
+ATOM   534  C  CB  . THR A 1 67  ? -1.858  48.347  14.372  1.00 24.77 ? 89   THR A CB  1 
+ATOM   535  O  OG1 . THR A 1 67  ? -1.542  47.373  15.406  1.00 21.01 ? 89   THR A OG1 1 
+ATOM   536  C  CG2 . THR A 1 67  ? -3.169  49.100  14.804  1.00 23.94 ? 89   THR A CG2 1 
+ATOM   537  N  N   . ILE A 1 68  ? -0.844  45.601  12.540  1.00 20.15 ? 90   ILE A N   1 
+ATOM   538  C  CA  . ILE A 1 68  ? 0.293   44.867  12.077  1.00 20.86 ? 90   ILE A CA  1 
+ATOM   539  C  C   . ILE A 1 68  ? 0.514   45.150  10.559  1.00 21.44 ? 90   ILE A C   1 
+ATOM   540  O  O   . ILE A 1 68  ? 1.577   44.839  10.004  1.00 24.05 ? 90   ILE A O   1 
+ATOM   541  C  CB  . ILE A 1 68  ? 0.126   43.359  12.385  1.00 17.84 ? 90   ILE A CB  1 
+ATOM   542  C  CG1 . ILE A 1 68  ? -0.057  43.182  13.885  1.00 18.13 ? 90   ILE A CG1 1 
+ATOM   543  C  CG2 . ILE A 1 68  ? 1.316   42.565  11.940  1.00 18.38 ? 90   ILE A CG2 1 
+ATOM   544  C  CD1 . ILE A 1 68  ? -0.392  41.765  14.252  1.00 18.67 ? 90   ILE A CD1 1 
+ATOM   545  N  N   . ALA A 1 69  ? -0.491  45.813  9.946   1.00 21.98 ? 91   ALA A N   1 
+ATOM   546  C  CA  . ALA A 1 69  ? -0.476  46.258  8.546   1.00 23.54 ? 91   ALA A CA  1 
+ATOM   547  C  C   . ALA A 1 69  ? -0.484  45.084  7.541   1.00 21.81 ? 91   ALA A C   1 
+ATOM   548  O  O   . ALA A 1 69  ? -0.075  45.253  6.368   1.00 27.45 ? 91   ALA A O   1 
+ATOM   549  C  CB  . ALA A 1 69  ? 0.657   47.195  8.314   1.00 28.07 ? 91   ALA A CB  1 
+ATOM   550  N  N   . LEU A 1 70  ? -1.033  43.957  7.987   1.00 19.71 ? 92   LEU A N   1 
+ATOM   551  C  CA  . LEU A 1 70  ? -1.368  42.827  7.108   1.00 20.51 ? 92   LEU A CA  1 
+ATOM   552  C  C   . LEU A 1 70  ? -2.893  42.890  6.858   1.00 17.90 ? 92   LEU A C   1 
+ATOM   553  O  O   . LEU A 1 70  ? -3.679  42.852  7.822   1.00 20.23 ? 92   LEU A O   1 
+ATOM   554  C  CB  . LEU A 1 70  ? -0.962  41.490  7.709   1.00 22.08 ? 92   LEU A CB  1 
+ATOM   555  C  CG  . LEU A 1 70  ? 0.509   41.236  8.018   1.00 24.23 ? 92   LEU A CG  1 
+ATOM   556  C  CD1 . LEU A 1 70  ? 0.606   39.913  8.812   1.00 25.29 ? 92   LEU A CD1 1 
+ATOM   557  C  CD2 . LEU A 1 70  ? 1.392   41.243  6.751   1.00 29.20 ? 92   LEU A CD2 1 
+ATOM   558  N  N   . SER A 1 71  ? -3.310  43.018  5.586   1.00 18.48 ? 93   SER A N   1 
+ATOM   559  C  CA  . SER A 1 71  ? -4.714  42.806  5.317   1.00 18.29 ? 93   SER A CA  1 
+ATOM   560  C  C   . SER A 1 71  ? -5.104  41.383  5.636   1.00 18.16 ? 93   SER A C   1 
+ATOM   561  O  O   . SER A 1 71  ? -4.246  40.494  5.734   1.00 19.17 ? 93   SER A O   1 
+ATOM   562  C  CB  . SER A 1 71  ? -4.996  43.056  3.809   1.00 19.56 ? 93   SER A CB  1 
+ATOM   563  O  OG  . SER A 1 71  ? -4.312  42.095  3.016   1.00 20.53 ? 93   SER A OG  1 
+ATOM   564  N  N   . GLU A 1 72  ? -6.394  41.129  5.730   1.00 20.07 ? 94   GLU A N   1 
+ATOM   565  C  CA  . GLU A 1 72  ? -6.848  39.770  5.888   1.00 20.27 ? 94   GLU A CA  1 
+ATOM   566  C  C   . GLU A 1 72  ? -6.215  38.891  4.818   1.00 18.93 ? 94   GLU A C   1 
+ATOM   567  O  O   . GLU A 1 72  ? -5.688  37.800  5.043   1.00 17.86 ? 94   GLU A O   1 
+ATOM   568  C  CB  . GLU A 1 72  ? -8.373  39.667  5.825   1.00 22.58 ? 94   GLU A CB  1 
+ATOM   569  C  CG  . GLU A 1 72  ? -9.033  40.425  6.996   1.00 22.40 ? 94   GLU A CG  1 
+ATOM   570  C  CD  . GLU A 1 72  ? -9.201  39.574  8.225   1.00 25.98 ? 94   GLU A CD  1 
+ATOM   571  O  OE1 . GLU A 1 72  ? -9.599  38.385  8.078   1.00 28.60 ? 94   GLU A OE1 1 
+ATOM   572  O  OE2 . GLU A 1 72  ? -8.925  40.114  9.321   1.00 27.97 ? 94   GLU A OE2 1 
+ATOM   573  N  N   . ALA A 1 73  ? -6.335  39.363  3.544   1.00 19.87 ? 95   ALA A N   1 
+ATOM   574  C  CA  . ALA A 1 73  ? -5.856  38.548  2.437   1.00 18.45 ? 95   ALA A CA  1 
+ATOM   575  C  C   . ALA A 1 73  ? -4.352  38.306  2.469   1.00 15.97 ? 95   ALA A C   1 
+ATOM   576  O  O   . ALA A 1 73  ? -3.858  37.222  2.105   1.00 16.09 ? 95   ALA A O   1 
+ATOM   577  C  CB  . ALA A 1 73  ? -6.256  39.220  1.121   1.00 19.08 ? 95   ALA A CB  1 
+ATOM   578  N  N   . GLU A 1 74  ? -3.596  39.300  2.894   1.00 16.07 ? 96   GLU A N   1 
+ATOM   579  C  CA  . GLU A 1 74  ? -2.148  39.143  2.994   1.00 15.13 ? 96   GLU A CA  1 
+ATOM   580  C  C   . GLU A 1 74  ? -1.769  38.167  4.119   1.00 16.61 ? 96   GLU A C   1 
+ATOM   581  O  O   . GLU A 1 74  ? -0.801  37.428  4.006   1.00 16.35 ? 96   GLU A O   1 
+ATOM   582  C  CB  . GLU A 1 74  ? -1.450  40.481  3.204   1.00 17.65 ? 96   GLU A CB  1 
+ATOM   583  C  CG  . GLU A 1 74  ? 0.075   40.364  3.272   1.00 17.98 ? 96   GLU A CG  1 
+ATOM   584  C  CD  . GLU A 1 74  ? 0.740   39.757  2.060   1.00 19.28 ? 96   GLU A CD  1 
+ATOM   585  O  OE1 . GLU A 1 74  ? 0.137   39.906  0.937   1.00 19.67 ? 96   GLU A OE1 1 
+ATOM   586  O  OE2 . GLU A 1 74  ? 1.864   39.231  2.197   1.00 20.89 ? 96   GLU A OE2 1 
+ATOM   587  N  N   . PHE A 1 75  ? -2.452  38.290  5.230   1.00 16.62 ? 97   PHE A N   1 
+ATOM   588  C  CA  . PHE A 1 75  ? -2.228  37.338  6.346   1.00 16.80 ? 97   PHE A CA  1 
+ATOM   589  C  C   . PHE A 1 75  ? -2.471  35.942  5.866   1.00 15.17 ? 97   PHE A C   1 
+ATOM   590  O  O   . PHE A 1 75  ? -1.626  35.058  6.091   1.00 16.67 ? 97   PHE A O   1 
+ATOM   591  C  CB  . PHE A 1 75  ? -3.177  37.717  7.499   1.00 16.58 ? 97   PHE A CB  1 
+ATOM   592  C  CG  . PHE A 1 75  ? -3.106  36.827  8.747   1.00 16.45 ? 97   PHE A CG  1 
+ATOM   593  C  CD1 . PHE A 1 75  ? -1.967  36.797  9.505   1.00 17.84 ? 97   PHE A CD1 1 
+ATOM   594  C  CD2 . PHE A 1 75  ? -4.220  36.141  9.161   1.00 17.76 ? 97   PHE A CD2 1 
+ATOM   595  C  CE1 . PHE A 1 75  ? -1.933  36.054  10.702  1.00 18.37 ? 97   PHE A CE1 1 
+ATOM   596  C  CE2 . PHE A 1 75  ? -4.189  35.385  10.316  1.00 20.85 ? 97   PHE A CE2 1 
+ATOM   597  C  CZ  . PHE A 1 75  ? -3.043  35.354  11.041  1.00 19.89 ? 97   PHE A CZ  1 
+ATOM   598  N  N   . ILE A 1 76  ? -3.576  35.740  5.148   1.00 17.40 ? 98   ILE A N   1 
+ATOM   599  C  CA  . ILE A 1 76  ? -3.902  34.451  4.550   1.00 16.16 ? 98   ILE A CA  1 
+ATOM   600  C  C   . ILE A 1 76  ? -2.744  33.983  3.628   1.00 16.90 ? 98   ILE A C   1 
+ATOM   601  O  O   . ILE A 1 76  ? -2.372  32.781  3.597   1.00 16.14 ? 98   ILE A O   1 
+ATOM   602  C  CB  . ILE A 1 76  ? -5.293  34.532  3.850   1.00 18.16 ? 98   ILE A CB  1 
+ATOM   603  C  CG1 . ILE A 1 76  ? -6.381  34.616  4.962   1.00 18.18 ? 98   ILE A CG1 1 
+ATOM   604  C  CG2 . ILE A 1 76  ? -5.565  33.324  2.979   1.00 15.70 ? 98   ILE A CG2 1 
+ATOM   605  C  CD1 . ILE A 1 76  ? -7.818  34.932  4.343   1.00 21.11 ? 98   ILE A CD1 1 
+ATOM   606  N  N   . ALA A 1 77  ? -2.293  34.893  2.750   1.00 15.10 ? 99   ALA A N   1 
+ATOM   607  C  CA  . ALA A 1 77  ? -1.211  34.576  1.873   1.00 14.20 ? 99   ALA A CA  1 
+ATOM   608  C  C   . ALA A 1 77  ? 0.064   34.159  2.609   1.00 15.46 ? 99   ALA A C   1 
+ATOM   609  O  O   . ALA A 1 77  ? 0.768   33.255  2.169   1.00 16.72 ? 99   ALA A O   1 
+ATOM   610  C  CB  . ALA A 1 77  ? -0.952  35.773  0.942   1.00 16.93 ? 99   ALA A CB  1 
+ATOM   611  N  N   . GLN A 1 78  ? 0.361   34.787  3.753   1.00 15.68 ? 100  GLN A N   1 
+ATOM   612  C  CA  . GLN A 1 78  ? 1.596   34.436  4.454   1.00 15.79 ? 100  GLN A CA  1 
+ATOM   613  C  C   . GLN A 1 78  ? 1.464   33.100  5.164   1.00 15.49 ? 100  GLN A C   1 
+ATOM   614  O  O   . GLN A 1 78  ? 2.431   32.360  5.233   1.00 15.23 ? 100  GLN A O   1 
+ATOM   615  C  CB  . GLN A 1 78  ? 2.052   35.573  5.393   1.00 15.55 ? 100  GLN A CB  1 
+ATOM   616  C  CG  . GLN A 1 78  ? 2.428   36.831  4.598   1.00 15.75 ? 100  GLN A CG  1 
+ATOM   617  C  CD  . GLN A 1 78  ? 3.090   37.881  5.419   1.00 17.61 ? 100  GLN A CD  1 
+ATOM   618  O  OE1 . GLN A 1 78  ? 3.538   37.645  6.538   1.00 17.24 ? 100  GLN A OE1 1 
+ATOM   619  N  NE2 . GLN A 1 78  ? 3.218   39.099  4.840   1.00 17.46 ? 100  GLN A NE2 1 
+ATOM   620  N  N   . ILE A 1 79  ? 0.304   32.770  5.686   1.00 14.35 ? 101  ILE A N   1 
+ATOM   621  C  CA  . ILE A 1 79  ? 0.070   31.395  6.171   1.00 13.82 ? 101  ILE A CA  1 
+ATOM   622  C  C   . ILE A 1 79  ? 0.239   30.371  5.055   1.00 17.27 ? 101  ILE A C   1 
+ATOM   623  O  O   . ILE A 1 79  ? 0.798   29.344  5.270   1.00 16.48 ? 101  ILE A O   1 
+ATOM   624  C  CB  . ILE A 1 79  ? -1.339  31.323  6.807   1.00 13.86 ? 101  ILE A CB  1 
+ATOM   625  C  CG1 . ILE A 1 79  ? -1.389  32.178  8.082   1.00 14.54 ? 101  ILE A CG1 1 
+ATOM   626  C  CG2 . ILE A 1 79  ? -1.742  29.909  7.142   1.00 13.89 ? 101  ILE A CG2 1 
+ATOM   627  C  CD1 . ILE A 1 79  ? -2.783  32.312  8.674   1.00 16.35 ? 101  ILE A CD1 1 
+ATOM   628  N  N   . ASP A 1 80  ? -0.280  30.698  3.870   1.00 17.33 ? 102  ASP A N   1 
+ATOM   629  C  CA  . ASP A 1 80  ? -0.108  29.803  2.754   1.00 16.68 ? 102  ASP A CA  1 
+ATOM   630  C  C   . ASP A 1 80  ? 1.347   29.602  2.419   1.00 17.34 ? 102  ASP A C   1 
+ATOM   631  O  O   . ASP A 1 80  ? 1.778   28.505  2.102   1.00 16.97 ? 102  ASP A O   1 
+ATOM   632  C  CB  . ASP A 1 80  ? -0.908  30.366  1.557   1.00 19.44 ? 102  ASP A CB  1 
+ATOM   633  C  CG  . ASP A 1 80  ? -0.705  29.520  0.277   1.00 21.59 ? 102  ASP A CG  1 
+ATOM   634  O  OD1 . ASP A 1 80  ? -1.212  28.387  0.224   1.00 25.23 ? 102  ASP A OD1 1 
+ATOM   635  O  OD2 . ASP A 1 80  ? -0.029  29.978  -0.679  1.00 21.93 ? 102  ASP A OD2 1 
+ATOM   636  N  N   . THR A 1 81  ? 2.130   30.654  2.486   1.00 17.05 ? 103  THR A N   1 
+ATOM   637  C  CA  . THR A 1 81  ? 3.528   30.533  2.250   1.00 17.20 ? 103  THR A CA  1 
+ATOM   638  C  C   . THR A 1 81  ? 4.196   29.585  3.269   1.00 18.19 ? 103  THR A C   1 
+ATOM   639  O  O   . THR A 1 81  ? 4.989   28.697  2.885   1.00 17.99 ? 103  THR A O   1 
+ATOM   640  C  CB  . THR A 1 81  ? 4.239   31.919  2.333   1.00 21.67 ? 103  THR A CB  1 
+ATOM   641  O  OG1 . THR A 1 81  ? 3.769   32.762  1.294   1.00 21.65 ? 103  THR A OG1 1 
+ATOM   642  C  CG2 . THR A 1 81  ? 5.756   31.819  2.210   1.00 24.02 ? 103  THR A CG2 1 
+ATOM   643  N  N   . LEU A 1 82  ? 3.921   29.779  4.562   1.00 16.52 ? 104  LEU A N   1 
+ATOM   644  C  CA  . LEU A 1 82  ? 4.432   28.824  5.535   1.00 14.19 ? 104  LEU A CA  1 
+ATOM   645  C  C   . LEU A 1 82  ? 4.034   27.392  5.226   1.00 13.06 ? 104  LEU A C   1 
+ATOM   646  O  O   . LEU A 1 82  ? 4.877   26.471  5.341   1.00 16.02 ? 104  LEU A O   1 
+ATOM   647  C  CB  . LEU A 1 82  ? 3.993   29.229  6.934   1.00 17.28 ? 104  LEU A CB  1 
+ATOM   648  C  CG  . LEU A 1 82  ? 5.037   30.099  7.674   1.00 16.66 ? 104  LEU A CG  1 
+ATOM   649  C  CD1 . LEU A 1 82  ? 5.328   31.445  6.960   1.00 18.77 ? 104  LEU A CD1 1 
+ATOM   650  C  CD2 . LEU A 1 82  ? 4.610   30.348  9.143   1.00 20.61 ? 104  LEU A CD2 1 
+ATOM   651  N  N   . ASN A 1 83  ? 2.744   27.192  4.907   1.00 14.48 ? 105  ASN A N   1 
+ATOM   652  C  CA  . ASN A 1 83  ? 2.254   25.850  4.586   1.00 14.47 ? 105  ASN A CA  1 
+ATOM   653  C  C   . ASN A 1 83  ? 3.020   25.245  3.355   1.00 16.48 ? 105  ASN A C   1 
+ATOM   654  O  O   . ASN A 1 83  ? 3.355   24.073  3.325   1.00 18.67 ? 105  ASN A O   1 
+ATOM   655  C  CB  . ASN A 1 83  ? 0.770   25.829  4.310   1.00 15.01 ? 105  ASN A CB  1 
+ATOM   656  C  CG  . ASN A 1 83  ? -0.108  25.969  5.540   1.00 14.98 ? 105  ASN A CG  1 
+ATOM   657  O  OD1 . ASN A 1 83  ? -1.317  26.275  5.402   1.00 16.39 ? 105  ASN A OD1 1 
+ATOM   658  N  ND2 . ASN A 1 83  ? 0.460   25.784  6.764   1.00 15.53 ? 105  ASN A ND2 1 
+ATOM   659  N  N   A SER A 1 84  ? 3.331   26.101  2.380   0.80 19.31 ? 106  SER A N   1 
+ATOM   660  N  N   B SER A 1 84  ? 3.341   26.101  2.386   0.20 18.10 ? 106  SER A N   1 
+ATOM   661  C  CA  . SER A 1 84  ? 4.092   25.660  1.209   1.00 18.87 ? 106  SER A CA  1 
+ATOM   662  C  C   . SER A 1 84  ? 5.489   25.198  1.552   1.00 18.96 ? 106  SER A C   1 
+ATOM   663  O  O   . SER A 1 84  ? 6.097   24.381  0.842   1.00 22.42 ? 106  SER A O   1 
+ATOM   664  C  CB  A SER A 1 84  ? 4.157   26.778  0.165   0.80 21.50 ? 106  SER A CB  1 
+ATOM   665  C  CB  B SER A 1 84  ? 4.125   26.746  0.142   0.20 18.97 ? 106  SER A CB  1 
+ATOM   666  O  OG  A SER A 1 84  ? 5.168   27.791  0.443   0.80 26.17 ? 106  SER A OG  1 
+ATOM   667  O  OG  B SER A 1 84  ? 2.864   26.879  -0.487  0.20 19.89 ? 106  SER A OG  1 
+ATOM   668  N  N   . GLN A 1 85  ? 6.018   25.760  2.641   1.00 16.46 ? 107  GLN A N   1 
+ATOM   669  C  CA  . GLN A 1 85  ? 7.305   25.341  3.196   1.00 17.31 ? 107  GLN A CA  1 
+ATOM   670  C  C   . GLN A 1 85  ? 7.185   24.115  4.127   1.00 17.54 ? 107  GLN A C   1 
+ATOM   671  O  O   . GLN A 1 85  ? 8.218   23.673  4.660   1.00 21.05 ? 107  GLN A O   1 
+ATOM   672  C  CB  . GLN A 1 85  ? 7.913   26.483  4.002   1.00 17.02 ? 107  GLN A CB  1 
+ATOM   673  C  CG  . GLN A 1 85  ? 8.251   27.807  3.171   1.00 18.17 ? 107  GLN A CG  1 
+ATOM   674  C  CD  . GLN A 1 85  ? 8.541   29.060  3.988   1.00 21.54 ? 107  GLN A CD  1 
+ATOM   675  O  OE1 . GLN A 1 85  ? 8.563   28.970  5.211   1.00 21.59 ? 107  GLN A OE1 1 
+ATOM   676  N  NE2 . GLN A 1 85  ? 8.744   30.225  3.366   1.00 21.74 ? 107  GLN A NE2 1 
+ATOM   677  N  N   . GLY A 1 86  ? 5.961   23.569  4.295   1.00 15.12 ? 108  GLY A N   1 
+ATOM   678  C  CA  . GLY A 1 86  ? 5.794   22.445  5.168   1.00 14.27 ? 108  GLY A CA  1 
+ATOM   679  C  C   . GLY A 1 86  ? 5.719   22.782  6.653   1.00 14.95 ? 108  GLY A C   1 
+ATOM   680  O  O   . GLY A 1 86  ? 5.829   21.909  7.494   1.00 18.08 ? 108  GLY A O   1 
+ATOM   681  N  N   . ARG A 1 87  ? 5.489   24.040  6.932   1.00 14.11 ? 109  ARG A N   1 
+ATOM   682  C  CA  . ARG A 1 87  ? 5.384   24.547  8.336   1.00 14.96 ? 109  ARG A CA  1 
+ATOM   683  C  C   . ARG A 1 87  ? 3.934   24.677  8.724   1.00 15.17 ? 109  ARG A C   1 
+ATOM   684  O  O   . ARG A 1 87  ? 3.091   24.926  7.896   1.00 15.43 ? 109  ARG A O   1 
+ATOM   685  C  CB  . ARG A 1 87  ? 6.095   25.866  8.474   1.00 14.54 ? 109  ARG A CB  1 
+ATOM   686  C  CG  . ARG A 1 87  ? 7.551   25.748  8.152   1.00 13.70 ? 109  ARG A CG  1 
+ATOM   687  C  CD  . ARG A 1 87  ? 8.275   27.099  7.875   1.00 16.42 ? 109  ARG A CD  1 
+ATOM   688  N  NE  . ARG A 1 87  ? 8.306   27.957  9.022   1.00 17.18 ? 109  ARG A NE  1 
+ATOM   689  C  CZ  . ARG A 1 87  ? 8.517   29.273  8.971   1.00 15.47 ? 109  ARG A CZ  1 
+ATOM   690  N  NH1 . ARG A 1 87  ? 8.524   29.922  10.096  1.00 13.88 ? 109  ARG A NH1 1 
+ATOM   691  N  NH2 . ARG A 1 87  ? 8.657   29.950  7.842   1.00 16.48 ? 109  ARG A NH2 1 
+ATOM   692  N  N   . SER A 1 88  ? 3.620   24.491  10.016  1.00 12.84 ? 110  SER A N   1 
+ATOM   693  C  CA  . SER A 1 88  ? 2.280   24.544  10.516  1.00 13.12 ? 110  SER A CA  1 
+ATOM   694  C  C   . SER A 1 88  ? 2.002   25.909  11.206  1.00 13.97 ? 110  SER A C   1 
+ATOM   695  O  O   . SER A 1 88  ? 2.885   26.481  11.870  1.00 13.80 ? 110  SER A O   1 
+ATOM   696  C  CB  . SER A 1 88  ? 2.096   23.473  11.594  1.00 14.01 ? 110  SER A CB  1 
+ATOM   697  O  OG  . SER A 1 88  ? 2.262   22.182  10.972  1.00 15.61 ? 110  SER A OG  1 
+ATOM   698  N  N   . VAL A 1 89  ? 0.775   26.395  11.069  1.00 12.10 ? 111  VAL A N   1 
+ATOM   699  C  CA  . VAL A 1 89  ? 0.366   27.614  11.730  1.00 12.73 ? 111  VAL A CA  1 
+ATOM   700  C  C   . VAL A 1 89  ? -0.899  27.257  12.506  1.00 12.80 ? 111  VAL A C   1 
+ATOM   701  O  O   . VAL A 1 89  ? -1.972  26.945  11.944  1.00 14.61 ? 111  VAL A O   1 
+ATOM   702  C  CB  . VAL A 1 89  ? 0.039   28.724  10.716  1.00 13.90 ? 111  VAL A CB  1 
+ATOM   703  C  CG1 . VAL A 1 89  ? -0.468  29.998  11.445  1.00 14.22 ? 111  VAL A CG1 1 
+ATOM   704  C  CG2 . VAL A 1 89  ? 1.226   29.056  9.856   1.00 15.82 ? 111  VAL A CG2 1 
+ATOM   705  N  N   . LEU A 1 90  ? -0.787  27.271  13.839  1.00 11.92 ? 112  LEU A N   1 
+ATOM   706  C  CA  . LEU A 1 90  ? -1.940  26.948  14.679  1.00 11.45 ? 112  LEU A CA  1 
+ATOM   707  C  C   . LEU A 1 90  ? -2.563  28.256  15.190  1.00 11.94 ? 112  LEU A C   1 
+ATOM   708  O  O   . LEU A 1 90  ? -1.922  29.291  15.281  1.00 14.02 ? 112  LEU A O   1 
+ATOM   709  C  CB  . LEU A 1 90  ? -1.550  26.103  15.891  1.00 12.66 ? 112  LEU A CB  1 
+ATOM   710  C  CG  . LEU A 1 90  ? -0.631  24.924  15.638  1.00 13.09 ? 112  LEU A CG  1 
+ATOM   711  C  CD1 . LEU A 1 90  ? -0.382  24.119  16.929  1.00 13.24 ? 112  LEU A CD1 1 
+ATOM   712  C  CD2 . LEU A 1 90  ? -1.173  24.009  14.545  1.00 14.38 ? 112  LEU A CD2 1 
+ATOM   713  N  N   . ILE A 1 91  ? -3.820  28.157  15.605  1.00 12.23 ? 113  ILE A N   1 
+ATOM   714  C  CA  . ILE A 1 91  ? -4.462  29.205  16.375  1.00 13.15 ? 113  ILE A CA  1 
+ATOM   715  C  C   . ILE A 1 91  ? -4.421  28.842  17.860  1.00 12.52 ? 113  ILE A C   1 
+ATOM   716  O  O   . ILE A 1 91  ? -4.861  27.749  18.237  1.00 15.47 ? 113  ILE A O   1 
+ATOM   717  C  CB  . ILE A 1 91  ? -5.865  29.483  15.857  1.00 14.07 ? 113  ILE A CB  1 
+ATOM   718  C  CG1 . ILE A 1 91  ? -6.526  30.636  16.594  1.00 15.40 ? 113  ILE A CG1 1 
+ATOM   719  C  CG2 . ILE A 1 91  ? -6.753  28.273  15.957  1.00 15.12 ? 113  ILE A CG2 1 
+ATOM   720  C  CD1 . ILE A 1 91  ? -5.944  31.933  16.362  1.00 16.16 ? 113  ILE A CD1 1 
+ATOM   721  N  N   . ALA A 1 92  ? -3.903  29.753  18.682  1.00 12.13 ? 114  ALA A N   1 
+ATOM   722  C  CA  . ALA A 1 92  ? -3.782  29.499  20.127  1.00 11.78 ? 114  ALA A CA  1 
+ATOM   723  C  C   . ALA A 1 92  ? -4.984  30.104  20.802  1.00 13.96 ? 114  ALA A C   1 
+ATOM   724  O  O   . ALA A 1 92  ? -5.245  31.327  20.669  1.00 14.62 ? 114  ALA A O   1 
+ATOM   725  C  CB  . ALA A 1 92  ? -2.479  30.148  20.674  1.00 15.08 ? 114  ALA A CB  1 
+ATOM   726  N  N   . LEU A 1 93  ? -5.685  29.265  21.559  1.00 13.79 ? 115  LEU A N   1 
+ATOM   727  C  CA  . LEU A 1 93  ? -6.891  29.634  22.313  1.00 14.81 ? 115  LEU A CA  1 
+ATOM   728  C  C   . LEU A 1 93  ? -6.538  30.040  23.743  1.00 14.94 ? 115  LEU A C   1 
+ATOM   729  O  O   . LEU A 1 93  ? -5.907  29.279  24.484  1.00 14.73 ? 115  LEU A O   1 
+ATOM   730  C  CB  . LEU A 1 93  ? -7.803  28.400  22.349  1.00 16.78 ? 115  LEU A CB  1 
+ATOM   731  C  CG  . LEU A 1 93  ? -9.052  28.627  23.138  1.00 16.53 ? 115  LEU A CG  1 
+ATOM   732  C  CD1 . LEU A 1 93  ? -10.044 29.639  22.533  1.00 17.52 ? 115  LEU A CD1 1 
+ATOM   733  C  CD2 . LEU A 1 93  ? -9.707  27.284  23.362  1.00 19.25 ? 115  LEU A CD2 1 
+ATOM   734  N  N   . GLY A 1 94  ? -6.950  31.233  24.124  1.00 14.31 ? 116  GLY A N   1 
+ATOM   735  C  CA  . GLY A 1 94  ? -6.769  31.753  25.490  1.00 16.41 ? 116  GLY A CA  1 
+ATOM   736  C  C   . GLY A 1 94  ? -5.703  32.839  25.608  1.00 15.38 ? 116  GLY A C   1 
+ATOM   737  O  O   . GLY A 1 94  ? -5.838  33.938  25.082  1.00 14.92 ? 116  GLY A O   1 
+ATOM   738  N  N   . GLY A 1 95  ? -4.593  32.496  26.286  1.00 13.68 ? 117  GLY A N   1 
+ATOM   739  C  CA  . GLY A 1 95  ? -3.534  33.426  26.605  1.00 15.97 ? 117  GLY A CA  1 
+ATOM   740  C  C   . GLY A 1 95  ? -3.782  34.042  27.981  1.00 16.45 ? 117  GLY A C   1 
+ATOM   741  O  O   . GLY A 1 95  ? -4.838  33.887  28.576  1.00 16.73 ? 117  GLY A O   1 
+ATOM   742  N  N   . ALA A 1 96  ? -2.802  34.805  28.440  1.00 16.78 ? 118  ALA A N   1 
+ATOM   743  C  CA  . ALA A 1 96  ? -2.948  35.518  29.706  1.00 17.82 ? 118  ALA A CA  1 
+ATOM   744  C  C   . ALA A 1 96  ? -4.109  36.488  29.672  1.00 20.48 ? 118  ALA A C   1 
+ATOM   745  O  O   . ALA A 1 96  ? -4.245  37.270  28.760  1.00 20.05 ? 118  ALA A O   1 
+ATOM   746  C  CB  . ALA A 1 96  ? -1.695  36.262  30.031  1.00 19.63 ? 118  ALA A CB  1 
+ATOM   747  N  N   . ASP A 1 97  ? -4.873  36.511  30.755  1.00 22.16 ? 119  ASP A N   1 
+ATOM   748  C  CA  . ASP A 1 97  ? -5.946  37.490  30.946  1.00 24.03 ? 119  ASP A CA  1 
+ATOM   749  C  C   . ASP A 1 97  ? -7.079  37.389  29.970  1.00 23.74 ? 119  ASP A C   1 
+ATOM   750  O  O   . ASP A 1 97  ? -7.948  38.211  29.928  1.00 31.41 ? 119  ASP A O   1 
+ATOM   751  C  CB  . ASP A 1 97  ? -5.368  38.880  31.225  1.00 30.13 ? 119  ASP A CB  1 
+ATOM   752  C  CG  . ASP A 1 97  ? -4.556  38.848  32.528  1.00 38.16 ? 119  ASP A CG  1 
+ATOM   753  O  OD1 . ASP A 1 97  ? -5.163  38.639  33.622  1.00 41.83 ? 119  ASP A OD1 1 
+ATOM   754  O  OD2 . ASP A 1 97  ? -3.302  38.896  32.473  1.00 40.61 ? 119  ASP A OD2 1 
+ATOM   755  N  N   . ALA A 1 98  ? -7.194  36.232  29.355  1.00 23.68 ? 120  ALA A N   1 
+ATOM   756  C  CA  . ALA A 1 98  ? -8.327  35.953  28.533  1.00 23.61 ? 120  ALA A CA  1 
+ATOM   757  C  C   . ALA A 1 98  ? -9.344  35.098  29.237  1.00 27.22 ? 120  ALA A C   1 
+ATOM   758  O  O   . ALA A 1 98  ? -9.146  33.883  29.361  1.00 30.93 ? 120  ALA A O   1 
+ATOM   759  C  CB  . ALA A 1 98  ? -7.885  35.206  27.278  1.00 26.56 ? 120  ALA A CB  1 
+ATOM   760  N  N   . HIS A 1 99  ? -10.495 35.644  29.523  1.00 25.70 ? 121  HIS A N   1 
+ATOM   761  C  CA  . HIS A 1 99  ? -11.540 34.882  30.211  1.00 28.60 ? 121  HIS A CA  1 
+ATOM   762  C  C   . HIS A 1 99  ? -12.472 34.284  29.160  1.00 28.20 ? 121  HIS A C   1 
+ATOM   763  O  O   . HIS A 1 99  ? -12.943 34.955  28.293  1.00 28.50 ? 121  HIS A O   1 
+ATOM   764  C  CB  . HIS A 1 99  ? -12.302 35.764  31.203  1.00 35.63 ? 121  HIS A CB  1 
+ATOM   765  C  CG  . HIS A 1 99  ? -11.405 36.516  32.147  1.00 42.00 ? 121  HIS A CG  1 
+ATOM   766  N  ND1 . HIS A 1 99  ? -11.185 36.120  33.450  0.50 44.17 ? 121  HIS A ND1 1 
+ATOM   767  C  CD2 . HIS A 1 99  ? -10.694 37.659  31.977  0.50 43.70 ? 121  HIS A CD2 1 
+ATOM   768  C  CE1 . HIS A 1 99  ? -10.369 36.981  34.039  0.50 44.35 ? 121  HIS A CE1 1 
+ATOM   769  N  NE2 . HIS A 1 99  ? -10.048 37.919  33.161  0.50 43.78 ? 121  HIS A NE2 1 
+ATOM   770  N  N   . ILE A 1 100 ? -12.712 32.998  29.286  1.00 27.36 ? 122  ILE A N   1 
+ATOM   771  C  CA  . ILE A 1 100 ? -13.552 32.257  28.376  1.00 24.21 ? 122  ILE A CA  1 
+ATOM   772  C  C   . ILE A 1 100 ? -14.419 31.447  29.342  1.00 26.09 ? 122  ILE A C   1 
+ATOM   773  O  O   . ILE A 1 100 ? -13.900 30.852  30.281  1.00 24.84 ? 122  ILE A O   1 
+ATOM   774  C  CB  . ILE A 1 100 ? -12.699 31.313  27.553  1.00 22.85 ? 122  ILE A CB  1 
+ATOM   775  C  CG1 . ILE A 1 100 ? -11.824 32.116  26.563  1.00 22.90 ? 122  ILE A CG1 1 
+ATOM   776  C  CG2 . ILE A 1 100 ? -13.593 30.262  26.859  1.00 23.30 ? 122  ILE A CG2 1 
+ATOM   777  C  CD1 . ILE A 1 100 ? -10.792 31.344  25.774  1.00 26.04 ? 122  ILE A CD1 1 
+ATOM   778  N  N   . GLU A 1 101 ? -15.720 31.431  29.137  1.00 25.12 ? 123  GLU A N   1 
+ATOM   779  C  CA  . GLU A 1 101 ? -16.628 30.800  30.065  1.00 27.41 ? 123  GLU A CA  1 
+ATOM   780  C  C   . GLU A 1 101 ? -17.805 30.152  29.325  1.00 26.01 ? 123  GLU A C   1 
+ATOM   781  O  O   . GLU A 1 101 ? -18.832 30.742  29.082  1.00 28.56 ? 123  GLU A O   1 
+ATOM   782  C  CB  . GLU A 1 101 ? -17.076 31.774  31.134  1.00 32.14 ? 123  GLU A CB  1 
+ATOM   783  C  CG  . GLU A 1 101 ? -17.717 31.050  32.257  1.00 39.00 ? 123  GLU A CG  1 
+ATOM   784  C  CD  . GLU A 1 101 ? -17.930 31.891  33.507  1.00 45.56 ? 123  GLU A CD  1 
+ATOM   785  O  OE1 . GLU A 1 101 ? -16.959 32.573  33.993  1.00 47.17 ? 123  GLU A OE1 1 
+ATOM   786  O  OE2 . GLU A 1 101 ? -19.091 31.818  34.033  1.00 48.18 ? 123  GLU A OE2 1 
+ATOM   787  N  N   . LEU A 1 102 ? -17.668 28.896  29.012  1.00 26.07 ? 124  LEU A N   1 
+ATOM   788  C  CA  . LEU A 1 102 ? -18.651 28.258  28.153  1.00 26.22 ? 124  LEU A CA  1 
+ATOM   789  C  C   . LEU A 1 102 ? -19.569 27.367  28.958  1.00 29.20 ? 124  LEU A C   1 
+ATOM   790  O  O   . LEU A 1 102 ? -19.188 26.896  30.012  1.00 29.72 ? 124  LEU A O   1 
+ATOM   791  C  CB  . LEU A 1 102 ? -17.927 27.444  27.076  1.00 25.58 ? 124  LEU A CB  1 
+ATOM   792  C  CG  . LEU A 1 102 ? -16.980 28.283  26.219  1.00 25.20 ? 124  LEU A CG  1 
+ATOM   793  C  CD1 . LEU A 1 102 ? -15.918 27.423  25.635  1.00 26.06 ? 124  LEU A CD1 1 
+ATOM   794  C  CD2 . LEU A 1 102 ? -17.758 28.954  25.107  1.00 30.26 ? 124  LEU A CD2 1 
+ATOM   795  N  N   . THR A 1 103 ? -20.791 27.178  28.462  1.00 31.62 ? 125  THR A N   1 
+ATOM   796  C  CA  . THR A 1 103 ? -21.803 26.329  29.062  1.00 34.36 ? 125  THR A CA  1 
+ATOM   797  C  C   . THR A 1 103 ? -22.048 25.060  28.228  1.00 35.24 ? 125  THR A C   1 
+ATOM   798  O  O   . THR A 1 103 ? -21.969 25.095  26.983  1.00 34.44 ? 125  THR A O   1 
+ATOM   799  C  CB  . THR A 1 103 ? -23.123 27.085  29.100  1.00 37.75 ? 125  THR A CB  1 
+ATOM   800  O  OG1 . THR A 1 103 ? -22.973 28.252  29.912  1.00 40.66 ? 125  THR A OG1 1 
+ATOM   801  C  CG2 . THR A 1 103 ? -24.222 26.218  29.750  1.00 39.38 ? 125  THR A CG2 1 
+ATOM   802  N  N   . ARG A 1 104 ? -22.314 23.958  28.915  1.00 36.00 ? 126  ARG A N   1 
+ATOM   803  C  CA  . ARG A 1 104 ? -22.667 22.683  28.318  1.00 37.19 ? 126  ARG A CA  1 
+ATOM   804  C  C   . ARG A 1 104 ? -23.727 22.974  27.258  1.00 38.04 ? 126  ARG A C   1 
+ATOM   805  O  O   . ARG A 1 104 ? -24.727 23.661  27.491  1.00 39.62 ? 126  ARG A O   1 
+ATOM   806  C  CB  . ARG A 1 104 ? -23.095 21.704  29.415  1.00 39.08 ? 126  ARG A CB  1 
+ATOM   807  C  CG  . ARG A 1 104 ? -23.474 20.286  29.008  1.00 44.36 ? 126  ARG A CG  1 
+ATOM   808  C  CD  . ARG A 1 104 ? -23.872 19.390  30.231  1.00 47.71 ? 126  ARG A CD  1 
+ATOM   809  N  NE  . ARG A 1 104 ? -22.714 19.064  31.091  1.00 47.05 ? 126  ARG A NE  1 
+ATOM   810  C  CZ  . ARG A 1 104 ? -21.851 18.051  30.859  1.00 48.36 ? 126  ARG A CZ  1 
+ATOM   811  N  NH1 . ARG A 1 104 ? -22.059 17.213  29.853  1.00 50.56 ? 126  ARG A NH1 1 
+ATOM   812  N  NH2 . ARG A 1 104 ? -20.802 17.825  31.661  1.00 45.68 ? 126  ARG A NH2 1 
+ATOM   813  N  N   . GLY A 1 105 ? -23.429 22.532  26.050  1.00 38.50 ? 127  GLY A N   1 
+ATOM   814  C  CA  . GLY A 1 105 ? -24.279 22.811  24.896  1.00 36.86 ? 127  GLY A CA  1 
+ATOM   815  C  C   . GLY A 1 105 ? -23.582 23.737  23.903  1.00 34.40 ? 127  GLY A C   1 
+ATOM   816  O  O   . GLY A 1 105 ? -23.932 23.810  22.731  1.00 36.96 ? 127  GLY A O   1 
+ATOM   817  N  N   . ASP A 1 106 ? -22.574 24.463  24.368  1.00 32.82 ? 128  ASP A N   1 
+ATOM   818  C  CA  . ASP A 1 106 ? -21.831 25.391  23.500  1.00 29.54 ? 128  ASP A CA  1 
+ATOM   819  C  C   . ASP A 1 106 ? -20.824 24.715  22.572  1.00 27.73 ? 128  ASP A C   1 
+ATOM   820  O  O   . ASP A 1 106 ? -20.201 25.368  21.709  1.00 28.24 ? 128  ASP A O   1 
+ATOM   821  C  CB  . ASP A 1 106 ? -21.053 26.384  24.363  1.00 29.84 ? 128  ASP A CB  1 
+ATOM   822  C  CG  . ASP A 1 106 ? -21.907 27.459  24.940  1.00 31.10 ? 128  ASP A CG  1 
+ATOM   823  O  OD1 . ASP A 1 106 ? -23.090 27.579  24.508  1.00 33.29 ? 128  ASP A OD1 1 
+ATOM   824  O  OD2 . ASP A 1 106 ? -21.374 28.208  25.813  1.00 30.43 ? 128  ASP A OD2 1 
+ATOM   825  N  N   . GLU A 1 107 ? -20.604 23.432  22.790  1.00 27.72 ? 129  GLU A N   1 
+ATOM   826  C  CA  . GLU A 1 107 ? -19.611 22.729  22.002  1.00 27.16 ? 129  GLU A CA  1 
+ATOM   827  C  C   . GLU A 1 107 ? -19.848 22.772  20.482  1.00 26.51 ? 129  GLU A C   1 
+ATOM   828  O  O   . GLU A 1 107 ? -18.882 22.918  19.729  1.00 26.34 ? 129  GLU A O   1 
+ATOM   829  C  CB  . GLU A 1 107 ? -19.391 21.312  22.504  1.00 30.34 ? 129  GLU A CB  1 
+ATOM   830  C  CG  . GLU A 1 107 ? -20.594 20.435  22.517  1.00 30.28 ? 129  GLU A CG  1 
+ATOM   831  C  CD  . GLU A 1 107 ? -21.408 20.494  23.801  1.00 32.46 ? 129  GLU A CD  1 
+ATOM   832  O  OE1 . GLU A 1 107 ? -21.241 21.461  24.590  1.00 32.52 ? 129  GLU A OE1 1 
+ATOM   833  O  OE2 . GLU A 1 107 ? -22.206 19.553  24.065  1.00 36.34 ? 129  GLU A OE2 1 
+ATOM   834  N  N   . ASP A 1 108 ? -21.081 22.657  20.052  1.00 28.47 ? 130  ASP A N   1 
+ATOM   835  C  CA  . ASP A 1 108 ? -21.355 22.661  18.610  1.00 29.71 ? 130  ASP A CA  1 
+ATOM   836  C  C   . ASP A 1 108 ? -20.937 24.023  18.022  1.00 27.96 ? 130  ASP A C   1 
+ATOM   837  O  O   . ASP A 1 108 ? -20.287 24.070  16.969  1.00 26.93 ? 130  ASP A O   1 
+ATOM   838  C  CB  . ASP A 1 108 ? -22.842 22.423  18.310  1.00 32.50 ? 130  ASP A CB  1 
+ATOM   839  C  CG  . ASP A 1 108 ? -23.281 20.956  18.450  1.00 36.88 ? 130  ASP A CG  1 
+ATOM   840  O  OD1 . ASP A 1 108 ? -22.455 20.020  18.465  1.00 38.42 ? 130  ASP A OD1 1 
+ATOM   841  O  OD2 . ASP A 1 108 ? -24.526 20.744  18.478  1.00 38.80 ? 130  ASP A OD2 1 
+ATOM   842  N  N   . ALA A 1 109 ? -21.330 25.119  18.680  1.00 28.59 ? 131  ALA A N   1 
+ATOM   843  C  CA  . ALA A 1 109 ? -21.008 26.452  18.159  1.00 27.04 ? 131  ALA A CA  1 
+ATOM   844  C  C   . ALA A 1 109 ? -19.495 26.713  18.200  1.00 25.08 ? 131  ALA A C   1 
+ATOM   845  O  O   . ALA A 1 109 ? -18.917 27.346  17.269  1.00 25.48 ? 131  ALA A O   1 
+ATOM   846  C  CB  . ALA A 1 109 ? -21.781 27.527  18.901  1.00 29.58 ? 131  ALA A CB  1 
+ATOM   847  N  N   . LEU A 1 110 ? -18.848 26.198  19.246  1.00 24.88 ? 132  LEU A N   1 
+ATOM   848  C  CA  . LEU A 1 110 ? -17.397 26.362  19.324  1.00 22.60 ? 132  LEU A CA  1 
+ATOM   849  C  C   . LEU A 1 110 ? -16.699 25.590  18.205  1.00 21.95 ? 132  LEU A C   1 
+ATOM   850  O  O   . LEU A 1 110 ? -15.804 26.103  17.541  1.00 21.16 ? 132  LEU A O   1 
+ATOM   851  C  CB  . LEU A 1 110 ? -16.869 25.887  20.686  1.00 22.34 ? 132  LEU A CB  1 
+ATOM   852  C  CG  . LEU A 1 110 ? -15.358 25.863  20.851  1.00 20.91 ? 132  LEU A CG  1 
+ATOM   853  C  CD1 . LEU A 1 110 ? -14.804 27.232  20.610  1.00 20.91 ? 132  LEU A CD1 1 
+ATOM   854  C  CD2 . LEU A 1 110 ? -14.994 25.429  22.242  1.00 21.14 ? 132  LEU A CD2 1 
+ATOM   855  N  N   . ALA A 1 111 ? -17.106 24.351  17.986  1.00 22.98 ? 133  ALA A N   1 
+ATOM   856  C  CA  . ALA A 1 111 ? -16.538 23.595  16.855  1.00 23.47 ? 133  ALA A CA  1 
+ATOM   857  C  C   . ALA A 1 111 ? -16.759 24.296  15.513  1.00 22.49 ? 133  ALA A C   1 
+ATOM   858  O  O   . ALA A 1 111 ? -15.842 24.391  14.707  1.00 23.82 ? 133  ALA A O   1 
+ATOM   859  C  CB  . ALA A 1 111 ? -17.107 22.178  16.800  1.00 22.72 ? 133  ALA A CB  1 
+ATOM   860  N  N   . ALA A 1 112 ? -17.968 24.783  15.314  1.00 23.43 ? 134  ALA A N   1 
+ATOM   861  C  CA  . ALA A 1 112 ? -18.315 25.463  14.072  1.00 23.47 ? 134  ALA A CA  1 
+ATOM   862  C  C   . ALA A 1 112 ? -17.400 26.679  13.870  1.00 21.43 ? 134  ALA A C   1 
+ATOM   863  O  O   . ALA A 1 112 ? -16.929 26.939  12.750  1.00 23.16 ? 134  ALA A O   1 
+ATOM   864  C  CB  . ALA A 1 112 ? -19.774 25.894  14.118  1.00 25.19 ? 134  ALA A CB  1 
+ATOM   865  N  N   . GLU A 1 113 ? -17.140 27.424  14.956  1.00 23.62 ? 135  GLU A N   1 
+ATOM   866  C  CA  . GLU A 1 113 ? -16.288 28.606  14.822  1.00 22.33 ? 135  GLU A CA  1 
+ATOM   867  C  C   . GLU A 1 113 ? -14.833 28.199  14.547  1.00 19.63 ? 135  GLU A C   1 
+ATOM   868  O  O   . GLU A 1 113 ? -14.152 28.835  13.759  1.00 21.22 ? 135  GLU A O   1 
+ATOM   869  C  CB  . GLU A 1 113 ? -16.445 29.540  16.034  1.00 22.38 ? 135  GLU A CB  1 
+ATOM   870  C  CG  . GLU A 1 113 ? -15.544 30.787  15.985  1.00 24.18 ? 135  GLU A CG  1 
+ATOM   871  C  CD  . GLU A 1 113 ? -15.869 31.797  14.892  1.00 25.30 ? 135  GLU A CD  1 
+ATOM   872  O  OE1 . GLU A 1 113 ? -16.831 31.601  14.123  1.00 27.77 ? 135  GLU A OE1 1 
+ATOM   873  O  OE2 . GLU A 1 113 ? -15.126 32.799  14.763  1.00 26.98 ? 135  GLU A OE2 1 
+ATOM   874  N  N   . ILE A 1 114 ? -14.329 27.157  15.220  1.00 19.19 ? 136  ILE A N   1 
+ATOM   875  C  CA  . ILE A 1 114 ? -12.950 26.690  14.947  1.00 17.50 ? 136  ILE A CA  1 
+ATOM   876  C  C   . ILE A 1 114 ? -12.835 26.302  13.466  1.00 18.38 ? 136  ILE A C   1 
+ATOM   877  O  O   . ILE A 1 114 ? -11.854 26.639  12.803  1.00 19.50 ? 136  ILE A O   1 
+ATOM   878  C  CB  . ILE A 1 114 ? -12.576 25.515  15.831  1.00 17.12 ? 136  ILE A CB  1 
+ATOM   879  C  CG1 . ILE A 1 114 ? -12.451 26.002  17.323  1.00 16.62 ? 136  ILE A CG1 1 
+ATOM   880  C  CG2 . ILE A 1 114 ? -11.282 24.861  15.373  1.00 17.62 ? 136  ILE A CG2 1 
+ATOM   881  C  CD1 . ILE A 1 114 ? -12.464 24.942  18.297  1.00 18.67 ? 136  ILE A CD1 1 
+ATOM   882  N  N   . ILE A 1 115 ? -13.808 25.562  12.966  1.00 21.48 ? 137  ILE A N   1 
+ATOM   883  C  CA  . ILE A 1 115 ? -13.809 25.164  11.545  1.00 21.26 ? 137  ILE A CA  1 
+ATOM   884  C  C   . ILE A 1 115 ? -13.862 26.373  10.626  1.00 19.93 ? 137  ILE A C   1 
+ATOM   885  O  O   . ILE A 1 115 ? -13.162 26.428  9.616   1.00 21.22 ? 137  ILE A O   1 
+ATOM   886  C  CB  . ILE A 1 115 ? -14.940 24.175  11.275  1.00 23.53 ? 137  ILE A CB  1 
+ATOM   887  C  CG1 . ILE A 1 115 ? -14.567 22.848  11.937  1.00 22.29 ? 137  ILE A CG1 1 
+ATOM   888  C  CG2 . ILE A 1 115 ? -15.182 23.971  9.787   1.00 24.61 ? 137  ILE A CG2 1 
+ATOM   889  C  CD1 . ILE A 1 115 ? -15.785 21.919  12.195  1.00 21.93 ? 137  ILE A CD1 1 
+ATOM   890  N  N   . ARG A 1 116 ? -14.712 27.333  10.951  1.00 22.48 ? 138  ARG A N   1 
+ATOM   891  C  CA  . ARG A 1 116 ? -14.843 28.511  10.112  1.00 22.70 ? 138  ARG A CA  1 
+ATOM   892  C  C   . ARG A 1 116 ? -13.490 29.240  9.995   1.00 20.75 ? 138  ARG A C   1 
+ATOM   893  O  O   . ARG A 1 116 ? -13.012 29.576  8.884   1.00 20.25 ? 138  ARG A O   1 
+ATOM   894  C  CB  . ARG A 1 116 ? -15.895 29.452  10.671  1.00 22.34 ? 138  ARG A CB  1 
+ATOM   895  C  CG  . ARG A 1 116 ? -16.162 30.586  9.747   1.00 23.85 ? 138  ARG A CG  1 
+ATOM   896  C  CD  . ARG A 1 116 ? -17.060 31.618  10.387  1.00 25.00 ? 138  ARG A CD  1 
+ATOM   897  N  NE  . ARG A 1 116 ? -16.377 32.373  11.433  1.00 25.96 ? 138  ARG A NE  1 
+ATOM   898  C  CZ  . ARG A 1 116 ? -15.639 33.450  11.209  1.00 28.20 ? 138  ARG A CZ  1 
+ATOM   899  N  NH1 . ARG A 1 116 ? -15.063 34.068  12.235  1.00 31.75 ? 138  ARG A NH1 1 
+ATOM   900  N  NH2 . ARG A 1 116 ? -15.509 33.940  9.964   1.00 29.06 ? 138  ARG A NH2 1 
+ATOM   901  N  N   . LEU A 1 117 ? -12.865 29.473  11.164  1.00 18.97 ? 139  LEU A N   1 
+ATOM   902  C  CA  . LEU A 1 117 ? -11.585 30.170  11.206  1.00 17.12 ? 139  LEU A CA  1 
+ATOM   903  C  C   . LEU A 1 117 ? -10.516 29.354  10.490  1.00 18.68 ? 139  LEU A C   1 
+ATOM   904  O  O   . LEU A 1 117 ? -9.695  29.923  9.785   1.00 18.10 ? 139  LEU A O   1 
+ATOM   905  C  CB  . LEU A 1 117 ? -11.109 30.412  12.627  1.00 17.88 ? 139  LEU A CB  1 
+ATOM   906  C  CG  . LEU A 1 117 ? -11.970 31.377  13.421  1.00 20.47 ? 139  LEU A CG  1 
+ATOM   907  C  CD1 . LEU A 1 117 ? -11.651 31.287  14.920  1.00 20.83 ? 139  LEU A CD1 1 
+ATOM   908  C  CD2 . LEU A 1 117 ? -11.774 32.769  12.909  1.00 24.66 ? 139  LEU A CD2 1 
+ATOM   909  N  N   . THR A 1 118 ? -10.511 28.043  10.717  1.00 18.96 ? 140  THR A N   1 
+ATOM   910  C  CA  . THR A 1 118 ? -9.537  27.165  10.110  1.00 19.29 ? 140  THR A CA  1 
+ATOM   911  C  C   . THR A 1 118 ? -9.657  27.205  8.583   1.00 17.43 ? 140  THR A C   1 
+ATOM   912  O  O   . THR A 1 118 ? -8.636  27.312  7.839   1.00 19.27 ? 140  THR A O   1 
+ATOM   913  C  CB  . THR A 1 118 ? -9.703  25.721  10.659  1.00 20.01 ? 140  THR A CB  1 
+ATOM   914  O  OG1 . THR A 1 118 ? -9.314  25.718  12.034  1.00 20.19 ? 140  THR A OG1 1 
+ATOM   915  C  CG2 . THR A 1 118 ? -8.807  24.727  9.972   1.00 20.24 ? 140  THR A CG2 1 
+ATOM   916  N  N   . ASP A 1 119 ? -10.885 27.152  8.096   1.00 18.35 ? 141  ASP A N   1 
+ATOM   917  C  CA  . ASP A 1 119 ? -11.074 27.156  6.616   1.00 19.49 ? 141  ASP A CA  1 
+ATOM   918  C  C   . ASP A 1 119 ? -10.747 28.527  5.992   1.00 21.02 ? 141  ASP A C   1 
+ATOM   919  O  O   . ASP A 1 119 ? -10.232 28.608  4.851   1.00 22.68 ? 141  ASP A O   1 
+ATOM   920  C  CB  . ASP A 1 119 ? -12.486 26.703  6.282   1.00 20.56 ? 141  ASP A CB  1 
+ATOM   921  C  CG  . ASP A 1 119 ? -12.712 25.241  6.607   1.00 23.89 ? 141  ASP A CG  1 
+ATOM   922  O  OD1 . ASP A 1 119 ? -11.750 24.488  6.909   1.00 24.15 ? 141  ASP A OD1 1 
+ATOM   923  O  OD2 . ASP A 1 119 ? -13.853 24.796  6.527   1.00 26.69 ? 141  ASP A OD2 1 
+ATOM   924  N  N   . LEU A 1 120 ? -11.036 29.595  6.722   1.00 21.93 ? 142  LEU A N   1 
+ATOM   925  C  CA  . LEU A 1 120 ? -10.807 30.925  6.183   1.00 19.92 ? 142  LEU A CA  1 
+ATOM   926  C  C   . LEU A 1 120 ? -9.321  31.263  6.136   1.00 18.80 ? 142  LEU A C   1 
+ATOM   927  O  O   . LEU A 1 120 ? -8.780  31.695  5.144   1.00 19.83 ? 142  LEU A O   1 
+ATOM   928  C  CB  . LEU A 1 120 ? -11.528 31.933  7.038   1.00 19.22 ? 142  LEU A CB  1 
+ATOM   929  C  CG  . LEU A 1 120 ? -11.265 33.394  6.768   1.00 22.91 ? 142  LEU A CG  1 
+ATOM   930  C  CD1 . LEU A 1 120 ? -11.570 33.783  5.354   1.00 25.64 ? 142  LEU A CD1 1 
+ATOM   931  C  CD2 . LEU A 1 120 ? -12.138 34.170  7.794   1.00 26.22 ? 142  LEU A CD2 1 
+ATOM   932  N  N   . TYR A 1 121 ? -8.604  31.005  7.256   1.00 17.99 ? 143  TYR A N   1 
+ATOM   933  C  CA  . TYR A 1 121 ? -7.218  31.452  7.362   1.00 18.59 ? 143  TYR A CA  1 
+ATOM   934  C  C   . TYR A 1 121 ? -6.176  30.444  6.920   1.00 17.00 ? 143  TYR A C   1 
+ATOM   935  O  O   . TYR A 1 121 ? -5.039  30.818  6.663   1.00 16.85 ? 143  TYR A O   1 
+ATOM   936  C  CB  . TYR A 1 121 ? -6.866  31.936  8.804   1.00 16.14 ? 143  TYR A CB  1 
+ATOM   937  C  CG  . TYR A 1 121 ? -7.669  33.188  9.142   1.00 18.62 ? 143  TYR A CG  1 
+ATOM   938  C  CD1 . TYR A 1 121 ? -7.404  34.368  8.487   1.00 19.85 ? 143  TYR A CD1 1 
+ATOM   939  C  CD2 . TYR A 1 121 ? -8.692  33.187  10.071  1.00 17.88 ? 143  TYR A CD2 1 
+ATOM   940  C  CE1 . TYR A 1 121 ? -8.115  35.489  8.736   1.00 20.48 ? 143  TYR A CE1 1 
+ATOM   941  C  CE2 . TYR A 1 121 ? -9.412  34.339  10.348  1.00 20.34 ? 143  TYR A CE2 1 
+ATOM   942  C  CZ  . TYR A 1 121 ? -9.109  35.478  9.681   1.00 19.80 ? 143  TYR A CZ  1 
+ATOM   943  O  OH  . TYR A 1 121 ? -9.860  36.594  9.926   1.00 23.70 ? 143  TYR A OH  1 
+ATOM   944  N  N   . GLY A 1 122 ? -6.547  29.173  6.885   1.00 16.66 ? 144  GLY A N   1 
+ATOM   945  C  CA  . GLY A 1 122 ? -5.636  28.092  6.555   1.00 15.94 ? 144  GLY A CA  1 
+ATOM   946  C  C   . GLY A 1 122 ? -4.865  27.588  7.764   1.00 13.78 ? 144  GLY A C   1 
+ATOM   947  O  O   . GLY A 1 122 ? -3.867  26.909  7.601   1.00 16.65 ? 144  GLY A O   1 
+ATOM   948  N  N   . PHE A 1 123 ? -5.411  27.791  8.966   1.00 17.02 ? 145  PHE A N   1 
+ATOM   949  C  CA  . PHE A 1 123 ? -4.782  27.183  10.147  1.00 15.66 ? 145  PHE A CA  1 
+ATOM   950  C  C   . PHE A 1 123 ? -4.715  25.658  10.061  1.00 15.52 ? 145  PHE A C   1 
+ATOM   951  O  O   . PHE A 1 123 ? -5.535  24.997  9.386   1.00 17.19 ? 145  PHE A O   1 
+ATOM   952  C  CB  . PHE A 1 123 ? -5.552  27.556  11.463  1.00 14.81 ? 145  PHE A CB  1 
+ATOM   953  C  CG  . PHE A 1 123 ? -5.704  29.012  11.710  1.00 13.92 ? 145  PHE A CG  1 
+ATOM   954  C  CD1 . PHE A 1 123 ? -4.659  29.900  11.494  1.00 15.56 ? 145  PHE A CD1 1 
+ATOM   955  C  CD2 . PHE A 1 123 ? -6.900  29.516  12.222  1.00 14.92 ? 145  PHE A CD2 1 
+ATOM   956  C  CE1 . PHE A 1 123 ? -4.795  31.237  11.815  1.00 17.00 ? 145  PHE A CE1 1 
+ATOM   957  C  CE2 . PHE A 1 123 ? -7.017  30.879  12.497  1.00 17.09 ? 145  PHE A CE2 1 
+ATOM   958  C  CZ  . PHE A 1 123 ? -5.994  31.713  12.289  1.00 17.34 ? 145  PHE A CZ  1 
+ATOM   959  N  N   . ASP A 1 124 ? -3.721  25.107  10.748  1.00 13.17 ? 146  ASP A N   1 
+ATOM   960  C  CA  . ASP A 1 124 ? -3.477  23.698  10.722  1.00 12.97 ? 146  ASP A CA  1 
+ATOM   961  C  C   . ASP A 1 124 ? -3.912  22.971  12.011  1.00 13.02 ? 146  ASP A C   1 
+ATOM   962  O  O   . ASP A 1 124 ? -3.693  21.758  12.115  1.00 15.34 ? 146  ASP A O   1 
+ATOM   963  C  CB  . ASP A 1 124 ? -2.009  23.476  10.460  1.00 13.40 ? 146  ASP A CB  1 
+ATOM   964  C  CG  . ASP A 1 124 ? -1.589  24.141  9.151   1.00 13.46 ? 146  ASP A CG  1 
+ATOM   965  O  OD1 . ASP A 1 124 ? -2.194  23.752  8.101   1.00 16.83 ? 146  ASP A OD1 1 
+ATOM   966  O  OD2 . ASP A 1 124 ? -0.751  25.082  9.157   1.00 15.12 ? 146  ASP A OD2 1 
+ATOM   967  N  N   . GLY A 1 125 ? -4.455  23.690  12.980  1.00 14.08 ? 147  GLY A N   1 
+ATOM   968  C  CA  . GLY A 1 125 ? -4.815  23.143  14.275  1.00 14.84 ? 147  GLY A CA  1 
+ATOM   969  C  C   . GLY A 1 125 ? -4.952  24.241  15.278  1.00 14.96 ? 147  GLY A C   1 
+ATOM   970  O  O   . GLY A 1 125 ? -4.965  25.418  14.952  1.00 14.46 ? 147  GLY A O   1 
+ATOM   971  N  N   . LEU A 1 126 ? -5.069  23.814  16.543  1.00 13.78 ? 148  LEU A N   1 
+ATOM   972  C  CA  . LEU A 1 126 ? -5.360  24.687  17.650  1.00 12.45 ? 148  LEU A CA  1 
+ATOM   973  C  C   . LEU A 1 126 ? -4.525  24.286  18.858  1.00 12.91 ? 148  LEU A C   1 
+ATOM   974  O  O   . LEU A 1 126 ? -4.408  23.096  19.146  1.00 15.02 ? 148  LEU A O   1 
+ATOM   975  C  CB  . LEU A 1 126 ? -6.863  24.671  17.959  1.00 14.57 ? 148  LEU A CB  1 
+ATOM   976  C  CG  . LEU A 1 126 ? -7.337  25.572  19.131  1.00 14.21 ? 148  LEU A CG  1 
+ATOM   977  C  CD1 . LEU A 1 126 ? -8.777  26.038  18.876  1.00 15.18 ? 148  LEU A CD1 1 
+ATOM   978  C  CD2 . LEU A 1 126 ? -7.304  24.821  20.484  1.00 14.63 ? 148  LEU A CD2 1 
+ATOM   979  N  N   . ASP A 1 127 ? -4.010  25.314  19.546  1.00 14.12 ? 149  ASP A N   1 
+ATOM   980  C  CA  . ASP A 1 127 ? -3.261  25.151  20.806  1.00 12.91 ? 149  ASP A CA  1 
+ATOM   981  C  C   . ASP A 1 127 ? -4.158  25.610  21.958  1.00 14.15 ? 149  ASP A C   1 
+ATOM   982  O  O   . ASP A 1 127 ? -4.630  26.751  21.942  1.00 14.23 ? 149  ASP A O   1 
+ATOM   983  C  CB  . ASP A 1 127 ? -2.010  26.041  20.767  1.00 12.04 ? 149  ASP A CB  1 
+ATOM   984  C  CG  . ASP A 1 127 ? -1.174  25.924  22.033  1.00 11.42 ? 149  ASP A CG  1 
+ATOM   985  O  OD1 . ASP A 1 127 ? -0.765  24.772  22.415  1.00 13.76 ? 149  ASP A OD1 1 
+ATOM   986  O  OD2 . ASP A 1 127 ? -1.002  26.981  22.651  1.00 13.41 ? 149  ASP A OD2 1 
+ATOM   987  N  N   . ILE A 1 128 ? -4.348  24.743  22.960  1.00 13.02 ? 150  ILE A N   1 
+ATOM   988  C  CA  . ILE A 1 128 ? -5.132  25.118  24.151  1.00 11.99 ? 150  ILE A CA  1 
+ATOM   989  C  C   . ILE A 1 128 ? -4.185  25.804  25.144  1.00 12.11 ? 150  ILE A C   1 
+ATOM   990  O  O   . ILE A 1 128 ? -3.347  25.181  25.778  1.00 13.53 ? 150  ILE A O   1 
+ATOM   991  C  CB  . ILE A 1 128 ? -5.781  23.900  24.821  1.00 14.08 ? 150  ILE A CB  1 
+ATOM   992  C  CG1 . ILE A 1 128 ? -6.687  23.140  23.847  1.00 14.70 ? 150  ILE A CG1 1 
+ATOM   993  C  CG2 . ILE A 1 128 ? -6.575  24.353  26.009  1.00 14.96 ? 150  ILE A CG2 1 
+ATOM   994  C  CD1 . ILE A 1 128 ? -7.297  21.912  24.473  1.00 18.73 ? 150  ILE A CD1 1 
+ATOM   995  N  N   . ASP A 1 129 ? -4.361  27.122  25.282  1.00 13.12 ? 151  ASP A N   1 
+ATOM   996  C  CA  . ASP A 1 129 ? -3.555  27.914  26.198  1.00 12.50 ? 151  ASP A CA  1 
+ATOM   997  C  C   . ASP A 1 129 ? -4.479  28.668  27.187  1.00 14.47 ? 151  ASP A C   1 
+ATOM   998  O  O   . ASP A 1 129 ? -4.426  29.873  27.374  1.00 13.38 ? 151  ASP A O   1 
+ATOM   999  C  CB  . ASP A 1 129 ? -2.653  28.927  25.481  1.00 14.47 ? 151  ASP A CB  1 
+ATOM   1000 C  CG  . ASP A 1 129 ? -1.841  29.751  26.474  1.00 13.78 ? 151  ASP A CG  1 
+ATOM   1001 O  OD1 . ASP A 1 129 ? -1.584  29.199  27.614  1.00 14.61 ? 151  ASP A OD1 1 
+ATOM   1002 O  OD2 . ASP A 1 129 ? -1.392  30.878  26.113  1.00 14.28 ? 151  ASP A OD2 1 
+ATOM   1003 N  N   . LEU A 1 130 ? -5.351  27.914  27.827  1.00 14.40 ? 152  LEU A N   1 
+ATOM   1004 C  CA  . LEU A 1 130 ? -6.156  28.442  28.894  1.00 15.15 ? 152  LEU A CA  1 
+ATOM   1005 C  C   . LEU A 1 130 ? -5.331  28.681  30.136  1.00 14.12 ? 152  LEU A C   1 
+ATOM   1006 O  O   . LEU A 1 130 ? -4.502  27.843  30.515  1.00 14.14 ? 152  LEU A O   1 
+ATOM   1007 C  CB  . LEU A 1 130 ? -7.286  27.484  29.238  1.00 16.32 ? 152  LEU A CB  1 
+ATOM   1008 C  CG  . LEU A 1 130 ? -8.164  27.090  28.056  1.00 17.47 ? 152  LEU A CG  1 
+ATOM   1009 C  CD1 . LEU A 1 130 ? -8.983  25.939  28.425  1.00 19.07 ? 152  LEU A CD1 1 
+ATOM   1010 C  CD2 . LEU A 1 130 ? -9.077  28.272  27.657  1.00 17.67 ? 152  LEU A CD2 1 
+ATOM   1011 N  N   . GLN A 1 131 ? -5.593  29.821  30.784  1.00 13.90 ? 153  GLN A N   1 
+ATOM   1012 C  CA  . GLN A 1 131 ? -4.855  30.168  31.999  1.00 15.24 ? 153  GLN A CA  1 
+ATOM   1013 C  C   . GLN A 1 131 ? -5.851  30.714  33.020  1.00 14.66 ? 153  GLN A C   1 
+ATOM   1014 O  O   . GLN A 1 131 ? -6.968  31.093  32.711  1.00 16.39 ? 153  GLN A O   1 
+ATOM   1015 C  CB  . GLN A 1 131 ? -3.759  31.201  31.688  1.00 16.13 ? 153  GLN A CB  1 
+ATOM   1016 C  CG  . GLN A 1 131 ? -2.825  30.720  30.586  1.00 14.04 ? 153  GLN A CG  1 
+ATOM   1017 C  CD  . GLN A 1 131 ? -1.589  31.504  30.280  1.00 16.25 ? 153  GLN A CD  1 
+ATOM   1018 O  OE1 . GLN A 1 131 ? -0.821  31.112  29.391  1.00 14.32 ? 153  GLN A OE1 1 
+ATOM   1019 N  NE2 . GLN A 1 131 ? -1.375  32.631  30.961  1.00 16.29 ? 153  GLN A NE2 1 
+ATOM   1020 N  N   . GLN A 1 132 ? -5.397  30.683  34.272  1.00 15.21 ? 154  GLN A N   1 
+ATOM   1021 C  CA  . GLN A 1 132 ? -6.137  31.216  35.414  1.00 19.07 ? 154  GLN A CA  1 
+ATOM   1022 C  C   . GLN A 1 132 ? -7.570  30.610  35.432  1.00 17.74 ? 154  GLN A C   1 
+ATOM   1023 O  O   . GLN A 1 132 ? -7.777  29.450  35.215  1.00 17.23 ? 154  GLN A O   1 
+ATOM   1024 C  CB  . GLN A 1 132 ? -6.231  32.745  35.345  1.00 26.51 ? 154  GLN A CB  1 
+ATOM   1025 C  CG  . GLN A 1 132 ? -5.013  33.516  34.944  1.00 32.49 ? 154  GLN A CG  1 
+ATOM   1026 C  CD  . GLN A 1 132 ? -5.314  34.851  34.166  1.00 34.22 ? 154  GLN A CD  1 
+ATOM   1027 O  OE1 . GLN A 1 132 ? -5.299  34.896  32.899  1.00 27.95 ? 154  GLN A OE1 1 
+ATOM   1028 N  NE2 . GLN A 1 132 ? -5.569  35.950  34.965  1.00 37.74 ? 154  GLN A NE2 1 
+ATOM   1029 N  N   . ALA A 1 133 ? -8.578  31.435  35.649  1.00 17.02 ? 155  ALA A N   1 
+ATOM   1030 C  CA  . ALA A 1 133 ? -9.934  30.923  35.774  1.00 16.01 ? 155  ALA A CA  1 
+ATOM   1031 C  C   . ALA A 1 133 ? -10.457 30.233  34.537  1.00 18.64 ? 155  ALA A C   1 
+ATOM   1032 O  O   . ALA A 1 133 ? -11.342 29.377  34.647  1.00 20.77 ? 155  ALA A O   1 
+ATOM   1033 C  CB  . ALA A 1 133 ? -10.886 32.082  36.186  1.00 20.17 ? 155  ALA A CB  1 
+ATOM   1034 N  N   . ALA A 1 134 ? -9.944  30.629  33.372  1.00 16.73 ? 156  ALA A N   1 
+ATOM   1035 C  CA  . ALA A 1 134 ? -10.394 30.049  32.142  1.00 16.60 ? 156  ALA A CA  1 
+ATOM   1036 C  C   . ALA A 1 134 ? -10.143 28.554  32.091  1.00 16.97 ? 156  ALA A C   1 
+ATOM   1037 O  O   . ALA A 1 134 ? -10.803 27.863  31.308  1.00 19.55 ? 156  ALA A O   1 
+ATOM   1038 C  CB  . ALA A 1 134 ? -9.779  30.735  30.926  1.00 20.36 ? 156  ALA A CB  1 
+ATOM   1039 N  N   . ILE A 1 135 ? -9.191  28.016  32.840  1.00 15.65 ? 157  ILE A N   1 
+ATOM   1040 C  CA  . ILE A 1 135 ? -8.983  26.579  32.797  1.00 16.66 ? 157  ILE A CA  1 
+ATOM   1041 C  C   . ILE A 1 135 ? -10.180 25.829  33.345  1.00 17.34 ? 157  ILE A C   1 
+ATOM   1042 O  O   . ILE A 1 135 ? -10.509 24.759  32.858  1.00 17.58 ? 157  ILE A O   1 
+ATOM   1043 C  CB  . ILE A 1 135 ? -7.746  26.218  33.619  1.00 15.55 ? 157  ILE A CB  1 
+ATOM   1044 C  CG1 . ILE A 1 135 ? -6.489  26.978  33.042  1.00 16.95 ? 157  ILE A CG1 1 
+ATOM   1045 C  CG2 . ILE A 1 135 ? -7.520  24.692  33.594  1.00 16.48 ? 157  ILE A CG2 1 
+ATOM   1046 C  CD1 . ILE A 1 135 ? -5.287  26.899  34.070  1.00 16.48 ? 157  ILE A CD1 1 
+ATOM   1047 N  N   . THR A 1 136 ? -10.821 26.372  34.391  1.00 17.39 ? 158  THR A N   1 
+ATOM   1048 C  CA  . THR A 1 136 ? -11.901 25.670  35.051  1.00 17.85 ? 158  THR A CA  1 
+ATOM   1049 C  C   . THR A 1 136 ? -13.296 26.332  35.019  1.00 21.30 ? 158  THR A C   1 
+ATOM   1050 O  O   . THR A 1 136 ? -14.272 25.793  35.607  1.00 23.78 ? 158  THR A O   1 
+ATOM   1051 C  CB  . THR A 1 136 ? -11.512 25.499  36.543  1.00 18.81 ? 158  THR A CB  1 
+ATOM   1052 O  OG1 . THR A 1 136 ? -11.257 26.764  37.133  1.00 20.47 ? 158  THR A OG1 1 
+ATOM   1053 C  CG2 . THR A 1 136 ? -10.249 24.678  36.669  1.00 17.95 ? 158  THR A CG2 1 
+ATOM   1054 N  N   . ALA A 1 137 ? -13.401 27.457  34.337  1.00 21.39 ? 159  ALA A N   1 
+ATOM   1055 C  CA  . ALA A 1 137 ? -14.642 28.231  34.367  1.00 23.66 ? 159  ALA A CA  1 
+ATOM   1056 C  C   . ALA A 1 137 ? -15.829 27.428  33.822  1.00 24.05 ? 159  ALA A C   1 
+ATOM   1057 O  O   . ALA A 1 137 ? -15.734 26.743  32.796  1.00 24.76 ? 159  ALA A O   1 
+ATOM   1058 C  CB  . ALA A 1 137 ? -14.527 29.542  33.591  1.00 26.50 ? 159  ALA A CB  1 
+ATOM   1059 N  N   . LYS A 1 138 ? -16.950 27.551  34.531  1.00 27.42 ? 160  LYS A N   1 
+ATOM   1060 C  CA  . LYS A 1 138 ? -18.176 26.931  34.125  1.00 29.87 ? 160  LYS A CA  1 
+ATOM   1061 C  C   . LYS A 1 138 ? -17.992 25.485  33.564  1.00 27.62 ? 160  LYS A C   1 
+ATOM   1062 O  O   . LYS A 1 138 ? -17.522 24.620  34.307  1.00 27.90 ? 160  LYS A O   1 
+ATOM   1063 C  CB  . LYS A 1 138 ? -18.955 27.892  33.211  1.00 34.89 ? 160  LYS A CB  1 
+ATOM   1064 C  CG  . LYS A 1 138 ? -20.393 27.399  32.913  1.00 42.04 ? 160  LYS A CG  1 
+ATOM   1065 C  CD  . LYS A 1 138 ? -21.147 26.957  34.206  1.00 47.94 ? 160  LYS A CD  1 
+ATOM   1066 C  CE  . LYS A 1 138 ? -22.669 26.680  33.884  1.00 51.09 ? 160  LYS A CE  1 
+ATOM   1067 N  NZ  . LYS A 1 138 ? -23.230 27.632  32.879  1.00 53.03 ? 160  LYS A NZ  1 
+ATOM   1068 N  N   . ASP A 1 139 ? -18.369 25.223  32.300  1.00 26.35 ? 161  ASP A N   1 
+ATOM   1069 C  CA  . ASP A 1 139 ? -18.267 23.908  31.713  1.00 26.36 ? 161  ASP A CA  1 
+ATOM   1070 C  C   . ASP A 1 139 ? -17.112 23.800  30.687  1.00 23.25 ? 161  ASP A C   1 
+ATOM   1071 O  O   . ASP A 1 139 ? -17.101 22.895  29.856  1.00 25.93 ? 161  ASP A O   1 
+ATOM   1072 C  CB  . ASP A 1 139 ? -19.602 23.557  31.063  1.00 29.75 ? 161  ASP A CB  1 
+ATOM   1073 C  CG  . ASP A 1 139 ? -20.728 23.521  32.073  1.00 32.68 ? 161  ASP A CG  1 
+ATOM   1074 O  OD1 . ASP A 1 139 ? -20.469 23.000  33.184  1.00 32.66 ? 161  ASP A OD1 1 
+ATOM   1075 O  OD2 . ASP A 1 139 ? -21.845 24.024  31.748  1.00 33.90 ? 161  ASP A OD2 1 
+ATOM   1076 N  N   . ASN A 1 140 ? -16.117 24.693  30.763  1.00 21.70 ? 162  ASN A N   1 
+ATOM   1077 C  CA  . ASN A 1 140 ? -14.992 24.644  29.820  1.00 21.48 ? 162  ASN A CA  1 
+ATOM   1078 C  C   . ASN A 1 140 ? -14.322 23.274  29.730  1.00 21.11 ? 162  ASN A C   1 
+ATOM   1079 O  O   . ASN A 1 140 ? -13.960 22.841  28.633  1.00 21.25 ? 162  ASN A O   1 
+ATOM   1080 C  CB  . ASN A 1 140 ? -13.917 25.668  30.203  1.00 21.56 ? 162  ASN A CB  1 
+ATOM   1081 C  CG  . ASN A 1 140 ? -14.308 27.074  29.917  1.00 22.97 ? 162  ASN A CG  1 
+ATOM   1082 O  OD1 . ASN A 1 140 ? -15.391 27.320  29.409  1.00 25.10 ? 162  ASN A OD1 1 
+ATOM   1083 N  ND2 . ASN A 1 140 ? -13.399 28.038  30.220  1.00 21.07 ? 162  ASN A ND2 1 
+ATOM   1084 N  N   . GLN A 1 141 ? -14.117 22.611  30.881  1.00 22.59 ? 163  GLN A N   1 
+ATOM   1085 C  CA  . GLN A 1 141 ? -13.403 21.342  30.894  1.00 23.22 ? 163  GLN A CA  1 
+ATOM   1086 C  C   . GLN A 1 141 ? -14.182 20.254  30.177  1.00 23.87 ? 163  GLN A C   1 
+ATOM   1087 O  O   . GLN A 1 141 ? -13.611 19.223  29.818  1.00 24.89 ? 163  GLN A O   1 
+ATOM   1088 C  CB  . GLN A 1 141 ? -13.080 20.949  32.321  1.00 22.74 ? 163  GLN A CB  1 
+ATOM   1089 C  CG  . GLN A 1 141 ? -12.018 21.852  32.921  1.00 23.98 ? 163  GLN A CG  1 
+ATOM   1090 C  CD  . GLN A 1 141 ? -11.946 21.792  34.452  1.00 24.45 ? 163  GLN A CD  1 
+ATOM   1091 O  OE1 . GLN A 1 141 ? -12.923 22.055  35.127  1.00 24.14 ? 163  GLN A OE1 1 
+ATOM   1092 N  NE2 . GLN A 1 141 ? -10.767 21.493  34.984  1.00 22.61 ? 163  GLN A NE2 1 
+ATOM   1093 N  N   . PHE A 1 142 ? -15.483 20.469  29.992  1.00 25.27 ? 164  PHE A N   1 
+ATOM   1094 C  CA  . PHE A 1 142 ? -16.283 19.583  29.138  1.00 25.82 ? 164  PHE A CA  1 
+ATOM   1095 C  C   . PHE A 1 142 ? -16.414 20.103  27.689  1.00 26.32 ? 164  PHE A C   1 
+ATOM   1096 O  O   . PHE A 1 142 ? -16.214 19.340  26.731  1.00 25.28 ? 164  PHE A O   1 
+ATOM   1097 C  CB  . PHE A 1 142 ? -17.682 19.421  29.725  1.00 29.94 ? 164  PHE A CB  1 
+ATOM   1098 C  CG  . PHE A 1 142 ? -18.639 18.772  28.745  1.00 33.64 ? 164  PHE A CG  1 
+ATOM   1099 C  CD1 . PHE A 1 142 ? -18.614 17.392  28.537  1.00 32.74 ? 164  PHE A CD1 1 
+ATOM   1100 C  CD2 . PHE A 1 142 ? -19.508 19.541  27.979  1.00 33.26 ? 164  PHE A CD2 1 
+ATOM   1101 C  CE1 . PHE A 1 142 ? -19.459 16.803  27.624  1.00 33.43 ? 164  PHE A CE1 1 
+ATOM   1102 C  CE2 . PHE A 1 142 ? -20.355 18.937  27.038  1.00 32.92 ? 164  PHE A CE2 1 
+ATOM   1103 C  CZ  . PHE A 1 142 ? -20.305 17.583  26.846  1.00 33.24 ? 164  PHE A CZ  1 
+ATOM   1104 N  N   . VAL A 1 143 ? -16.773 21.372  27.527  1.00 25.15 ? 165  VAL A N   1 
+ATOM   1105 C  CA  . VAL A 1 143 ? -17.102 21.937  26.231  1.00 25.75 ? 165  VAL A CA  1 
+ATOM   1106 C  C   . VAL A 1 143 ? -15.914 21.969  25.284  1.00 22.51 ? 165  VAL A C   1 
+ATOM   1107 O  O   . VAL A 1 143 ? -16.010 21.547  24.108  1.00 22.87 ? 165  VAL A O   1 
+ATOM   1108 C  CB  . VAL A 1 143 ? -17.675 23.338  26.412  1.00 27.42 ? 165  VAL A CB  1 
+ATOM   1109 C  CG1 . VAL A 1 143 ? -17.896 24.010  25.074  1.00 27.10 ? 165  VAL A CG1 1 
+ATOM   1110 C  CG2 . VAL A 1 143 ? -18.995 23.229  27.123  1.00 28.64 ? 165  VAL A CG2 1 
+ATOM   1111 N  N   . ILE A 1 144 ? -14.757 22.374  25.787  1.00 22.15 ? 166  ILE A N   1 
+ATOM   1112 C  CA  . ILE A 1 144 ? -13.642 22.590  24.880  1.00 19.93 ? 166  ILE A CA  1 
+ATOM   1113 C  C   . ILE A 1 144 ? -13.163 21.232  24.334  1.00 21.37 ? 166  ILE A C   1 
+ATOM   1114 O  O   . ILE A 1 144 ? -13.034 21.068  23.121  1.00 22.68 ? 166  ILE A O   1 
+ATOM   1115 C  CB  . ILE A 1 144 ? -12.580 23.455  25.561  1.00 19.00 ? 166  ILE A CB  1 
+ATOM   1116 C  CG1 . ILE A 1 144 ? -13.130 24.893  25.716  1.00 21.91 ? 166  ILE A CG1 1 
+ATOM   1117 C  CG2 . ILE A 1 144 ? -11.288 23.463  24.790  1.00 20.83 ? 166  ILE A CG2 1 
+ATOM   1118 C  CD1 . ILE A 1 144 ? -12.325 25.857  26.593  1.00 22.00 ? 166  ILE A CD1 1 
+ATOM   1119 N  N   . PRO A 1 145 ? -12.978 20.207  25.204  1.00 20.89 ? 167  PRO A N   1 
+ATOM   1120 C  CA  . PRO A 1 145 ? -12.639 18.883  24.630  1.00 21.22 ? 167  PRO A CA  1 
+ATOM   1121 C  C   . PRO A 1 145 ? -13.705 18.323  23.689  1.00 20.35 ? 167  PRO A C   1 
+ATOM   1122 O  O   . PRO A 1 145 ? -13.361 17.794  22.611  1.00 20.60 ? 167  PRO A O   1 
+ATOM   1123 C  CB  . PRO A 1 145 ? -12.448 18.000  25.846  1.00 19.72 ? 167  PRO A CB  1 
+ATOM   1124 C  CG  . PRO A 1 145 ? -11.953 18.971  26.890  1.00 21.21 ? 167  PRO A CG  1 
+ATOM   1125 C  CD  . PRO A 1 145 ? -12.799 20.218  26.660  1.00 21.16 ? 167  PRO A CD  1 
+ATOM   1126 N  N   . ALA A 1 146 ? -14.973 18.565  24.009  1.00 21.61 ? 168  ALA A N   1 
+ATOM   1127 C  CA  . ALA A 1 146 ? -16.046 18.000  23.213  1.00 24.75 ? 168  ALA A CA  1 
+ATOM   1128 C  C   . ALA A 1 146 ? -15.960 18.647  21.820  1.00 24.20 ? 168  ALA A C   1 
+ATOM   1129 O  O   . ALA A 1 146 ? -16.091 17.954  20.782  1.00 25.19 ? 168  ALA A O   1 
+ATOM   1130 C  CB  . ALA A 1 146 ? -17.410 18.261  23.847  1.00 25.50 ? 168  ALA A CB  1 
+ATOM   1131 N  N   . ALA A 1 147 ? -15.793 19.958  21.792  1.00 23.24 ? 169  ALA A N   1 
+ATOM   1132 C  CA  . ALA A 1 147 ? -15.726 20.679  20.520  1.00 22.36 ? 169  ALA A CA  1 
+ATOM   1133 C  C   . ALA A 1 147 ? -14.531 20.197  19.697  1.00 21.98 ? 169  ALA A C   1 
+ATOM   1134 O  O   . ALA A 1 147 ? -14.617 19.998  18.504  1.00 21.38 ? 169  ALA A O   1 
+ATOM   1135 C  CB  . ALA A 1 147 ? -15.604 22.133  20.779  1.00 22.12 ? 169  ALA A CB  1 
+ATOM   1136 N  N   . LEU A 1 148 ? -13.395 20.020  20.361  1.00 19.87 ? 170  LEU A N   1 
+ATOM   1137 C  CA  . LEU A 1 148 ? -12.201 19.676  19.649  1.00 19.88 ? 170  LEU A CA  1 
+ATOM   1138 C  C   . LEU A 1 148 ? -12.297 18.262  19.098  1.00 21.92 ? 170  LEU A C   1 
+ATOM   1139 O  O   . LEU A 1 148 ? -11.700 17.967  18.052  1.00 20.82 ? 170  LEU A O   1 
+ATOM   1140 C  CB  . LEU A 1 148 ? -10.989 19.902  20.532  1.00 20.49 ? 170  LEU A CB  1 
+ATOM   1141 C  CG  . LEU A 1 148 ? -10.566 21.354  20.597  1.00 20.17 ? 170  LEU A CG  1 
+ATOM   1142 C  CD1 . LEU A 1 148 ? -9.563  21.473  21.777  1.00 19.41 ? 170  LEU A CD1 1 
+ATOM   1143 C  CD2 . LEU A 1 148 ? -9.972  21.921  19.277  1.00 18.31 ? 170  LEU A CD2 1 
+ATOM   1144 N  N   . LYS A 1 149 ? -12.974 17.362  19.800  1.00 22.61 ? 171  LYS A N   1 
+ATOM   1145 C  CA  . LYS A 1 149 ? -13.110 16.035  19.203  1.00 24.90 ? 171  LYS A CA  1 
+ATOM   1146 C  C   . LYS A 1 149 ? -13.905 16.121  17.896  1.00 25.22 ? 171  LYS A C   1 
+ATOM   1147 O  O   . LYS A 1 149 ? -13.627 15.420  16.903  1.00 24.98 ? 171  LYS A O   1 
+ATOM   1148 C  CB  . LYS A 1 149 ? -13.805 15.075  20.136  1.00 25.07 ? 171  LYS A CB  1 
+ATOM   1149 C  CG  . LYS A 1 149 ? -13.008 14.750  21.342  1.00 27.58 ? 171  LYS A CG  1 
+ATOM   1150 C  CD  . LYS A 1 149 ? -13.854 13.921  22.309  1.00 31.55 ? 171  LYS A CD  1 
+ATOM   1151 C  CE  . LYS A 1 149 ? -13.022 13.374  23.356  1.00 35.04 ? 171  LYS A CE  1 
+ATOM   1152 N  NZ  . LYS A 1 149 ? -13.856 12.731  24.417  1.00 38.63 ? 171  LYS A NZ  1 
+ATOM   1153 N  N   . MET A 1 150 ? -14.919 16.985  17.891  1.00 24.87 ? 172  MET A N   1 
+ATOM   1154 C  CA  . MET A 1 150 ? -15.738 17.168  16.702  1.00 24.74 ? 172  MET A CA  1 
+ATOM   1155 C  C   . MET A 1 150 ? -14.918 17.722  15.569  1.00 22.17 ? 172  MET A C   1 
+ATOM   1156 O  O   . MET A 1 150 ? -15.140 17.309  14.425  1.00 22.98 ? 172  MET A O   1 
+ATOM   1157 C  CB  . MET A 1 150 ? -16.938 18.070  16.959  1.00 25.81 ? 172  MET A CB  1 
+ATOM   1158 C  CG  . MET A 1 150 ? -18.036 17.296  17.721  1.00 27.47 ? 172  MET A CG  1 
+ATOM   1159 S  SD  . MET A 1 150 ? -19.625 18.182  17.962  1.00 34.59 ? 172  MET A SD  1 
+ATOM   1160 C  CE  . MET A 1 150 ? -19.183 19.265  19.204  1.00 30.31 ? 172  MET A CE  1 
+ATOM   1161 N  N   . VAL A 1 151 ? -14.034 18.665  15.874  1.00 21.45 ? 173  VAL A N   1 
+ATOM   1162 C  CA  . VAL A 1 151 ? -13.205 19.291  14.843  1.00 20.83 ? 173  VAL A CA  1 
+ATOM   1163 C  C   . VAL A 1 151 ? -12.236 18.247  14.303  1.00 21.37 ? 173  VAL A C   1 
+ATOM   1164 O  O   . VAL A 1 151 ? -12.073 18.093  13.086  1.00 21.16 ? 173  VAL A O   1 
+ATOM   1165 C  CB  . VAL A 1 151 ? -12.465 20.531  15.390  1.00 19.77 ? 173  VAL A CB  1 
+ATOM   1166 C  CG1 . VAL A 1 151 ? -11.473 21.056  14.379  1.00 20.07 ? 173  VAL A CG1 1 
+ATOM   1167 C  CG2 . VAL A 1 151 ? -13.459 21.592  15.826  1.00 22.13 ? 173  VAL A CG2 1 
+ATOM   1168 N  N   . LYS A 1 152 ? -11.617 17.500  15.192  1.00 22.19 ? 174  LYS A N   1 
+ATOM   1169 C  CA  . LYS A 1 152 ? -10.649 16.511  14.746  1.00 20.94 ? 174  LYS A CA  1 
+ATOM   1170 C  C   . LYS A 1 152 ? -11.358 15.538  13.768  1.00 23.26 ? 174  LYS A C   1 
+ATOM   1171 O  O   . LYS A 1 152 ? -10.836 15.206  12.685  1.00 25.09 ? 174  LYS A O   1 
+ATOM   1172 C  CB  . LYS A 1 152 ? -10.066 15.760  15.940  1.00 21.75 ? 174  LYS A CB  1 
+ATOM   1173 C  CG  . LYS A 1 152 ? -8.876  14.889  15.602  1.00 21.69 ? 174  LYS A CG  1 
+ATOM   1174 C  CD  . LYS A 1 152 ? -7.613  15.665  15.850  1.00 22.22 ? 174  LYS A CD  1 
+ATOM   1175 C  CE  . LYS A 1 152 ? -6.345  14.907  15.397  1.00 21.20 ? 174  LYS A CE  1 
+ATOM   1176 N  NZ  . LYS A 1 152 ? -5.107  15.600  15.771  1.00 21.99 ? 174  LYS A NZ  1 
+ATOM   1177 N  N   . GLU A 1 153 ? -12.543 15.076  14.157  1.00 26.14 ? 175  GLU A N   1 
+ATOM   1178 C  CA  . GLU A 1 153 ? -13.248 14.081  13.368  1.00 27.40 ? 175  GLU A CA  1 
+ATOM   1179 C  C   . GLU A 1 153 ? -13.660 14.679  12.062  1.00 27.44 ? 175  GLU A C   1 
+ATOM   1180 O  O   . GLU A 1 153 ? -13.571 14.023  11.036  1.00 28.94 ? 175  GLU A O   1 
+ATOM   1181 C  CB  . GLU A 1 153 ? -14.441 13.579  14.141  1.00 31.98 ? 175  GLU A CB  1 
+ATOM   1182 C  CG  . GLU A 1 153 ? -13.974 12.554  15.235  1.00 40.71 ? 175  GLU A CG  1 
+ATOM   1183 C  CD  . GLU A 1 153 ? -13.039 11.482  14.576  1.00 48.29 ? 175  GLU A CD  1 
+ATOM   1184 O  OE1 . GLU A 1 153 ? -12.002 11.201  15.265  1.00 49.05 ? 175  GLU A OE1 1 
+ATOM   1185 O  OE2 . GLU A 1 153 ? -13.348 10.986  13.411  1.00 50.98 ? 175  GLU A OE2 1 
+ATOM   1186 N  N   . HIS A 1 154 ? -14.063 15.937  12.081  1.00 27.91 ? 176  HIS A N   1 
+ATOM   1187 C  CA  . HIS A 1 154 ? -14.488 16.607  10.862  1.00 27.37 ? 176  HIS A CA  1 
+ATOM   1188 C  C   . HIS A 1 154 ? -13.391 16.594  9.794   1.00 25.09 ? 176  HIS A C   1 
+ATOM   1189 O  O   . HIS A 1 154 ? -13.670 16.373  8.603   1.00 26.46 ? 176  HIS A O   1 
+ATOM   1190 C  CB  . HIS A 1 154 ? -14.815 18.068  11.209  1.00 27.16 ? 176  HIS A CB  1 
+ATOM   1191 C  CG  . HIS A 1 154 ? -15.036 18.932  9.999   1.00 27.73 ? 176  HIS A CG  1 
+ATOM   1192 N  ND1 . HIS A 1 154 ? -16.244 18.994  9.354   1.00 30.76 ? 176  HIS A ND1 1 
+ATOM   1193 C  CD2 . HIS A 1 154 ? -14.221 19.820  9.367   1.00 28.44 ? 176  HIS A CD2 1 
+ATOM   1194 C  CE1 . HIS A 1 154 ? -16.163 19.842  8.341   1.00 32.51 ? 176  HIS A CE1 1 
+ATOM   1195 N  NE2 . HIS A 1 154 ? -14.949 20.363  8.326   1.00 31.40 ? 176  HIS A NE2 1 
+ATOM   1196 N  N   . TYR A 1 155 ? -12.155 16.906  10.216  1.00 24.74 ? 177  TYR A N   1 
+ATOM   1197 C  CA  . TYR A 1 155 ? -11.034 16.968  9.283   1.00 21.74 ? 177  TYR A CA  1 
+ATOM   1198 C  C   . TYR A 1 155 ? -10.507 15.569  8.980   1.00 22.05 ? 177  TYR A C   1 
+ATOM   1199 O  O   . TYR A 1 155 ? -10.014 15.318  7.859   1.00 24.14 ? 177  TYR A O   1 
+ATOM   1200 C  CB  . TYR A 1 155 ? -9.971  17.915  9.775   1.00 21.35 ? 177  TYR A CB  1 
+ATOM   1201 C  CG  . TYR A 1 155 ? -10.427 19.343  9.659   1.00 20.45 ? 177  TYR A CG  1 
+ATOM   1202 C  CD1 . TYR A 1 155 ? -10.638 19.913  8.421   1.00 20.59 ? 177  TYR A CD1 1 
+ATOM   1203 C  CD2 . TYR A 1 155 ? -10.675 20.115  10.789  1.00 20.25 ? 177  TYR A CD2 1 
+ATOM   1204 C  CE1 . TYR A 1 155 ? -11.061 21.196  8.310   1.00 22.95 ? 177  TYR A CE1 1 
+ATOM   1205 C  CE2 . TYR A 1 155 ? -11.083 21.386  10.698  1.00 19.84 ? 177  TYR A CE2 1 
+ATOM   1206 C  CZ  . TYR A 1 155 ? -11.249 21.949  9.436   1.00 21.11 ? 177  TYR A CZ  1 
+ATOM   1207 O  OH  . TYR A 1 155 ? -11.625 23.271  9.307   1.00 20.67 ? 177  TYR A OH  1 
+ATOM   1208 N  N   . ARG A 1 156 ? -10.717 14.620  9.891   1.00 24.10 ? 178  ARG A N   1 
+ATOM   1209 C  CA  . ARG A 1 156 ? -10.289 13.248  9.598   1.00 26.66 ? 178  ARG A CA  1 
+ATOM   1210 C  C   . ARG A 1 156 ? -11.071 12.677  8.412   1.00 28.96 ? 178  ARG A C   1 
+ATOM   1211 O  O   . ARG A 1 156 ? -10.549 11.893  7.623   1.00 30.43 ? 178  ARG A O   1 
+ATOM   1212 C  CB  . ARG A 1 156 ? -10.414 12.334  10.823  1.00 29.16 ? 178  ARG A CB  1 
+ATOM   1213 C  CG  . ARG A 1 156 ? -9.215  12.447  11.759  1.00 34.07 ? 178  ARG A CG  1 
+ATOM   1214 C  CD  . ARG A 1 156 ? -9.404  11.712  13.096  1.00 37.56 ? 178  ARG A CD  1 
+ATOM   1215 N  NE  . ARG A 1 156 ? -8.236  11.727  13.996  1.00 37.80 ? 178  ARG A NE  1 
+ATOM   1216 C  CZ  . ARG A 1 156 ? -8.247  11.246  15.237  1.00 39.68 ? 178  ARG A CZ  1 
+ATOM   1217 N  NH1 . ARG A 1 156 ? -7.142  11.266  15.995  1.00 39.31 ? 178  ARG A NH1 1 
+ATOM   1218 N  NH2 . ARG A 1 156 ? -9.370  10.776  15.752  1.00 40.34 ? 178  ARG A NH2 1 
+ATOM   1219 N  N   . LYS A 1 157 ? -12.302 13.119  8.234   1.00 30.76 ? 179  LYS A N   1 
+ATOM   1220 C  CA  . LYS A 1 157 ? -13.133 12.607  7.160   1.00 34.17 ? 179  LYS A CA  1 
+ATOM   1221 C  C   . LYS A 1 157 ? -12.491 12.854  5.820   1.00 35.06 ? 179  LYS A C   1 
+ATOM   1222 O  O   . LYS A 1 157 ? -12.758 12.118  4.864   1.00 37.41 ? 179  LYS A O   1 
+ATOM   1223 C  CB  . LYS A 1 157 ? -14.468 13.297  7.199   1.00 38.33 ? 179  LYS A CB  1 
+ATOM   1224 C  CG  . LYS A 1 157 ? -15.396 12.698  8.185   1.00 41.78 ? 179  LYS A CG  1 
+ATOM   1225 C  CD  . LYS A 1 157 ? -16.553 13.623  8.533   1.00 45.63 ? 179  LYS A CD  1 
+ATOM   1226 C  CE  . LYS A 1 157 ? -16.934 14.618  7.461   0.46 46.82 ? 179  LYS A CE  1 
+ATOM   1227 N  NZ  . LYS A 1 157 ? -17.795 15.651  8.089   0.55 47.03 ? 179  LYS A NZ  1 
+ATOM   1228 N  N   . THR A 1 158 ? -11.693 13.913  5.723   1.00 34.88 ? 180  THR A N   1 
+ATOM   1229 C  CA  . THR A 1 158 ? -11.113 14.312  4.449   1.00 35.41 ? 180  THR A CA  1 
+ATOM   1230 C  C   . THR A 1 158 ? -9.628  14.016  4.411   1.00 35.09 ? 180  THR A C   1 
+ATOM   1231 O  O   . THR A 1 158 ? -8.909  14.506  3.507   1.00 36.51 ? 180  THR A O   1 
+ATOM   1232 C  CB  . THR A 1 158 ? -11.366 15.778  4.117   1.00 37.46 ? 180  THR A CB  1 
+ATOM   1233 O  OG1 . THR A 1 158 ? -11.030 16.590  5.244   1.00 38.68 ? 180  THR A OG1 1 
+ATOM   1234 C  CG2 . THR A 1 158 ? -12.819 16.025  3.707   1.00 39.63 ? 180  THR A CG2 1 
+ATOM   1235 N  N   . GLY A 1 159 ? -9.195  13.196  5.370   1.00 33.71 ? 181  GLY A N   1 
+ATOM   1236 C  CA  . GLY A 1 159 ? -7.840  12.703  5.427   1.00 31.56 ? 181  GLY A CA  1 
+ATOM   1237 C  C   . GLY A 1 159 ? -6.836  13.678  6.030   1.00 31.45 ? 181  GLY A C   1 
+ATOM   1238 O  O   . GLY A 1 159 ? -5.627  13.497  5.792   1.00 32.00 ? 181  GLY A O   1 
+ATOM   1239 N  N   . ASP A 1 160 ? -7.302  14.668  6.800   1.00 27.98 ? 182  ASP A N   1 
+ATOM   1240 C  CA  . ASP A 1 160 ? -6.452  15.746  7.302   1.00 26.78 ? 182  ASP A CA  1 
+ATOM   1241 C  C   . ASP A 1 160 ? -6.306  15.551  8.804   1.00 25.95 ? 182  ASP A C   1 
+ATOM   1242 O  O   . ASP A 1 160 ? -7.291  15.159  9.487   1.00 26.41 ? 182  ASP A O   1 
+ATOM   1243 C  CB  . ASP A 1 160 ? -7.081  17.075  7.049   1.00 29.47 ? 182  ASP A CB  1 
+ATOM   1244 C  CG  . ASP A 1 160 ? -7.246  17.357  5.564   1.00 32.47 ? 182  ASP A CG  1 
+ATOM   1245 O  OD1 . ASP A 1 160 ? -6.219  17.473  4.887   1.00 34.95 ? 182  ASP A OD1 1 
+ATOM   1246 O  OD2 . ASP A 1 160 ? -8.403  17.435  5.122   1.00 34.81 ? 182  ASP A OD2 1 
+ATOM   1247 N  N   . ASN A 1 161 ? -5.103  15.835  9.297   1.00 22.76 ? 183  ASN A N   1 
+ATOM   1248 C  CA  . ASN A 1 161 ? -4.834  15.787  10.732  1.00 21.99 ? 183  ASN A CA  1 
+ATOM   1249 C  C   . ASN A 1 161 ? -4.777  17.211  11.235  1.00 19.37 ? 183  ASN A C   1 
+ATOM   1250 O  O   . ASN A 1 161 ? -3.699  17.881  11.183  1.00 20.51 ? 183  ASN A O   1 
+ATOM   1251 C  CB  . ASN A 1 161 ? -3.466  15.157  10.979  1.00 20.39 ? 183  ASN A CB  1 
+ATOM   1252 C  CG  . ASN A 1 161 ? -3.114  15.080  12.469  1.00 23.11 ? 183  ASN A CG  1 
+ATOM   1253 O  OD1 . ASN A 1 161 ? -3.935  14.692  13.289  1.00 26.99 ? 183  ASN A OD1 1 
+ATOM   1254 N  ND2 . ASN A 1 161 ? -1.921  15.489  12.814  1.00 23.06 ? 183  ASN A ND2 1 
+ATOM   1255 N  N   . PHE A 1 162 ? -5.913  17.714  11.702  1.00 17.64 ? 184  PHE A N   1 
+ATOM   1256 C  CA  . PHE A 1 162 ? -5.993  18.983  12.416  1.00 17.14 ? 184  PHE A CA  1 
+ATOM   1257 C  C   . PHE A 1 162 ? -5.267  18.809  13.736  1.00 16.93 ? 184  PHE A C   1 
+ATOM   1258 O  O   . PHE A 1 162 ? -5.662  17.958  14.582  1.00 18.05 ? 184  PHE A O   1 
+ATOM   1259 C  CB  . PHE A 1 162 ? -7.475  19.302  12.649  1.00 17.14 ? 184  PHE A CB  1 
+ATOM   1260 C  CG  . PHE A 1 162 ? -7.733  20.561  13.431  1.00 18.42 ? 184  PHE A CG  1 
+ATOM   1261 C  CD1 . PHE A 1 162 ? -7.960  21.748  12.772  1.00 19.33 ? 184  PHE A CD1 1 
+ATOM   1262 C  CD2 . PHE A 1 162 ? -7.773  20.551  14.824  1.00 18.23 ? 184  PHE A CD2 1 
+ATOM   1263 C  CE1 . PHE A 1 162 ? -8.203  22.917  13.473  1.00 17.68 ? 184  PHE A CE1 1 
+ATOM   1264 C  CE2 . PHE A 1 162 ? -8.009  21.760  15.517  1.00 16.29 ? 184  PHE A CE2 1 
+ATOM   1265 C  CZ  . PHE A 1 162 ? -8.241  22.922  14.829  1.00 15.70 ? 184  PHE A CZ  1 
+ATOM   1266 N  N   . MET A 1 163 ? -4.221  19.604  13.904  1.00 15.73 ? 185  MET A N   1 
+ATOM   1267 C  CA  . MET A 1 163 ? -3.352  19.430  15.072  1.00 15.36 ? 185  MET A CA  1 
+ATOM   1268 C  C   . MET A 1 163 ? -4.020  19.948  16.330  1.00 15.17 ? 185  MET A C   1 
+ATOM   1269 O  O   . MET A 1 163 ? -4.685  20.973  16.297  1.00 16.43 ? 185  MET A O   1 
+ATOM   1270 C  CB  . MET A 1 163 ? -2.006  20.113  14.891  1.00 16.15 ? 185  MET A CB  1 
+ATOM   1271 C  CG  . MET A 1 163 ? -1.184  19.543  13.714  1.00 16.50 ? 185  MET A CG  1 
+ATOM   1272 S  SD  . MET A 1 163 ? 0.285   20.519  13.377  1.00 18.69 ? 185  MET A SD  1 
+ATOM   1273 C  CE  . MET A 1 163 ? 1.175   20.399  14.930  1.00 21.58 ? 185  MET A CE  1 
+ATOM   1274 N  N   . ILE A 1 164 ? -3.848  19.215  17.416  1.00 14.08 ? 186  ILE A N   1 
+ATOM   1275 C  CA  . ILE A 1 164 ? -4.281  19.750  18.714  1.00 14.02 ? 186  ILE A CA  1 
+ATOM   1276 C  C   . ILE A 1 164 ? -3.075  19.738  19.639  1.00 14.44 ? 186  ILE A C   1 
+ATOM   1277 O  O   . ILE A 1 164 ? -2.445  18.682  19.819  1.00 14.28 ? 186  ILE A O   1 
+ATOM   1278 C  CB  . ILE A 1 164 ? -5.417  18.950  19.309  1.00 14.83 ? 186  ILE A CB  1 
+ATOM   1279 C  CG1 . ILE A 1 164 ? -6.654  19.069  18.451  1.00 16.28 ? 186  ILE A CG1 1 
+ATOM   1280 C  CG2 . ILE A 1 164 ? -5.760  19.456  20.760  1.00 16.28 ? 186  ILE A CG2 1 
+ATOM   1281 C  CD1 . ILE A 1 164 ? -7.795  18.135  18.823  1.00 18.29 ? 186  ILE A CD1 1 
+ATOM   1282 N  N   . THR A 1 165 ? -2.773  20.906  20.225  1.00 13.17 ? 187  THR A N   1 
+ATOM   1283 C  CA  . THR A 1 165 ? -1.671  20.972  21.165  1.00 13.35 ? 187  THR A CA  1 
+ATOM   1284 C  C   . THR A 1 165 ? -2.228  21.662  22.425  1.00 11.05 ? 187  THR A C   1 
+ATOM   1285 O  O   . THR A 1 165 ? -3.336  22.229  22.415  1.00 13.61 ? 187  THR A O   1 
+ATOM   1286 C  CB  . THR A 1 165 ? -0.449  21.717  20.590  1.00 12.82 ? 187  THR A CB  1 
+ATOM   1287 O  OG1 . THR A 1 165 ? -0.756  23.079  20.348  1.00 12.62 ? 187  THR A OG1 1 
+ATOM   1288 C  CG2 . THR A 1 165 ? -0.020  21.092  19.270  1.00 13.70 ? 187  THR A CG2 1 
+ATOM   1289 N  N   . MET A 1 166 ? -1.417  21.718  23.474  1.00 12.28 ? 188  MET A N   1 
+ATOM   1290 C  CA  . MET A 1 166 ? -1.794  22.503  24.687  1.00 12.40 ? 188  MET A CA  1 
+ATOM   1291 C  C   . MET A 1 166 ? -0.555  23.103  25.327  1.00 10.84 ? 188  MET A C   1 
+ATOM   1292 O  O   . MET A 1 166 ? 0.552   22.515  25.246  1.00 13.88 ? 188  MET A O   1 
+ATOM   1293 C  CB  . MET A 1 166 ? -2.489  21.632  25.730  1.00 12.98 ? 188  MET A CB  1 
+ATOM   1294 C  CG  . MET A 1 166 ? -3.485  20.663  25.127  1.00 15.67 ? 188  MET A CG  1 
+ATOM   1295 S  SD  . MET A 1 166 ? -4.373  19.780  26.454  1.00 15.21 ? 188  MET A SD  1 
+ATOM   1296 C  CE  . MET A 1 166 ? -4.929  18.384  25.528  1.00 16.86 ? 188  MET A CE  1 
+ATOM   1297 N  N   . ALA A 1 167 ? -0.741  24.223  26.028  1.00 12.00 ? 189  ALA A N   1 
+ATOM   1298 C  CA  . ALA A 1 167 ? 0.376   24.917  26.675  1.00 11.04 ? 189  ALA A CA  1 
+ATOM   1299 C  C   . ALA A 1 167 ? 0.052   25.129  28.190  1.00 11.82 ? 189  ALA A C   1 
+ATOM   1300 O  O   . ALA A 1 167 ? 0.113   26.240  28.719  1.00 12.77 ? 189  ALA A O   1 
+ATOM   1301 C  CB  . ALA A 1 167 ? 0.575   26.238  26.032  1.00 13.66 ? 189  ALA A CB  1 
+ATOM   1302 N  N   . PRO A 1 168 ? -0.257  24.027  28.907  1.00 11.41 ? 190  PRO A N   1 
+ATOM   1303 C  CA  . PRO A 1 168 ? -0.474  24.189  30.349  1.00 12.26 ? 190  PRO A CA  1 
+ATOM   1304 C  C   . PRO A 1 168 ? 0.765   24.701  31.086  1.00 14.29 ? 190  PRO A C   1 
+ATOM   1305 O  O   . PRO A 1 168 ? 1.837   24.179  30.871  1.00 12.33 ? 190  PRO A O   1 
+ATOM   1306 C  CB  . PRO A 1 168 ? -0.809  22.768  30.799  1.00 12.61 ? 190  PRO A CB  1 
+ATOM   1307 C  CG  . PRO A 1 168 ? -0.036  21.876  29.822  1.00 13.46 ? 190  PRO A CG  1 
+ATOM   1308 C  CD  . PRO A 1 168 ? -0.274  22.618  28.509  1.00 12.59 ? 190  PRO A CD  1 
+ATOM   1309 N  N   . GLU A 1 169 ? 0.561   25.618  32.038  1.00 13.66 ? 191  GLU A N   1 
+ATOM   1310 C  CA  . GLU A 1 169 ? 1.609   25.877  32.978  1.00 12.88 ? 191  GLU A CA  1 
+ATOM   1311 C  C   . GLU A 1 169 ? 1.884   24.596  33.755  1.00 13.24 ? 191  GLU A C   1 
+ATOM   1312 O  O   . GLU A 1 169 ? 0.942   23.906  34.154  1.00 13.90 ? 191  GLU A O   1 
+ATOM   1313 C  CB  . GLU A 1 169 ? 1.238   27.040  33.897  1.00 12.58 ? 191  GLU A CB  1 
+ATOM   1314 C  CG  . GLU A 1 169 ? 1.078   28.313  33.132  1.00 13.13 ? 191  GLU A CG  1 
+ATOM   1315 C  CD  . GLU A 1 169 ? 0.244   29.331  33.875  1.00 13.21 ? 191  GLU A CD  1 
+ATOM   1316 O  OE1 . GLU A 1 169 ? 0.815   29.961  34.799  1.00 15.17 ? 191  GLU A OE1 1 
+ATOM   1317 O  OE2 . GLU A 1 169 ? -0.960  29.475  33.544  1.00 14.38 ? 191  GLU A OE2 1 
+ATOM   1318 N  N   . PHE A 1 170 ? 3.161   24.286  33.965  1.00 13.30 ? 192  PHE A N   1 
+ATOM   1319 C  CA  . PHE A 1 170 ? 3.474   22.967  34.541  1.00 14.55 ? 192  PHE A CA  1 
+ATOM   1320 C  C   . PHE A 1 170 ? 2.810   22.605  35.867  1.00 15.33 ? 192  PHE A C   1 
+ATOM   1321 O  O   . PHE A 1 170 ? 2.527   21.465  36.061  1.00 16.29 ? 192  PHE A O   1 
+ATOM   1322 C  CB  . PHE A 1 170 ? 4.971   22.671  34.553  1.00 15.73 ? 192  PHE A CB  1 
+ATOM   1323 C  CG  . PHE A 1 170 ? 5.728   23.345  35.660  1.00 14.86 ? 192  PHE A CG  1 
+ATOM   1324 C  CD1 . PHE A 1 170 ? 5.847   22.757  36.911  1.00 17.33 ? 192  PHE A CD1 1 
+ATOM   1325 C  CD2 . PHE A 1 170 ? 6.342   24.544  35.472  1.00 14.71 ? 192  PHE A CD2 1 
+ATOM   1326 C  CE1 . PHE A 1 170 ? 6.573   23.378  37.905  1.00 18.24 ? 192  PHE A CE1 1 
+ATOM   1327 C  CE2 . PHE A 1 170 ? 7.078   25.182  36.513  1.00 14.71 ? 192  PHE A CE2 1 
+ATOM   1328 C  CZ  . PHE A 1 170 ? 7.183   24.570  37.698  1.00 17.63 ? 192  PHE A CZ  1 
+ATOM   1329 N  N   . PRO A 1 171 ? 2.549   23.573  36.742  1.00 15.87 ? 193  PRO A N   1 
+ATOM   1330 C  CA  . PRO A 1 171 ? 1.966   23.133  38.014  1.00 17.38 ? 193  PRO A CA  1 
+ATOM   1331 C  C   . PRO A 1 171 ? 0.601   22.502  37.892  1.00 17.78 ? 193  PRO A C   1 
+ATOM   1332 O  O   . PRO A 1 171 ? 0.178   21.799  38.805  1.00 18.88 ? 193  PRO A O   1 
+ATOM   1333 C  CB  . PRO A 1 171 ? 1.875   24.445  38.819  1.00 19.31 ? 193  PRO A CB  1 
+ATOM   1334 C  CG  . PRO A 1 171 ? 3.031   25.275  38.315  1.00 19.07 ? 193  PRO A CG  1 
+ATOM   1335 C  CD  . PRO A 1 171 ? 2.940   24.981  36.784  1.00 15.50 ? 193  PRO A CD  1 
+ATOM   1336 N  N   . TYR A 1 172 ? -0.099  22.756  36.778  1.00 15.36 ? 194  TYR A N   1 
+ATOM   1337 C  CA  . TYR A 1 172 ? -1.393  22.209  36.589  1.00 16.10 ? 194  TYR A CA  1 
+ATOM   1338 C  C   . TYR A 1 172 ? -1.326  20.757  36.127  1.00 19.04 ? 194  TYR A C   1 
+ATOM   1339 O  O   . TYR A 1 172 ? -2.407  20.171  35.819  1.00 21.03 ? 194  TYR A O   1 
+ATOM   1340 C  CB  . TYR A 1 172 ? -2.183  23.027  35.559  1.00 16.51 ? 194  TYR A CB  1 
+ATOM   1341 C  CG  . TYR A 1 172 ? -2.434  24.447  35.982  1.00 15.88 ? 194  TYR A CG  1 
+ATOM   1342 C  CD1 . TYR A 1 172 ? -3.155  24.729  37.107  1.00 14.94 ? 194  TYR A CD1 1 
+ATOM   1343 C  CD2 . TYR A 1 172 ? -1.997  25.514  35.222  1.00 14.53 ? 194  TYR A CD2 1 
+ATOM   1344 C  CE1 . TYR A 1 172 ? -3.420  26.032  37.471  1.00 15.01 ? 194  TYR A CE1 1 
+ATOM   1345 C  CE2 . TYR A 1 172 ? -2.281  26.810  35.575  1.00 14.66 ? 194  TYR A CE2 1 
+ATOM   1346 C  CZ  . TYR A 1 172 ? -3.011  27.048  36.709  1.00 14.78 ? 194  TYR A CZ  1 
+ATOM   1347 O  OH  . TYR A 1 172 ? -3.314  28.339  37.124  1.00 17.48 ? 194  TYR A OH  1 
+ATOM   1348 N  N   . LEU A 1 173 ? -0.125  20.227  35.920  1.00 16.62 ? 195  LEU A N   1 
+ATOM   1349 C  CA  . LEU A 1 173 ? 0.024   18.871  35.365  1.00 16.23 ? 195  LEU A CA  1 
+ATOM   1350 C  C   . LEU A 1 173 ? 0.200   17.759  36.400  1.00 15.38 ? 195  LEU A C   1 
+ATOM   1351 O  O   . LEU A 1 173 ? 0.587   16.628  36.074  1.00 18.30 ? 195  LEU A O   1 
+ATOM   1352 C  CB  . LEU A 1 173 ? 1.207   18.860  34.387  1.00 15.67 ? 195  LEU A CB  1 
+ATOM   1353 C  CG  . LEU A 1 173 ? 0.967   19.723  33.150  1.00 15.32 ? 195  LEU A CG  1 
+ATOM   1354 C  CD1 . LEU A 1 173 ? 2.191   19.748  32.225  1.00 17.57 ? 195  LEU A CD1 1 
+ATOM   1355 C  CD2 . LEU A 1 173 ? -0.251  19.217  32.413  1.00 17.99 ? 195  LEU A CD2 1 
+ATOM   1356 N  N   . THR A 1 174 ? -0.065  18.095  37.684  1.00 15.21 ? 196  THR A N   1 
+ATOM   1357 C  CA  . THR A 1 174 ? -0.141  17.021  38.661  1.00 15.59 ? 196  THR A CA  1 
+ATOM   1358 C  C   . THR A 1 174 ? -1.242  16.065  38.285  1.00 18.84 ? 196  THR A C   1 
+ATOM   1359 O  O   . THR A 1 174 ? -2.118  16.380  37.478  1.00 21.05 ? 196  THR A O   1 
+ATOM   1360 C  CB  . THR A 1 174 ? -0.366  17.532  40.056  1.00 17.72 ? 196  THR A CB  1 
+ATOM   1361 O  OG1 . THR A 1 174 ? -1.592  18.263  40.088  1.00 20.42 ? 196  THR A OG1 1 
+ATOM   1362 C  CG2 . THR A 1 174 ? 0.798   18.472  40.494  1.00 21.12 ? 196  THR A CG2 1 
+ATOM   1363 N  N   . ALA A 1 175 ? -1.176  14.859  38.819  1.00 21.69 ? 197  ALA A N   1 
+ATOM   1364 C  CA  . ALA A 1 175 ? -2.009  13.774  38.355  1.00 23.78 ? 197  ALA A CA  1 
+ATOM   1365 C  C   . ALA A 1 175 ? -3.529  14.021  38.338  1.00 27.50 ? 197  ALA A C   1 
+ATOM   1366 O  O   . ALA A 1 175 ? -4.216  13.514  37.457  1.00 31.10 ? 197  ALA A O   1 
+ATOM   1367 C  CB  . ALA A 1 175 ? -1.678  12.472  39.156  1.00 26.20 ? 197  ALA A CB  1 
+ATOM   1368 N  N   . ASN A 1 176 ? -4.023  14.810  39.272  1.00 24.26 ? 198  ASN A N   1 
+ATOM   1369 C  CA  . ASN A 1 176 ? -5.450  15.205  39.392  1.00 24.69 ? 198  ASN A CA  1 
+ATOM   1370 C  C   . ASN A 1 176 ? -5.576  16.718  39.270  1.00 22.40 ? 198  ASN A C   1 
+ATOM   1371 O  O   . ASN A 1 176 ? -6.407  17.326  39.902  1.00 24.43 ? 198  ASN A O   1 
+ATOM   1372 C  CB  . ASN A 1 176 ? -6.116  14.819  40.723  1.00 26.01 ? 198  ASN A CB  1 
+ATOM   1373 C  CG  . ASN A 1 176 ? -6.459  13.312  40.837  1.00 29.60 ? 198  ASN A CG  1 
+ATOM   1374 O  OD1 . ASN A 1 176 ? -7.685  12.892  40.913  1.00 32.84 ? 198  ASN A OD1 1 
+ATOM   1375 N  ND2 . ASN A 1 176 ? -5.418  12.496  40.922  1.00 26.52 ? 198  ASN A ND2 1 
+ATOM   1376 N  N   . GLY A 1 177 ? -4.683  17.341  38.517  1.00 19.99 ? 199  GLY A N   1 
+ATOM   1377 C  CA  . GLY A 1 177 ? -4.670  18.792  38.434  1.00 18.80 ? 199  GLY A CA  1 
+ATOM   1378 C  C   . GLY A 1 177 ? -5.668  19.330  37.436  1.00 18.27 ? 199  GLY A C   1 
+ATOM   1379 O  O   . GLY A 1 177 ? -6.391  18.580  36.807  1.00 18.96 ? 199  GLY A O   1 
+ATOM   1380 N  N   . ALA A 1 178 ? -5.711  20.653  37.331  1.00 17.65 ? 200  ALA A N   1 
+ATOM   1381 C  CA  . ALA A 1 178 ? -6.773  21.331  36.590  1.00 14.73 ? 200  ALA A CA  1 
+ATOM   1382 C  C   . ALA A 1 178 ? -6.787  21.059  35.109  1.00 15.02 ? 200  ALA A C   1 
+ATOM   1383 O  O   . ALA A 1 178 ? -7.852  21.114  34.472  1.00 16.48 ? 200  ALA A O   1 
+ATOM   1384 C  CB  . ALA A 1 178 ? -6.745  22.828  36.840  1.00 15.87 ? 200  ALA A CB  1 
+ATOM   1385 N  N   . TYR A 1 179 ? -5.628  20.723  34.564  1.00 16.65 ? 201  TYR A N   1 
+ATOM   1386 C  CA  . TYR A 1 179 ? -5.637  20.378  33.125  1.00 16.95 ? 201  TYR A CA  1 
+ATOM   1387 C  C   . TYR A 1 179 ? -5.944  18.950  32.825  1.00 19.39 ? 201  TYR A C   1 
+ATOM   1388 O  O   . TYR A 1 179 ? -6.008  18.578  31.664  1.00 21.97 ? 201  TYR A O   1 
+ATOM   1389 C  CB  . TYR A 1 179 ? -4.311  20.720  32.458  1.00 17.84 ? 201  TYR A CB  1 
+ATOM   1390 C  CG  . TYR A 1 179 ? -4.349  21.995  31.620  1.00 15.94 ? 201  TYR A CG  1 
+ATOM   1391 C  CD1 . TYR A 1 179 ? -4.485  21.917  30.244  1.00 14.67 ? 201  TYR A CD1 1 
+ATOM   1392 C  CD2 . TYR A 1 179 ? -4.198  23.234  32.183  1.00 14.82 ? 201  TYR A CD2 1 
+ATOM   1393 C  CE1 . TYR A 1 179 ? -4.513  23.063  29.478  1.00 13.39 ? 201  TYR A CE1 1 
+ATOM   1394 C  CE2 . TYR A 1 179 ? -4.208  24.395  31.410  1.00 15.52 ? 201  TYR A CE2 1 
+ATOM   1395 C  CZ  . TYR A 1 179 ? -4.365  24.302  30.058  1.00 14.74 ? 201  TYR A CZ  1 
+ATOM   1396 O  OH  . TYR A 1 179 ? -4.421  25.440  29.303  1.00 16.42 ? 201  TYR A OH  1 
+ATOM   1397 N  N   . THR A 1 180 ? -6.144  18.126  33.833  1.00 21.65 ? 202  THR A N   1 
+ATOM   1398 C  CA  . THR A 1 180 ? -6.116  16.707  33.527  1.00 22.90 ? 202  THR A CA  1 
+ATOM   1399 C  C   . THR A 1 180 ? -7.388  16.283  32.702  1.00 22.88 ? 202  THR A C   1 
+ATOM   1400 O  O   . THR A 1 180 ? -7.267  15.443  31.850  1.00 23.09 ? 202  THR A O   1 
+ATOM   1401 C  CB  . THR A 1 180 ? -5.667  15.775  34.726  1.00 26.73 ? 202  THR A CB  1 
+ATOM   1402 O  OG1 . THR A 1 180 ? -6.449  16.074  35.840  1.00 21.70 ? 202  THR A OG1 1 
+ATOM   1403 C  CG2 . THR A 1 180 ? -4.120  15.928  35.151  1.00 23.11 ? 202  THR A CG2 1 
+ATOM   1404 N  N   . PRO A 1 181 ? -8.519  16.968  32.830  1.00 23.92 ? 203  PRO A N   1 
+ATOM   1405 C  CA  . PRO A 1 181 ? -9.686  16.688  31.989  1.00 24.12 ? 203  PRO A CA  1 
+ATOM   1406 C  C   . PRO A 1 181 ? -9.366  16.925  30.511  1.00 20.63 ? 203  PRO A C   1 
+ATOM   1407 O  O   . PRO A 1 181 ? -9.900  16.233  29.625  1.00 23.64 ? 203  PRO A O   1 
+ATOM   1408 C  CB  . PRO A 1 181 ? -10.730 17.681  32.497  1.00 28.57 ? 203  PRO A CB  1 
+ATOM   1409 C  CG  . PRO A 1 181 ? -10.305 17.876  33.860  1.00 29.71 ? 203  PRO A CG  1 
+ATOM   1410 C  CD  . PRO A 1 181 ? -8.862  17.942  33.869  1.00 28.73 ? 203  PRO A CD  1 
+ATOM   1411 N  N   . TYR A 1 182 ? -8.571  17.950  30.218  1.00 17.37 ? 204  TYR A N   1 
+ATOM   1412 C  CA  . TYR A 1 182 ? -8.255  18.231  28.802  1.00 16.32 ? 204  TYR A CA  1 
+ATOM   1413 C  C   . TYR A 1 182 ? -7.368  17.117  28.282  1.00 16.57 ? 204  TYR A C   1 
+ATOM   1414 O  O   . TYR A 1 182 ? -7.580  16.596  27.170  1.00 17.36 ? 204  TYR A O   1 
+ATOM   1415 C  CB  . TYR A 1 182 ? -7.564  19.585  28.639  1.00 17.38 ? 204  TYR A CB  1 
+ATOM   1416 C  CG  . TYR A 1 182 ? -8.420  20.740  29.083  1.00 16.62 ? 204  TYR A CG  1 
+ATOM   1417 C  CD1 . TYR A 1 182 ? -9.357  21.315  28.254  1.00 17.00 ? 204  TYR A CD1 1 
+ATOM   1418 C  CD2 . TYR A 1 182 ? -8.275  21.286  30.362  1.00 15.20 ? 204  TYR A CD2 1 
+ATOM   1419 C  CE1 . TYR A 1 182 ? -10.152 22.347  28.653  1.00 17.84 ? 204  TYR A CE1 1 
+ATOM   1420 C  CE2 . TYR A 1 182 ? -9.089  22.330  30.798  1.00 16.40 ? 204  TYR A CE2 1 
+ATOM   1421 C  CZ  . TYR A 1 182 ? -10.044 22.844  29.931  1.00 16.35 ? 204  TYR A CZ  1 
+ATOM   1422 O  OH  . TYR A 1 182 ? -10.852 23.853  30.285  1.00 17.74 ? 204  TYR A OH  1 
+ATOM   1423 N  N   . LEU A 1 183 ? -6.337  16.761  29.051  1.00 17.53 ? 205  LEU A N   1 
+ATOM   1424 C  CA  . LEU A 1 183 ? -5.423  15.675  28.693  1.00 17.27 ? 205  LEU A CA  1 
+ATOM   1425 C  C   . LEU A 1 183 ? -6.110  14.300  28.534  1.00 16.77 ? 205  LEU A C   1 
+ATOM   1426 O  O   . LEU A 1 183 ? -5.852  13.582  27.569  1.00 20.25 ? 205  LEU A O   1 
+ATOM   1427 C  CB  . LEU A 1 183 ? -4.315  15.596  29.729  1.00 20.32 ? 205  LEU A CB  1 
+ATOM   1428 C  CG  . LEU A 1 183 ? -3.402  16.802  29.761  1.00 22.45 ? 205  LEU A CG  1 
+ATOM   1429 C  CD1 . LEU A 1 183 ? -2.575  16.710  31.038  1.00 27.60 ? 205  LEU A CD1 1 
+ATOM   1430 C  CD2 . LEU A 1 183 ? -2.496  16.887  28.571  1.00 22.40 ? 205  LEU A CD2 1 
+ATOM   1431 N  N   . THR A 1 184 ? -7.005  13.942  29.420  1.00 19.34 ? 206  THR A N   1 
+ATOM   1432 C  CA  . THR A 1 184 ? -7.609  12.616  29.351  1.00 21.15 ? 206  THR A CA  1 
+ATOM   1433 C  C   . THR A 1 184 ? -8.669  12.541  28.302  1.00 22.33 ? 206  THR A C   1 
+ATOM   1434 O  O   . THR A 1 184 ? -8.733  11.588  27.533  1.00 23.62 ? 206  THR A O   1 
+ATOM   1435 C  CB  . THR A 1 184 ? -8.178  12.171  30.681  1.00 26.04 ? 206  THR A CB  1 
+ATOM   1436 O  OG1 . THR A 1 184 ? -9.257  13.019  31.083  1.00 28.54 ? 206  THR A OG1 1 
+ATOM   1437 C  CG2 . THR A 1 184 ? -7.082  12.228  31.712  1.00 23.96 ? 206  THR A CG2 1 
+ATOM   1438 N  N   . GLU A 1 185 ? -9.491  13.572  28.205  1.00 20.84 ? 207  GLU A N   1 
+ATOM   1439 C  CA  . GLU A 1 185 ? -10.558 13.517  27.189  1.00 23.53 ? 207  GLU A CA  1 
+ATOM   1440 C  C   . GLU A 1 185 ? -9.960  13.553  25.772  1.00 21.45 ? 207  GLU A C   1 
+ATOM   1441 O  O   . GLU A 1 185 ? -10.547 12.999  24.838  1.00 22.05 ? 207  GLU A O   1 
+ATOM   1442 C  CB  . GLU A 1 185 ? -11.508 14.701  27.323  1.00 24.48 ? 207  GLU A CB  1 
+ATOM   1443 C  CG  . GLU A 1 185 ? -12.424 14.655  28.528  1.00 28.98 ? 207  GLU A CG  1 
+ATOM   1444 C  CD  . GLU A 1 185 ? -13.282 13.439  28.524  1.00 36.31 ? 207  GLU A CD  1 
+ATOM   1445 O  OE1 . GLU A 1 185 ? -13.752 13.048  27.411  1.00 37.76 ? 207  GLU A OE1 1 
+ATOM   1446 O  OE2 . GLU A 1 185 ? -13.409 12.869  29.650  1.00 40.45 ? 207  GLU A OE2 1 
+ATOM   1447 N  N   . LEU A 1 186 ? -8.812  14.215  25.634  1.00 20.41 ? 208  LEU A N   1 
+ATOM   1448 C  CA  . LEU A 1 186 ? -8.178  14.360  24.314  1.00 18.40 ? 208  LEU A CA  1 
+ATOM   1449 C  C   . LEU A 1 186 ? -7.019  13.379  24.108  1.00 20.34 ? 208  LEU A C   1 
+ATOM   1450 O  O   . LEU A 1 186 ? -6.307  13.469  23.109  1.00 19.24 ? 208  LEU A O   1 
+ATOM   1451 C  CB  . LEU A 1 186 ? -7.798  15.806  24.051  1.00 17.53 ? 208  LEU A CB  1 
+ATOM   1452 C  CG  . LEU A 1 186 ? -8.982  16.759  23.861  1.00 18.88 ? 208  LEU A CG  1 
+ATOM   1453 C  CD1 . LEU A 1 186 ? -8.512  18.168  23.979  1.00 21.43 ? 208  LEU A CD1 1 
+ATOM   1454 C  CD2 . LEU A 1 186 ? -9.684  16.545  22.525  1.00 21.24 ? 208  LEU A CD2 1 
+ATOM   1455 N  N   . ASP A 1 187 ? -6.858  12.385  24.981  1.00 23.26 ? 209  ASP A N   1 
+ATOM   1456 C  CA  A ASP A 1 187 ? -5.861  11.340  24.734  0.62 21.58 ? 209  ASP A CA  1 
+ATOM   1457 C  CA  B ASP A 1 187 ? -5.902  11.312  24.740  0.38 24.63 ? 209  ASP A CA  1 
+ATOM   1458 C  C   . ASP A 1 187 ? -6.154  10.681  23.383  1.00 23.48 ? 209  ASP A C   1 
+ATOM   1459 O  O   . ASP A 1 187 ? -7.260  10.261  23.106  1.00 23.04 ? 209  ASP A O   1 
+ATOM   1460 C  CB  A ASP A 1 187 ? -5.824  10.242  25.817  0.62 22.40 ? 209  ASP A CB  1 
+ATOM   1461 C  CB  B ASP A 1 187 ? -6.056  10.224  25.783  0.38 28.95 ? 209  ASP A CB  1 
+ATOM   1462 C  CG  A ASP A 1 187 ? -4.851  10.552  27.013  0.62 24.21 ? 209  ASP A CG  1 
+ATOM   1463 C  CG  B ASP A 1 187 ? -4.742  9.830   26.419  0.38 32.35 ? 209  ASP A CG  1 
+ATOM   1464 O  OD1 A ASP A 1 187 ? -3.795  11.185  26.803  0.62 24.99 ? 209  ASP A OD1 1 
+ATOM   1465 O  OD1 B ASP A 1 187 ? -4.149  10.638  27.165  0.38 33.08 ? 209  ASP A OD1 1 
+ATOM   1466 O  OD2 A ASP A 1 187 ? -5.121  10.146  28.185  0.62 23.73 ? 209  ASP A OD2 1 
+ATOM   1467 O  OD2 B ASP A 1 187 ? -4.318  8.688   26.232  0.38 35.05 ? 209  ASP A OD2 1 
+ATOM   1468 N  N   . GLY A 1 188 ? -5.160  10.634  22.521  1.00 24.54 ? 210  GLY A N   1 
+ATOM   1469 C  CA  . GLY A 1 188 ? -5.367  10.080  21.197  1.00 25.20 ? 210  GLY A CA  1 
+ATOM   1470 C  C   . GLY A 1 188 ? -5.651  11.138  20.163  1.00 24.93 ? 210  GLY A C   1 
+ATOM   1471 O  O   . GLY A 1 188 ? -5.543  10.885  18.935  1.00 28.94 ? 210  GLY A O   1 
+ATOM   1472 N  N   . TYR A 1 189 ? -6.148  12.275  20.608  1.00 22.57 ? 211  TYR A N   1 
+ATOM   1473 C  CA  . TYR A 1 189 ? -6.486  13.387  19.715  1.00 20.56 ? 211  TYR A CA  1 
+ATOM   1474 C  C   . TYR A 1 189 ? -5.367  14.411  19.624  1.00 19.33 ? 211  TYR A C   1 
+ATOM   1475 O  O   . TYR A 1 189 ? -5.221  15.123  18.612  1.00 20.84 ? 211  TYR A O   1 
+ATOM   1476 C  CB  . TYR A 1 189 ? -7.788  14.077  20.187  1.00 20.53 ? 211  TYR A CB  1 
+ATOM   1477 C  CG  . TYR A 1 189 ? -9.069  13.291  20.016  1.00 21.31 ? 211  TYR A CG  1 
+ATOM   1478 C  CD1 . TYR A 1 189 ? -9.924  13.502  18.922  1.00 23.73 ? 211  TYR A CD1 1 
+ATOM   1479 C  CD2 . TYR A 1 189 ? -9.497  12.405  20.985  1.00 23.87 ? 211  TYR A CD2 1 
+ATOM   1480 C  CE1 . TYR A 1 189 ? -11.098 12.770  18.771  1.00 27.23 ? 211  TYR A CE1 1 
+ATOM   1481 C  CE2 . TYR A 1 189 ? -10.682 11.683  20.845  1.00 27.89 ? 211  TYR A CE2 1 
+ATOM   1482 C  CZ  . TYR A 1 189 ? -11.487 11.897  19.735  1.00 29.08 ? 211  TYR A CZ  1 
+ATOM   1483 O  OH  . TYR A 1 189 ? -12.666 11.187  19.533  1.00 31.41 ? 211  TYR A OH  1 
+ATOM   1484 N  N   . TYR A 1 190 ? -4.635  14.598  20.717  1.00 17.15 ? 212  TYR A N   1 
+ATOM   1485 C  CA  . TYR A 1 190 ? -3.631  15.639  20.725  1.00 16.81 ? 212  TYR A CA  1 
+ATOM   1486 C  C   . TYR A 1 190 ? -2.344  15.152  20.135  1.00 16.16 ? 212  TYR A C   1 
+ATOM   1487 O  O   . TYR A 1 190 ? -2.021  13.951  20.241  1.00 17.64 ? 212  TYR A O   1 
+ATOM   1488 C  CB  . TYR A 1 190 ? -3.443  16.260  22.118  1.00 17.16 ? 212  TYR A CB  1 
+ATOM   1489 C  CG  . TYR A 1 190 ? -2.747  15.429  23.202  1.00 17.81 ? 212  TYR A CG  1 
+ATOM   1490 C  CD1 . TYR A 1 190 ? -1.358  15.256  23.184  1.00 16.96 ? 212  TYR A CD1 1 
+ATOM   1491 C  CD2 . TYR A 1 190 ? -3.441  14.905  24.295  1.00 15.36 ? 212  TYR A CD2 1 
+ATOM   1492 C  CE1 . TYR A 1 190 ? -0.728  14.583  24.169  1.00 17.01 ? 212  TYR A CE1 1 
+ATOM   1493 C  CE2 . TYR A 1 190 ? -2.793  14.203  25.276  1.00 17.75 ? 212  TYR A CE2 1 
+ATOM   1494 C  CZ  . TYR A 1 190 ? -1.437  14.062  25.232  1.00 18.42 ? 212  TYR A CZ  1 
+ATOM   1495 O  OH  . TYR A 1 190 ? -0.758  13.409  26.239  1.00 20.56 ? 212  TYR A OH  1 
+ATOM   1496 N  N   . ASP A 1 191 ? -1.672  16.078  19.427  1.00 13.52 ? 213  ASP A N   1 
+ATOM   1497 C  CA  . ASP A 1 191 ? -0.376  15.790  18.779  1.00 13.89 ? 213  ASP A CA  1 
+ATOM   1498 C  C   . ASP A 1 191 ? 0.801   15.866  19.702  1.00 13.63 ? 213  ASP A C   1 
+ATOM   1499 O  O   . ASP A 1 191 ? 1.710   15.063  19.598  1.00 15.72 ? 213  ASP A O   1 
+ATOM   1500 C  CB  . ASP A 1 191 ? -0.240  16.719  17.552  1.00 15.23 ? 213  ASP A CB  1 
+ATOM   1501 C  CG  . ASP A 1 191 ? -1.302  16.382  16.532  1.00 16.64 ? 213  ASP A CG  1 
+ATOM   1502 O  OD1 . ASP A 1 191 ? -0.942  15.574  15.626  1.00 23.03 ? 213  ASP A OD1 1 
+ATOM   1503 O  OD2 . ASP A 1 191 ? -2.490  16.778  16.642  1.00 16.53 ? 213  ASP A OD2 1 
+ATOM   1504 N  N   . PHE A 1 192 ? 0.811   16.922  20.526  1.00 13.64 ? 214  PHE A N   1 
+ATOM   1505 C  CA  . PHE A 1 192 ? 1.840   17.069  21.565  1.00 14.16 ? 214  PHE A CA  1 
+ATOM   1506 C  C   . PHE A 1 192 ? 1.383   18.160  22.514  1.00 11.63 ? 214  PHE A C   1 
+ATOM   1507 O  O   . PHE A 1 192 ? 0.481   18.977  22.207  1.00 14.11 ? 214  PHE A O   1 
+ATOM   1508 C  CB  . PHE A 1 192 ? 3.245   17.395  20.971  1.00 13.70 ? 214  PHE A CB  1 
+ATOM   1509 C  CG  . PHE A 1 192 ? 3.289   18.549  19.961  1.00 14.05 ? 214  PHE A CG  1 
+ATOM   1510 C  CD1 . PHE A 1 192 ? 3.336   19.872  20.355  1.00 14.65 ? 214  PHE A CD1 1 
+ATOM   1511 C  CD2 . PHE A 1 192 ? 3.251   18.283  18.601  1.00 15.12 ? 214  PHE A CD2 1 
+ATOM   1512 C  CE1 . PHE A 1 192 ? 3.407   20.880  19.378  1.00 15.14 ? 214  PHE A CE1 1 
+ATOM   1513 C  CE2 . PHE A 1 192 ? 3.276   19.256  17.656  1.00 16.66 ? 214  PHE A CE2 1 
+ATOM   1514 C  CZ  . PHE A 1 192 ? 3.333   20.549  18.028  1.00 15.16 ? 214  PHE A CZ  1 
+ATOM   1515 N  N   . ILE A 1 193 ? 1.996   18.172  23.685  1.00 13.65 ? 215  ILE A N   1 
+ATOM   1516 C  CA  . ILE A 1 193 ? 1.746   19.173  24.675  1.00 11.65 ? 215  ILE A CA  1 
+ATOM   1517 C  C   . ILE A 1 193 ? 3.041   19.918  24.818  1.00 11.30 ? 215  ILE A C   1 
+ATOM   1518 O  O   . ILE A 1 193 ? 4.126   19.301  24.923  1.00 12.24 ? 215  ILE A O   1 
+ATOM   1519 C  CB  . ILE A 1 193 ? 1.415   18.516  26.054  1.00 13.57 ? 215  ILE A CB  1 
+ATOM   1520 C  CG1 . ILE A 1 193 ? 0.314   17.448  25.925  1.00 14.77 ? 215  ILE A CG1 1 
+ATOM   1521 C  CG2 . ILE A 1 193 ? 1.033   19.543  27.049  1.00 14.28 ? 215  ILE A CG2 1 
+ATOM   1522 C  CD1 . ILE A 1 193 ? -0.998  17.983  25.370  1.00 14.36 ? 215  ILE A CD1 1 
+ATOM   1523 N  N   . ASN A 1 194 ? 2.968   21.244  24.853  1.00 10.62 ? 216  ASN A N   1 
+ATOM   1524 C  CA  . ASN A 1 194 ? 4.130   22.076  25.169  1.00 12.48 ? 216  ASN A CA  1 
+ATOM   1525 C  C   . ASN A 1 194 ? 3.888   22.903  26.436  1.00 10.60 ? 216  ASN A C   1 
+ATOM   1526 O  O   . ASN A 1 194 ? 3.456   24.046  26.418  1.00 11.37 ? 216  ASN A O   1 
+ATOM   1527 C  CB  . ASN A 1 194 ? 4.517   23.011  23.999  1.00 12.71 ? 216  ASN A CB  1 
+ATOM   1528 C  CG  . ASN A 1 194 ? 3.341   23.549  23.161  1.00 12.28 ? 216  ASN A CG  1 
+ATOM   1529 O  OD1 . ASN A 1 194 ? 3.248   23.182  21.950  1.00 16.08 ? 216  ASN A OD1 1 
+ATOM   1530 N  ND2 . ASN A 1 194 ? 2.567   24.438  23.682  1.00 14.55 ? 216  ASN A ND2 1 
+ATOM   1531 N  N   . PRO A 1 195 ? 4.053   22.228  27.592  1.00 11.33 ? 217  PRO A N   1 
+ATOM   1532 C  CA  . PRO A 1 195 ? 3.830   23.016  28.836  1.00 11.30 ? 217  PRO A CA  1 
+ATOM   1533 C  C   . PRO A 1 195 ? 4.772   24.179  28.972  1.00 11.62 ? 217  PRO A C   1 
+ATOM   1534 O  O   . PRO A 1 195 ? 5.868   24.181  28.402  1.00 11.99 ? 217  PRO A O   1 
+ATOM   1535 C  CB  . PRO A 1 195 ? 4.148   21.976  29.969  1.00 11.97 ? 217  PRO A CB  1 
+ATOM   1536 C  CG  . PRO A 1 195 ? 4.087   20.612  29.271  1.00 12.99 ? 217  PRO A CG  1 
+ATOM   1537 C  CD  . PRO A 1 195 ? 4.636   20.910  27.852  1.00 12.56 ? 217  PRO A CD  1 
+ATOM   1538 N  N   . GLN A 1 196 ? 4.344   25.151  29.774  1.00 10.83 ? 218  GLN A N   1 
+ATOM   1539 C  CA  . GLN A 1 196 ? 5.147   26.339  30.060  1.00 11.56 ? 218  GLN A CA  1 
+ATOM   1540 C  C   . GLN A 1 196 ? 5.989   26.053  31.301  1.00 12.58 ? 218  GLN A C   1 
+ATOM   1541 O  O   . GLN A 1 196 ? 5.431   25.865  32.420  1.00 14.47 ? 218  GLN A O   1 
+ATOM   1542 C  CB  . GLN A 1 196 ? 4.227   27.558  30.295  1.00 11.34 ? 218  GLN A CB  1 
+ATOM   1543 C  CG  . GLN A 1 196 ? 3.327   27.819  29.119  1.00 12.79 ? 218  GLN A CG  1 
+ATOM   1544 C  CD  . GLN A 1 196 ? 2.477   29.026  29.341  1.00 12.94 ? 218  GLN A CD  1 
+ATOM   1545 O  OE1 . GLN A 1 196 ? 2.977   30.079  29.782  1.00 14.02 ? 218  GLN A OE1 1 
+ATOM   1546 N  NE2 . GLN A 1 196 ? 1.173   28.860  29.153  1.00 14.03 ? 218  GLN A NE2 1 
+ATOM   1547 N  N   . PHE A 1 197 ? 7.296   26.087  31.155  1.00 13.89 ? 219  PHE A N   1 
+ATOM   1548 C  CA  . PHE A 1 197 ? 8.188   25.913  32.285  1.00 12.92 ? 219  PHE A CA  1 
+ATOM   1549 C  C   . PHE A 1 197 ? 8.795   27.286  32.630  1.00 13.76 ? 219  PHE A C   1 
+ATOM   1550 O  O   . PHE A 1 197 ? 10.011  27.473  32.772  1.00 14.05 ? 219  PHE A O   1 
+ATOM   1551 C  CB  . PHE A 1 197 ? 9.233   24.828  31.960  1.00 13.95 ? 219  PHE A CB  1 
+ATOM   1552 C  CG  . PHE A 1 197 ? 8.639   23.501  31.686  1.00 12.64 ? 219  PHE A CG  1 
+ATOM   1553 C  CD1 . PHE A 1 197 ? 8.284   22.681  32.744  1.00 12.91 ? 219  PHE A CD1 1 
+ATOM   1554 C  CD2 . PHE A 1 197 ? 8.415   23.050  30.372  1.00 12.67 ? 219  PHE A CD2 1 
+ATOM   1555 C  CE1 . PHE A 1 197 ? 7.780   21.444  32.523  1.00 12.51 ? 219  PHE A CE1 1 
+ATOM   1556 C  CE2 . PHE A 1 197 ? 7.834   21.833  30.181  1.00 13.85 ? 219  PHE A CE2 1 
+ATOM   1557 C  CZ  . PHE A 1 197 ? 7.540   21.019  31.238  1.00 16.03 ? 219  PHE A CZ  1 
+ATOM   1558 N  N   . TYR A 1 198 ? 7.916   28.254  32.754  1.00 14.52 ? 220  TYR A N   1 
+ATOM   1559 C  CA  . TYR A 1 198 ? 8.282   29.654  33.036  1.00 13.03 ? 220  TYR A CA  1 
+ATOM   1560 C  C   . TYR A 1 198 ? 7.151   30.385  33.733  1.00 13.89 ? 220  TYR A C   1 
+ATOM   1561 O  O   . TYR A 1 198 ? 6.050   29.869  33.748  1.00 12.89 ? 220  TYR A O   1 
+ATOM   1562 C  CB  . TYR A 1 198 ? 8.720   30.351  31.731  1.00 12.96 ? 220  TYR A CB  1 
+ATOM   1563 C  CG  . TYR A 1 198 ? 7.753   30.300  30.535  1.00 12.80 ? 220  TYR A CG  1 
+ATOM   1564 C  CD1 . TYR A 1 198 ? 6.788   31.312  30.319  1.00 12.68 ? 220  TYR A CD1 1 
+ATOM   1565 C  CD2 . TYR A 1 198 ? 7.836   29.237  29.611  1.00 13.00 ? 220  TYR A CD2 1 
+ATOM   1566 C  CE1 . TYR A 1 198 ? 5.956   31.282  29.244  1.00 12.28 ? 220  TYR A CE1 1 
+ATOM   1567 C  CE2 . TYR A 1 198 ? 6.986   29.237  28.492  1.00 13.57 ? 220  TYR A CE2 1 
+ATOM   1568 C  CZ  . TYR A 1 198 ? 6.053   30.221  28.328  1.00 12.59 ? 220  TYR A CZ  1 
+ATOM   1569 O  OH  . TYR A 1 198 ? 5.193   30.134  27.224  1.00 13.27 ? 220  TYR A OH  1 
+ATOM   1570 N  N   . ASN A 1 199 ? 7.504   31.511  34.385  1.00 13.81 ? 221  ASN A N   1 
+ATOM   1571 C  CA  . ASN A 1 199 ? 6.546   32.346  35.155  1.00 14.23 ? 221  ASN A CA  1 
+ATOM   1572 C  C   . ASN A 1 199 ? 5.995   31.662  36.428  1.00 14.67 ? 221  ASN A C   1 
+ATOM   1573 O  O   . ASN A 1 199 ? 5.015   32.132  36.981  1.00 16.51 ? 221  ASN A O   1 
+ATOM   1574 C  CB  . ASN A 1 199 ? 5.399   32.867  34.277  1.00 14.73 ? 221  ASN A CB  1 
+ATOM   1575 C  CG  . ASN A 1 199 ? 5.838   33.963  33.369  1.00 15.00 ? 221  ASN A CG  1 
+ATOM   1576 O  OD1 . ASN A 1 199 ? 6.627   34.856  33.768  1.00 15.68 ? 221  ASN A OD1 1 
+ATOM   1577 N  ND2 . ASN A 1 199 ? 5.323   33.930  32.121  1.00 15.68 ? 221  ASN A ND2 1 
+ATOM   1578 N  N   . GLN A 1 200 ? 6.687   30.595  36.906  1.00 14.67 ? 222  GLN A N   1 
+ATOM   1579 C  CA  . GLN A 1 200 ? 6.229   29.942  38.115  1.00 14.04 ? 222  GLN A CA  1 
+ATOM   1580 C  C   . GLN A 1 200 ? 7.189   30.104  39.271  1.00 15.65 ? 222  GLN A C   1 
+ATOM   1581 O  O   . GLN A 1 200 ? 7.003   29.498  40.337  1.00 17.05 ? 222  GLN A O   1 
+ATOM   1582 C  CB  . GLN A 1 200 ? 6.065   28.464  37.871  1.00 14.08 ? 222  GLN A CB  1 
+ATOM   1583 C  CG  . GLN A 1 200 ? 5.316   28.172  36.582  1.00 15.07 ? 222  GLN A CG  1 
+ATOM   1584 C  CD  . GLN A 1 200 ? 3.938   28.830  36.531  1.00 15.45 ? 222  GLN A CD  1 
+ATOM   1585 O  OE1 . GLN A 1 200 ? 3.186   28.799  37.491  1.00 17.41 ? 222  GLN A OE1 1 
+ATOM   1586 N  NE2 . GLN A 1 200 ? 3.558   29.380  35.327  1.00 14.77 ? 222  GLN A NE2 1 
+ATOM   1587 N  N   . GLY A 1 201 ? 8.184   30.962  39.123  1.00 17.40 ? 223  GLY A N   1 
+ATOM   1588 C  CA  . GLY A 1 201 ? 9.025   31.288  40.294  1.00 16.34 ? 223  GLY A CA  1 
+ATOM   1589 C  C   . GLY A 1 201 ? 9.680   30.078  40.899  1.00 17.91 ? 223  GLY A C   1 
+ATOM   1590 O  O   . GLY A 1 201 ? 10.312  29.314  40.235  1.00 18.16 ? 223  GLY A O   1 
+ATOM   1591 N  N   . GLY A 1 202 ? 9.532   29.972  42.224  1.00 18.84 ? 224  GLY A N   1 
+ATOM   1592 C  CA  . GLY A 1 202 ? 10.109  28.872  42.948  1.00 16.77 ? 224  GLY A CA  1 
+ATOM   1593 C  C   . GLY A 1 202 ? 9.397   27.552  42.984  1.00 17.40 ? 224  GLY A C   1 
+ATOM   1594 O  O   . GLY A 1 202 ? 9.802   26.602  43.670  1.00 21.10 ? 224  GLY A O   1 
+ATOM   1595 N  N   . ASP A 1 203 ? 8.331   27.442  42.199  1.00 16.75 ? 225  ASP A N   1 
+ATOM   1596 C  CA  . ASP A 1 203 ? 7.643   26.182  42.067  1.00 17.15 ? 225  ASP A CA  1 
+ATOM   1597 C  C   . ASP A 1 203 ? 8.522   25.174  41.371  1.00 16.51 ? 225  ASP A C   1 
+ATOM   1598 O  O   . ASP A 1 203 ? 9.472   25.571  40.708  1.00 18.88 ? 225  ASP A O   1 
+ATOM   1599 C  CB  . ASP A 1 203 ? 6.370   26.364  41.294  1.00 17.73 ? 225  ASP A CB  1 
+ATOM   1600 C  CG  . ASP A 1 203 ? 5.323   25.420  41.674  1.00 23.13 ? 225  ASP A CG  1 
+ATOM   1601 O  OD1 . ASP A 1 203 ? 5.602   24.340  42.366  1.00 23.59 ? 225  ASP A OD1 1 
+ATOM   1602 O  OD2 . ASP A 1 203 ? 4.190   25.806  41.359  1.00 24.70 ? 225  ASP A OD2 1 
+ATOM   1603 N  N   . GLY A 1 204 ? 8.220   23.891  41.507  1.00 18.07 ? 226  GLY A N   1 
+ATOM   1604 C  CA  . GLY A 1 204 ? 9.103   22.868  40.978  1.00 19.62 ? 226  GLY A CA  1 
+ATOM   1605 C  C   . GLY A 1 204 ? 8.654   21.526  41.524  1.00 21.88 ? 226  GLY A C   1 
+ATOM   1606 O  O   . GLY A 1 204 ? 7.442   21.260  41.598  1.00 22.20 ? 226  GLY A O   1 
+ATOM   1607 N  N   . LEU A 1 205 ? 9.598   20.671  41.884  1.00 22.10 ? 227  LEU A N   1 
+ATOM   1608 C  CA  . LEU A 1 205 ? 9.243   19.339  42.349  1.00 23.45 ? 227  LEU A CA  1 
+ATOM   1609 C  C   . LEU A 1 205 ? 10.315  18.843  43.287  1.00 25.67 ? 227  LEU A C   1 
+ATOM   1610 O  O   . LEU A 1 205 ? 11.477  19.292  43.253  1.00 27.26 ? 227  LEU A O   1 
+ATOM   1611 C  CB  . LEU A 1 205 ? 9.068   18.354  41.187  1.00 24.16 ? 227  LEU A CB  1 
+ATOM   1612 C  CG  . LEU A 1 205 ? 10.311  17.851  40.441  1.00 24.54 ? 227  LEU A CG  1 
+ATOM   1613 C  CD1 . LEU A 1 205 ? 9.992   16.669  39.486  1.00 26.34 ? 227  LEU A CD1 1 
+ATOM   1614 C  CD2 . LEU A 1 205 ? 10.939  18.943  39.681  1.00 27.80 ? 227  LEU A CD2 1 
+ATOM   1615 N  N   . TRP A 1 206 ? 9.834   17.904  44.103  1.00 28.38 ? 228  TRP A N   1 
+ATOM   1616 C  CA  . TRP A 1 206 ? 10.654  17.234  45.094  1.00 29.21 ? 228  TRP A CA  1 
+ATOM   1617 C  C   . TRP A 1 206 ? 11.110  15.898  44.545  1.00 31.97 ? 228  TRP A C   1 
+ATOM   1618 O  O   . TRP A 1 206 ? 10.273  15.064  44.133  1.00 32.91 ? 228  TRP A O   1 
+ATOM   1619 C  CB  . TRP A 1 206 ? 9.820   16.960  46.353  1.00 29.05 ? 228  TRP A CB  1 
+ATOM   1620 C  CG  . TRP A 1 206 ? 10.598  16.205  47.359  1.00 30.91 ? 228  TRP A CG  1 
+ATOM   1621 C  CD1 . TRP A 1 206 ? 10.575  14.822  47.623  1.00 33.78 ? 228  TRP A CD1 1 
+ATOM   1622 C  CD2 . TRP A 1 206 ? 11.551  16.764  48.261  1.00 29.26 ? 228  TRP A CD2 1 
+ATOM   1623 N  NE1 . TRP A 1 206 ? 11.445  14.539  48.651  1.00 33.69 ? 228  TRP A NE1 1 
+ATOM   1624 C  CE2 . TRP A 1 206 ? 12.069  15.701  49.039  1.00 30.99 ? 228  TRP A CE2 1 
+ATOM   1625 C  CE3 . TRP A 1 206 ? 12.039  18.067  48.470  1.00 28.65 ? 228  TRP A CE3 1 
+ATOM   1626 C  CZ2 . TRP A 1 206 ? 13.044  15.913  50.004  1.00 30.54 ? 228  TRP A CZ2 1 
+ATOM   1627 C  CZ3 . TRP A 1 206 ? 12.991  18.275  49.453  1.00 29.43 ? 228  TRP A CZ3 1 
+ATOM   1628 C  CH2 . TRP A 1 206 ? 13.487  17.208  50.195  1.00 30.22 ? 228  TRP A CH2 1 
+ATOM   1629 N  N   . ILE A 1 207 ? 12.413  15.728  44.496  1.00 29.80 ? 229  ILE A N   1 
+ATOM   1630 C  CA  . ILE A 1 207 ? 12.994  14.468  44.061  1.00 33.78 ? 229  ILE A CA  1 
+ATOM   1631 C  C   . ILE A 1 207 ? 13.473  13.671  45.288  1.00 39.22 ? 229  ILE A C   1 
+ATOM   1632 O  O   . ILE A 1 207 ? 14.434  14.123  45.926  1.00 38.89 ? 229  ILE A O   1 
+ATOM   1633 C  CB  . ILE A 1 207 ? 14.135  14.743  43.072  1.00 33.16 ? 229  ILE A CB  1 
+ATOM   1634 C  CG1 . ILE A 1 207 ? 13.707  15.586  41.856  1.00 30.53 ? 229  ILE A CG1 1 
+ATOM   1635 C  CG2 . ILE A 1 207 ? 14.609  13.413  42.534  1.00 36.42 ? 229  ILE A CG2 1 
+ATOM   1636 C  CD1 . ILE A 1 207 ? 12.557  15.006  41.212  1.00 30.82 ? 229  ILE A CD1 1 
+ATOM   1637 N  N   . GLU A 1 208 ? 12.826  12.527  45.605  1.00 41.80 ? 230  GLU A N   1 
+ATOM   1638 C  CA  . GLU A 1 208 ? 13.230  11.744  46.817  1.00 46.23 ? 230  GLU A CA  1 
+ATOM   1639 C  C   . GLU A 1 208 ? 14.738  11.453  46.645  1.00 47.75 ? 230  GLU A C   1 
+ATOM   1640 O  O   . GLU A 1 208 ? 15.104  10.882  45.677  1.00 45.98 ? 230  GLU A O   1 
+ATOM   1641 C  CB  . GLU A 1 208 ? 12.336  10.465  47.018  1.00 47.13 ? 230  GLU A CB  1 
+ATOM   1642 C  CG  . GLU A 1 208 ? 10.832  10.777  47.565  1.00 48.01 ? 230  GLU A CG  1 
+ATOM   1643 C  CD  . GLU A 1 208 ? 9.851   9.534   47.670  1.00 48.23 ? 230  GLU A CD  1 
+ATOM   1644 O  OE1 . GLU A 1 208 ? 9.227   9.181   46.617  1.00 51.14 ? 230  GLU A OE1 1 
+ATOM   1645 O  OE2 . GLU A 1 208 ? 9.653   8.946   48.802  1.00 44.95 ? 230  GLU A OE2 1 
+ATOM   1646 N  N   . GLY A 1 209 ? 15.607  11.922  47.562  1.00 52.45 ? 231  GLY A N   1 
+ATOM   1647 C  CA  . GLY A 1 209 ? 17.057  11.819  47.339  1.00 54.83 ? 231  GLY A CA  1 
+ATOM   1648 C  C   . GLY A 1 209 ? 17.874  12.992  46.709  1.00 56.05 ? 231  GLY A C   1 
+ATOM   1649 O  O   . GLY A 1 209 ? 19.100  12.931  46.769  1.00 56.23 ? 231  GLY A O   1 
+ATOM   1650 N  N   . VAL A 1 210 ? 17.283  14.045  46.138  1.00 55.51 ? 232  VAL A N   1 
+ATOM   1651 C  CA  . VAL A 1 210 ? 18.090  15.243  45.737  1.00 52.90 ? 232  VAL A CA  1 
+ATOM   1652 C  C   . VAL A 1 210 ? 17.512  16.559  46.300  1.00 50.94 ? 232  VAL A C   1 
+ATOM   1653 O  O   . VAL A 1 210 ? 18.226  17.589  46.375  1.00 52.50 ? 232  VAL A O   1 
+ATOM   1654 C  CB  . VAL A 1 210 ? 18.277  15.376  44.200  1.00 53.79 ? 232  VAL A CB  1 
+ATOM   1655 C  CG1 . VAL A 1 210 ? 17.142  14.791  43.463  1.00 55.54 ? 232  VAL A CG1 1 
+ATOM   1656 C  CG2 . VAL A 1 210 ? 18.462  16.864  43.734  1.00 52.21 ? 232  VAL A CG2 1 
+ATOM   1657 N  N   . GLY A 1 211 ? 16.221  16.553  46.653  1.00 43.75 ? 233  GLY A N   1 
+ATOM   1658 C  CA  . GLY A 1 211 ? 15.625  17.711  47.276  1.00 35.64 ? 233  GLY A CA  1 
+ATOM   1659 C  C   . GLY A 1 211 ? 14.688  18.442  46.322  1.00 30.16 ? 233  GLY A C   1 
+ATOM   1660 O  O   . GLY A 1 211 ? 14.249  17.819  45.294  1.00 32.14 ? 233  GLY A O   1 
+ATOM   1661 N  N   . TRP A 1 212 ? 14.425  19.728  46.640  1.00 27.20 ? 234  TRP A N   1 
+ATOM   1662 C  CA  . TRP A 1 212 ? 13.517  20.570  45.850  1.00 22.33 ? 234  TRP A CA  1 
+ATOM   1663 C  C   . TRP A 1 212 ? 14.306  21.186  44.726  1.00 23.59 ? 234  TRP A C   1 
+ATOM   1664 O  O   . TRP A 1 212 ? 15.353  21.817  44.881  1.00 24.75 ? 234  TRP A O   1 
+ATOM   1665 C  CB  . TRP A 1 212 ? 12.940  21.680  46.725  1.00 22.32 ? 234  TRP A CB  1 
+ATOM   1666 C  CG  . TRP A 1 212 ? 11.868  22.468  46.064  1.00 21.19 ? 234  TRP A CG  1 
+ATOM   1667 C  CD1 . TRP A 1 212 ? 11.957  23.729  45.590  1.00 21.33 ? 234  TRP A CD1 1 
+ATOM   1668 C  CD2 . TRP A 1 212 ? 10.546  22.038  45.846  1.00 19.50 ? 234  TRP A CD2 1 
+ATOM   1669 N  NE1 . TRP A 1 212 ? 10.772  24.098  44.964  1.00 21.80 ? 234  TRP A NE1 1 
+ATOM   1670 C  CE2 . TRP A 1 212 ? 9.879   23.068  45.150  1.00 20.87 ? 234  TRP A CE2 1 
+ATOM   1671 C  CE3 . TRP A 1 212 ? 9.872   20.871  46.093  1.00 20.60 ? 234  TRP A CE3 1 
+ATOM   1672 C  CZ2 . TRP A 1 212 ? 8.571   22.964  44.786  1.00 19.38 ? 234  TRP A CZ2 1 
+ATOM   1673 C  CZ3 . TRP A 1 212 ? 8.553   20.779  45.697  1.00 19.19 ? 234  TRP A CZ3 1 
+ATOM   1674 C  CH2 . TRP A 1 212 ? 7.928   21.799  45.036  1.00 19.68 ? 234  TRP A CH2 1 
+ATOM   1675 N  N   . ILE A 1 213 ? 13.736  21.029  43.523  1.00 23.76 ? 235  ILE A N   1 
+ATOM   1676 C  CA  . ILE A 1 213 ? 14.368  21.602  42.323  1.00 23.42 ? 235  ILE A CA  1 
+ATOM   1677 C  C   . ILE A 1 213 ? 13.368  22.567  41.713  1.00 23.19 ? 235  ILE A C   1 
+ATOM   1678 O  O   . ILE A 1 213 ? 12.264  22.188  41.275  1.00 24.65 ? 235  ILE A O   1 
+ATOM   1679 C  CB  . ILE A 1 213 ? 14.757  20.533  41.350  1.00 24.94 ? 235  ILE A CB  1 
+ATOM   1680 C  CG1 . ILE A 1 213 ? 15.776  19.575  41.987  1.00 27.61 ? 235  ILE A CG1 1 
+ATOM   1681 C  CG2 . ILE A 1 213 ? 15.364  21.237  40.097  1.00 26.09 ? 235  ILE A CG2 1 
+ATOM   1682 C  CD1 . ILE A 1 213 ? 16.204  18.433  41.112  1.00 32.06 ? 235  ILE A CD1 1 
+ATOM   1683 N  N   . ALA A 1 214 ? 13.712  23.832  41.806  1.00 21.87 ? 236  ALA A N   1 
+ATOM   1684 C  CA  . ALA A 1 214 ? 12.806  24.935  41.396  1.00 19.72 ? 236  ALA A CA  1 
+ATOM   1685 C  C   . ALA A 1 214 ? 13.040  25.395  39.954  1.00 18.35 ? 236  ALA A C   1 
+ATOM   1686 O  O   . ALA A 1 214 ? 14.145  25.339  39.422  1.00 19.59 ? 236  ALA A O   1 
+ATOM   1687 C  CB  . ALA A 1 214 ? 12.972  26.159  42.323  1.00 22.45 ? 236  ALA A CB  1 
+ATOM   1688 N  N   . GLN A 1 215 ? 11.948  25.828  39.353  1.00 16.89 ? 237  GLN A N   1 
+ATOM   1689 C  CA  . GLN A 1 215 ? 11.989  26.414  37.989  1.00 16.90 ? 237  GLN A CA  1 
+ATOM   1690 C  C   . GLN A 1 215 ? 12.817  27.708  37.867  1.00 16.34 ? 237  GLN A C   1 
+ATOM   1691 O  O   . GLN A 1 215 ? 13.230  28.071  36.746  1.00 19.00 ? 237  GLN A O   1 
+ATOM   1692 C  CB  . GLN A 1 215 ? 10.573  26.671  37.572  1.00 15.54 ? 237  GLN A CB  1 
+ATOM   1693 C  CG  . GLN A 1 215 ? 10.416  27.179  36.128  1.00 14.98 ? 237  GLN A CG  1 
+ATOM   1694 C  CD  . GLN A 1 215 ? 9.788   28.566  36.101  1.00 14.79 ? 237  GLN A CD  1 
+ATOM   1695 O  OE1 . GLN A 1 215 ? 8.577   28.721  35.996  1.00 15.39 ? 237  GLN A OE1 1 
+ATOM   1696 N  NE2 . GLN A 1 215 ? 10.605  29.575  36.226  1.00 15.58 ? 237  GLN A NE2 1 
+ATOM   1697 N  N   . ASN A 1 216 ? 13.110  28.382  39.007  1.00 18.15 ? 238  ASN A N   1 
+ATOM   1698 C  CA  . ASN A 1 216 ? 13.886  29.614  38.966  1.00 19.19 ? 238  ASN A CA  1 
+ATOM   1699 C  C   . ASN A 1 216 ? 15.305  29.398  39.534  1.00 21.23 ? 238  ASN A C   1 
+ATOM   1700 O  O   . ASN A 1 216 ? 16.044  30.353  39.804  1.00 23.13 ? 238  ASN A O   1 
+ATOM   1701 C  CB  . ASN A 1 216 ? 13.163  30.777  39.677  1.00 20.34 ? 238  ASN A CB  1 
+ATOM   1702 C  CG  . ASN A 1 216 ? 13.094  30.561  41.153  1.00 22.74 ? 238  ASN A CG  1 
+ATOM   1703 O  OD1 . ASN A 1 216 ? 13.390  29.462  41.656  1.00 22.00 ? 238  ASN A OD1 1 
+ATOM   1704 N  ND2 . ASN A 1 216 ? 12.640  31.608  41.856  1.00 25.37 ? 238  ASN A ND2 1 
+ATOM   1705 N  N   . ASN A 1 217 ? 15.688  28.141  39.697  1.00 19.48 ? 239  ASN A N   1 
+ATOM   1706 C  CA  . ASN A 1 217 ? 17.031  27.825  40.153  1.00 19.74 ? 239  ASN A CA  1 
+ATOM   1707 C  C   . ASN A 1 217 ? 17.983  27.674  38.973  1.00 21.33 ? 239  ASN A C   1 
+ATOM   1708 O  O   . ASN A 1 217 ? 17.992  26.657  38.327  1.00 21.14 ? 239  ASN A O   1 
+ATOM   1709 C  CB  . ASN A 1 217 ? 17.014  26.533  41.006  1.00 22.26 ? 239  ASN A CB  1 
+ATOM   1710 C  CG  . ASN A 1 217 ? 18.335  26.253  41.679  1.00 25.11 ? 239  ASN A CG  1 
+ATOM   1711 O  OD1 . ASN A 1 217 ? 19.400  26.665  41.184  1.00 27.24 ? 239  ASN A OD1 1 
+ATOM   1712 N  ND2 . ASN A 1 217 ? 18.286  25.469  42.765  1.00 29.42 ? 239  ASN A ND2 1 
+ATOM   1713 N  N   . ASP A 1 218 ? 18.807  28.667  38.740  1.00 21.90 ? 240  ASP A N   1 
+ATOM   1714 C  CA  . ASP A 1 218 ? 19.723  28.641  37.608  1.00 21.94 ? 240  ASP A CA  1 
+ATOM   1715 C  C   . ASP A 1 218 ? 20.960  27.811  37.835  1.00 23.87 ? 240  ASP A C   1 
+ATOM   1716 O  O   . ASP A 1 218 ? 21.628  27.479  36.864  1.00 32.13 ? 240  ASP A O   1 
+ATOM   1717 C  CB  . ASP A 1 218 ? 20.000  30.062  37.165  1.00 24.69 ? 240  ASP A CB  1 
+ATOM   1718 C  CG  . ASP A 1 218 ? 18.808  30.629  36.400  1.00 27.68 ? 240  ASP A CG  1 
+ATOM   1719 O  OD1 . ASP A 1 218 ? 18.102  29.847  35.799  1.00 28.70 ? 240  ASP A OD1 1 
+ATOM   1720 O  OD2 . ASP A 1 218 ? 18.549  31.818  36.414  1.00 31.92 ? 240  ASP A OD2 1 
+ATOM   1721 N  N   . ALA A 1 219 ? 21.211  27.408  39.078  1.00 21.94 ? 241  ALA A N   1 
+ATOM   1722 C  CA  . ALA A 1 219 ? 22.279  26.467  39.345  1.00 22.05 ? 241  ALA A CA  1 
+ATOM   1723 C  C   . ALA A 1 219 ? 21.889  25.043  39.085  1.00 23.86 ? 241  ALA A C   1 
+ATOM   1724 O  O   . ALA A 1 219 ? 22.775  24.243  38.891  1.00 27.83 ? 241  ALA A O   1 
+ATOM   1725 C  CB  . ALA A 1 219 ? 22.798  26.600  40.747  1.00 24.39 ? 241  ALA A CB  1 
+ATOM   1726 N  N   . LEU A 1 220 ? 20.612  24.705  39.042  1.00 21.19 ? 242  LEU A N   1 
+ATOM   1727 C  CA  . LEU A 1 220 ? 20.196  23.328  38.866  1.00 19.30 ? 242  LEU A CA  1 
+ATOM   1728 C  C   . LEU A 1 220 ? 19.268  23.190  37.651  1.00 19.26 ? 242  LEU A C   1 
+ATOM   1729 O  O   . LEU A 1 220 ? 18.352  22.407  37.659  1.00 19.99 ? 242  LEU A O   1 
+ATOM   1730 C  CB  . LEU A 1 220 ? 19.448  22.816  40.121  1.00 21.24 ? 242  LEU A CB  1 
+ATOM   1731 C  CG  . LEU A 1 220 ? 20.296  22.677  41.365  1.00 24.09 ? 242  LEU A CG  1 
+ATOM   1732 C  CD1 . LEU A 1 220 ? 19.418  22.122  42.512  1.00 28.39 ? 242  LEU A CD1 1 
+ATOM   1733 C  CD2 . LEU A 1 220 ? 21.420  21.748  41.082  1.00 26.12 ? 242  LEU A CD2 1 
+ATOM   1734 N  N   . LYS A 1 221 ? 19.470  24.026  36.651  1.00 18.81 ? 243  LYS A N   1 
+ATOM   1735 C  CA  . LYS A 1 221 ? 18.535  24.025  35.509  1.00 18.34 ? 243  LYS A CA  1 
+ATOM   1736 C  C   . LYS A 1 221 ? 18.582  22.680  34.754  1.00 18.19 ? 243  LYS A C   1 
+ATOM   1737 O  O   . LYS A 1 221 ? 17.546  22.205  34.291  1.00 17.49 ? 243  LYS A O   1 
+ATOM   1738 C  CB  . LYS A 1 221 ? 18.867  25.162  34.528  1.00 17.77 ? 243  LYS A CB  1 
+ATOM   1739 C  CG  . LYS A 1 221 ? 17.939  25.313  33.295  1.00 17.85 ? 243  LYS A CG  1 
+ATOM   1740 C  CD  . LYS A 1 221 ? 16.488  25.542  33.689  1.00 15.52 ? 243  LYS A CD  1 
+ATOM   1741 C  CE  . LYS A 1 221 ? 16.230  26.962  34.149  1.00 18.36 ? 243  LYS A CE  1 
+ATOM   1742 N  NZ  . LYS A 1 221 ? 14.941  27.224  34.801  1.00 17.36 ? 243  LYS A NZ  1 
+ATOM   1743 N  N   . GLU A 1 222 ? 19.761  22.091  34.625  1.00 18.75 ? 244  GLU A N   1 
+ATOM   1744 C  CA  . GLU A 1 222 ? 19.845  20.776  33.946  1.00 17.94 ? 244  GLU A CA  1 
+ATOM   1745 C  C   . GLU A 1 222 ? 18.953  19.750  34.676  1.00 16.85 ? 244  GLU A C   1 
+ATOM   1746 O  O   . GLU A 1 222 ? 18.134  19.009  34.054  1.00 18.54 ? 244  GLU A O   1 
+ATOM   1747 C  CB  . GLU A 1 222 ? 21.266  20.256  33.858  1.00 21.22 ? 244  GLU A CB  1 
+ATOM   1748 C  CG  . GLU A 1 222 ? 21.342  18.873  33.144  1.00 21.41 ? 244  GLU A CG  1 
+ATOM   1749 C  CD  . GLU A 1 222 ? 22.753  18.313  33.155  1.00 23.76 ? 244  GLU A CD  1 
+ATOM   1750 O  OE1 . GLU A 1 222 ? 23.713  19.106  33.240  1.00 25.72 ? 244  GLU A OE1 1 
+ATOM   1751 O  OE2 . GLU A 1 222 ? 22.906  17.077  33.059  1.00 24.48 ? 244  GLU A OE2 1 
+ATOM   1752 N  N   . GLU A 1 223 ? 19.069  19.738  36.023  1.00 18.18 ? 245  GLU A N   1 
+ATOM   1753 C  CA  . GLU A 1 223 ? 18.260  18.833  36.797  1.00 18.47 ? 245  GLU A CA  1 
+ATOM   1754 C  C   . GLU A 1 223 ? 16.794  19.152  36.765  1.00 17.33 ? 245  GLU A C   1 
+ATOM   1755 O  O   . GLU A 1 223 ? 15.980  18.258  36.747  1.00 18.21 ? 245  GLU A O   1 
+ATOM   1756 C  CB  . GLU A 1 223 ? 18.697  18.892  38.288  1.00 21.30 ? 245  GLU A CB  1 
+ATOM   1757 C  CG  . GLU A 1 223 ? 20.039  18.302  38.517  1.00 24.86 ? 245  GLU A CG  1 
+ATOM   1758 C  CD  . GLU A 1 223 ? 21.236  19.146  38.121  1.00 30.37 ? 245  GLU A CD  1 
+ATOM   1759 O  OE1 . GLU A 1 223 ? 21.169  20.353  37.698  1.00 32.22 ? 245  GLU A OE1 1 
+ATOM   1760 O  OE2 . GLU A 1 223 ? 22.340  18.554  38.271  1.00 34.65 ? 245  GLU A OE2 1 
+ATOM   1761 N  N   . PHE A 1 224 ? 16.470  20.444  36.753  1.00 17.57 ? 246  PHE A N   1 
+ATOM   1762 C  CA  . PHE A 1 224 ? 15.081  20.838  36.606  1.00 17.50 ? 246  PHE A CA  1 
+ATOM   1763 C  C   . PHE A 1 224 ? 14.461  20.219  35.321  1.00 16.24 ? 246  PHE A C   1 
+ATOM   1764 O  O   . PHE A 1 224 ? 13.396  19.588  35.347  1.00 15.88 ? 246  PHE A O   1 
+ATOM   1765 C  CB  . PHE A 1 224 ? 14.921  22.341  36.640  1.00 17.17 ? 246  PHE A CB  1 
+ATOM   1766 C  CG  . PHE A 1 224 ? 13.461  22.800  36.433  1.00 16.33 ? 246  PHE A CG  1 
+ATOM   1767 C  CD1 . PHE A 1 224 ? 13.061  23.329  35.230  1.00 16.70 ? 246  PHE A CD1 1 
+ATOM   1768 C  CD2 . PHE A 1 224 ? 12.483  22.618  37.426  1.00 17.50 ? 246  PHE A CD2 1 
+ATOM   1769 C  CE1 . PHE A 1 224 ? 11.742  23.695  35.056  1.00 16.22 ? 246  PHE A CE1 1 
+ATOM   1770 C  CE2 . PHE A 1 224 ? 11.214  22.931  37.218  1.00 16.84 ? 246  PHE A CE2 1 
+ATOM   1771 C  CZ  . PHE A 1 224 ? 10.836  23.495  36.019  1.00 16.07 ? 246  PHE A CZ  1 
+ATOM   1772 N  N   . ILE A 1 225 ? 15.118  20.466  34.208  1.00 15.13 ? 247  ILE A N   1 
+ATOM   1773 C  CA  . ILE A 1 225 ? 14.596  20.019  32.884  1.00 15.52 ? 247  ILE A CA  1 
+ATOM   1774 C  C   . ILE A 1 225 ? 14.533  18.484  32.886  1.00 14.42 ? 247  ILE A C   1 
+ATOM   1775 O  O   . ILE A 1 225 ? 13.504  17.894  32.586  1.00 16.13 ? 247  ILE A O   1 
+ATOM   1776 C  CB  . ILE A 1 225 ? 15.480  20.481  31.747  1.00 14.95 ? 247  ILE A CB  1 
+ATOM   1777 C  CG1 . ILE A 1 225 ? 15.502  22.015  31.702  1.00 15.88 ? 247  ILE A CG1 1 
+ATOM   1778 C  CG2 . ILE A 1 225 ? 14.972  19.954  30.392  1.00 16.67 ? 247  ILE A CG2 1 
+ATOM   1779 C  CD1 . ILE A 1 225 ? 16.555  22.623  30.815  1.00 17.17 ? 247  ILE A CD1 1 
+ATOM   1780 N  N   . TYR A 1 226 ? 15.606  17.849  33.344  1.00 15.20 ? 248  TYR A N   1 
+ATOM   1781 C  CA  . TYR A 1 226 ? 15.656  16.422  33.287  1.00 16.18 ? 248  TYR A CA  1 
+ATOM   1782 C  C   . TYR A 1 226 ? 14.542  15.819  34.167  1.00 15.58 ? 248  TYR A C   1 
+ATOM   1783 O  O   . TYR A 1 226 ? 13.818  14.901  33.724  1.00 16.75 ? 248  TYR A O   1 
+ATOM   1784 C  CB  . TYR A 1 226 ? 17.031  15.878  33.777  1.00 18.86 ? 248  TYR A CB  1 
+ATOM   1785 C  CG  . TYR A 1 226 ? 16.932  14.393  33.869  1.00 19.40 ? 248  TYR A CG  1 
+ATOM   1786 C  CD1 . TYR A 1 226 ? 16.959  13.571  32.743  1.00 19.05 ? 248  TYR A CD1 1 
+ATOM   1787 C  CD2 . TYR A 1 226 ? 16.748  13.791  35.116  1.00 19.18 ? 248  TYR A CD2 1 
+ATOM   1788 C  CE1 . TYR A 1 226 ? 16.735  12.177  32.856  1.00 19.37 ? 248  TYR A CE1 1 
+ATOM   1789 C  CE2 . TYR A 1 226 ? 16.597  12.433  35.243  1.00 20.60 ? 248  TYR A CE2 1 
+ATOM   1790 C  CZ  . TYR A 1 226 ? 16.561  11.627  34.109  1.00 20.37 ? 248  TYR A CZ  1 
+ATOM   1791 O  OH  . TYR A 1 226 ? 16.348  10.301  34.350  1.00 22.39 ? 248  TYR A OH  1 
+ATOM   1792 N  N   . TYR A 1 227 ? 14.502  16.231  35.459  1.00 17.25 ? 249  TYR A N   1 
+ATOM   1793 C  CA  . TYR A 1 227 ? 13.580  15.558  36.344  1.00 16.17 ? 249  TYR A CA  1 
+ATOM   1794 C  C   . TYR A 1 227 ? 12.126  15.866  36.104  1.00 16.09 ? 249  TYR A C   1 
+ATOM   1795 O  O   . TYR A 1 227 ? 11.296  14.989  36.239  1.00 15.38 ? 249  TYR A O   1 
+ATOM   1796 C  CB  . TYR A 1 227 ? 13.960  15.856  37.852  1.00 19.64 ? 249  TYR A CB  1 
+ATOM   1797 C  CG  . TYR A 1 227 ? 15.170  15.051  38.308  1.00 20.85 ? 249  TYR A CG  1 
+ATOM   1798 C  CD1 . TYR A 1 227 ? 15.078  13.705  38.431  1.00 22.10 ? 249  TYR A CD1 1 
+ATOM   1799 C  CD2 . TYR A 1 227 ? 16.401  15.673  38.497  1.00 24.31 ? 249  TYR A CD2 1 
+ATOM   1800 C  CE1 . TYR A 1 227 ? 16.247  12.975  38.832  1.00 26.34 ? 249  TYR A CE1 1 
+ATOM   1801 C  CE2 . TYR A 1 227 ? 17.542  14.966  38.866  1.00 26.78 ? 249  TYR A CE2 1 
+ATOM   1802 C  CZ  . TYR A 1 227 ? 17.459  13.618  38.973  1.00 27.28 ? 249  TYR A CZ  1 
+ATOM   1803 O  OH  . TYR A 1 227 ? 18.589  12.867  39.362  1.00 34.77 ? 249  TYR A OH  1 
+ATOM   1804 N  N   . ILE A 1 228 ? 11.792  17.100  35.729  1.00 15.45 ? 250  ILE A N   1 
+ATOM   1805 C  CA  . ILE A 1 228 ? 10.370  17.366  35.456  1.00 14.88 ? 250  ILE A CA  1 
+ATOM   1806 C  C   . ILE A 1 228 ? 9.921   16.621  34.183  1.00 13.85 ? 250  ILE A C   1 
+ATOM   1807 O  O   . ILE A 1 228 ? 8.809   16.097  34.127  1.00 13.70 ? 250  ILE A O   1 
+ATOM   1808 C  CB  . ILE A 1 228 ? 10.024  18.861  35.456  1.00 15.76 ? 250  ILE A CB  1 
+ATOM   1809 C  CG1 . ILE A 1 228 ? 8.522   19.038  35.676  1.00 18.55 ? 250  ILE A CG1 1 
+ATOM   1810 C  CG2 . ILE A 1 228 ? 10.387  19.545  34.108  1.00 16.56 ? 250  ILE A CG2 1 
+ATOM   1811 C  CD1 . ILE A 1 228 ? 8.096   20.371  36.217  1.00 22.30 ? 250  ILE A CD1 1 
+ATOM   1812 N  N   . ALA A 1 229 ? 10.788  16.567  33.171  1.00 13.95 ? 251  ALA A N   1 
+ATOM   1813 C  CA  . ALA A 1 229 ? 10.437  15.799  31.974  1.00 15.02 ? 251  ALA A CA  1 
+ATOM   1814 C  C   . ALA A 1 229 ? 10.349  14.315  32.250  1.00 15.77 ? 251  ALA A C   1 
+ATOM   1815 O  O   . ALA A 1 229 ? 9.448   13.636  31.796  1.00 16.71 ? 251  ALA A O   1 
+ATOM   1816 C  CB  . ALA A 1 229 ? 11.444  16.063  30.827  1.00 15.32 ? 251  ALA A CB  1 
+ATOM   1817 N  N   . ASP A 1 230 ? 11.319  13.830  32.993  1.00 15.49 ? 252  ASP A N   1 
+ATOM   1818 C  CA  . ASP A 1 230 ? 11.307  12.427  33.305  1.00 13.96 ? 252  ASP A CA  1 
+ATOM   1819 C  C   . ASP A 1 230 ? 9.993   12.035  34.050  1.00 17.02 ? 252  ASP A C   1 
+ATOM   1820 O  O   . ASP A 1 230 ? 9.412   10.983  33.830  1.00 16.85 ? 252  ASP A O   1 
+ATOM   1821 C  CB  . ASP A 1 230 ? 12.516  12.084  34.223  1.00 16.66 ? 252  ASP A CB  1 
+ATOM   1822 C  CG  . ASP A 1 230 ? 12.494  10.597  34.701  1.00 18.05 ? 252  ASP A CG  1 
+ATOM   1823 O  OD1 . ASP A 1 230 ? 12.655  9.658   33.853  1.00 20.84 ? 252  ASP A OD1 1 
+ATOM   1824 O  OD2 . ASP A 1 230 ? 12.335  10.416  35.932  1.00 18.95 ? 252  ASP A OD2 1 
+ATOM   1825 N  N   . SER A 1 231 ? 9.542   12.897  34.970  1.00 15.98 ? 253  SER A N   1 
+ATOM   1826 C  CA  . SER A 1 231 ? 8.331   12.649  35.739  1.00 16.63 ? 253  SER A CA  1 
+ATOM   1827 C  C   . SER A 1 231 ? 7.126   12.689  34.810  1.00 14.83 ? 253  SER A C   1 
+ATOM   1828 O  O   . SER A 1 231 ? 6.260   11.788  34.869  1.00 16.67 ? 253  SER A O   1 
+ATOM   1829 C  CB  . SER A 1 231 ? 8.121   13.702  36.867  1.00 16.98 ? 253  SER A CB  1 
+ATOM   1830 O  OG  . SER A 1 231 ? 9.263   13.730  37.698  1.00 18.05 ? 253  SER A OG  1 
+ATOM   1831 N  N   . LEU A 1 232 ? 7.088   13.684  33.889  1.00 14.36 ? 254  LEU A N   1 
+ATOM   1832 C  CA  . LEU A 1 232 ? 5.938   13.742  32.959  1.00 13.61 ? 254  LEU A CA  1 
+ATOM   1833 C  C   . LEU A 1 232 ? 5.866   12.526  32.007  1.00 13.27 ? 254  LEU A C   1 
+ATOM   1834 O  O   . LEU A 1 232 ? 4.783   11.941  31.792  1.00 14.34 ? 254  LEU A O   1 
+ATOM   1835 C  CB  . LEU A 1 232 ? 5.986   15.065  32.173  1.00 13.29 ? 254  LEU A CB  1 
+ATOM   1836 C  CG  . LEU A 1 232 ? 5.622   16.287  32.999  1.00 15.76 ? 254  LEU A CG  1 
+ATOM   1837 C  CD1 . LEU A 1 232 ? 6.203   17.543  32.314  1.00 16.07 ? 254  LEU A CD1 1 
+ATOM   1838 C  CD2 . LEU A 1 232 ? 4.145   16.387  33.137  1.00 16.68 ? 254  LEU A CD2 1 
+ATOM   1839 N  N   . ILE A 1 233 ? 7.012   12.130  31.479  1.00 15.09 ? 255  ILE A N   1 
+ATOM   1840 C  CA  . ILE A 1 233 ? 6.963   11.141  30.413  1.00 15.69 ? 255  ILE A CA  1 
+ATOM   1841 C  C   . ILE A 1 233 ? 6.736   9.720   30.950  1.00 15.88 ? 255  ILE A C   1 
+ATOM   1842 O  O   . ILE A 1 233 ? 6.422   8.812   30.237  1.00 18.09 ? 255  ILE A O   1 
+ATOM   1843 C  CB  . ILE A 1 233 ? 8.202   11.228  29.509  1.00 15.54 ? 255  ILE A CB  1 
+ATOM   1844 C  CG1 . ILE A 1 233 ? 9.473   10.751  30.223  1.00 16.81 ? 255  ILE A CG1 1 
+ATOM   1845 C  CG2 . ILE A 1 233 ? 8.253   12.601  28.909  1.00 17.34 ? 255  ILE A CG2 1 
+ATOM   1846 C  CD1 . ILE A 1 233 ? 10.750  11.167  29.560  1.00 18.30 ? 255  ILE A CD1 1 
+ATOM   1847 N  N   . ASN A 1 234 ? 6.899   9.557   32.265  1.00 16.86 ? 256  ASN A N   1 
+ATOM   1848 C  CA  . ASN A 1 234 ? 6.628   8.282   32.929  1.00 19.19 ? 256  ASN A CA  1 
+ATOM   1849 C  C   . ASN A 1 234 ? 5.435   8.340   33.902  1.00 17.86 ? 256  ASN A C   1 
+ATOM   1850 O  O   . ASN A 1 234 ? 5.085   7.338   34.556  1.00 18.40 ? 256  ASN A O   1 
+ATOM   1851 C  CB  . ASN A 1 234 ? 7.890   7.860   33.670  1.00 17.21 ? 256  ASN A CB  1 
+ATOM   1852 C  CG  . ASN A 1 234 ? 8.987   7.520   32.689  1.00 17.95 ? 256  ASN A CG  1 
+ATOM   1853 O  OD1 . ASN A 1 234 ? 8.771   6.609   31.909  1.00 17.93 ? 256  ASN A OD1 1 
+ATOM   1854 N  ND2 . ASN A 1 234 ? 10.116  8.236   32.685  1.00 18.18 ? 256  ASN A ND2 1 
+ATOM   1855 N  N   . GLY A 1 235 ? 4.796   9.484   34.006  1.00 16.51 ? 257  GLY A N   1 
+ATOM   1856 C  CA  . GLY A 1 235 ? 3.765   9.564   35.029  1.00 16.62 ? 257  GLY A CA  1 
+ATOM   1857 C  C   . GLY A 1 235 ? 4.143   9.305   36.451  1.00 17.03 ? 257  GLY A C   1 
+ATOM   1858 O  O   . GLY A 1 235 ? 3.373   8.715   37.188  1.00 20.12 ? 257  GLY A O   1 
+ATOM   1859 N  N   . THR A 1 236 ? 5.328   9.741   36.797  1.00 16.64 ? 258  THR A N   1 
+ATOM   1860 C  CA  . THR A 1 236 ? 5.829   9.540   38.158  1.00 16.32 ? 258  THR A CA  1 
+ATOM   1861 C  C   . THR A 1 236 ? 5.857   10.847  38.926  1.00 17.08 ? 258  THR A C   1 
+ATOM   1862 O  O   . THR A 1 236 ? 5.588   11.942  38.401  1.00 17.21 ? 258  THR A O   1 
+ATOM   1863 C  CB  . THR A 1 236 ? 7.218   8.931   38.122  1.00 19.53 ? 258  THR A CB  1 
+ATOM   1864 O  OG1 . THR A 1 236 ? 8.078   9.777   37.348  1.00 20.15 ? 258  THR A OG1 1 
+ATOM   1865 C  CG2 . THR A 1 236 ? 7.192   7.518   37.505  1.00 21.50 ? 258  THR A CG2 1 
+ATOM   1866 N  N   . ARG A 1 237 ? 6.122   10.721  40.223  1.00 19.29 ? 259  ARG A N   1 
+ATOM   1867 C  CA  . ARG A 1 237 ? 6.315   11.877  41.093  1.00 20.18 ? 259  ARG A CA  1 
+ATOM   1868 C  C   . ARG A 1 237 ? 5.100   12.801  41.074  1.00 20.24 ? 259  ARG A C   1 
+ATOM   1869 O  O   . ARG A 1 237 ? 5.241   13.986  41.173  1.00 22.25 ? 259  ARG A O   1 
+ATOM   1870 C  CB  . ARG A 1 237 ? 7.577   12.633  40.783  1.00 19.88 ? 259  ARG A CB  1 
+ATOM   1871 C  CG  . ARG A 1 237 ? 8.818   11.699  40.725  1.00 21.73 ? 259  ARG A CG  1 
+ATOM   1872 C  CD  . ARG A 1 237 ? 10.112  12.498  40.743  1.00 18.80 ? 259  ARG A CD  1 
+ATOM   1873 N  NE  . ARG A 1 237 ? 11.259  11.656  40.638  1.00 21.36 ? 259  ARG A NE  1 
+ATOM   1874 C  CZ  . ARG A 1 237 ? 11.836  11.286  39.504  1.00 21.42 ? 259  ARG A CZ  1 
+ATOM   1875 N  NH1 . ARG A 1 237 ? 11.335  11.647  38.312  1.00 20.23 ? 259  ARG A NH1 1 
+ATOM   1876 N  NH2 . ARG A 1 237 ? 12.866  10.453  39.557  1.00 25.52 ? 259  ARG A NH2 1 
+ATOM   1877 N  N   . ASN A 1 238 ? 3.939   12.197  40.957  1.00 21.50 ? 260  ASN A N   1 
+ATOM   1878 C  CA  . ASN A 1 238 ? 2.682   12.886  41.014  1.00 21.86 ? 260  ASN A CA  1 
+ATOM   1879 C  C   . ASN A 1 238 ? 2.324   13.738  39.819  1.00 20.67 ? 260  ASN A C   1 
+ATOM   1880 O  O   . ASN A 1 238 ? 1.417   14.545  39.888  1.00 20.07 ? 260  ASN A O   1 
+ATOM   1881 C  CB  . ASN A 1 238 ? 2.549   13.766  42.267  1.00 24.08 ? 260  ASN A CB  1 
+ATOM   1882 C  CG  . ASN A 1 238 ? 1.177   13.880  42.635  0.50 22.64 ? 260  ASN A CG  1 
+ATOM   1883 O  OD1 . ASN A 1 238 ? 0.492   12.864  42.549  0.50 22.55 ? 260  ASN A OD1 1 
+ATOM   1884 N  ND2 . ASN A 1 238 ? 0.735   15.027  43.110  0.50 19.28 ? 260  ASN A ND2 1 
+ATOM   1885 N  N   . TYR A 1 239 ? 2.987   13.461  38.721  1.00 20.58 ? 261  TYR A N   1 
+ATOM   1886 C  CA  . TYR A 1 239 ? 2.620   14.143  37.479  1.00 17.94 ? 261  TYR A CA  1 
+ATOM   1887 C  C   . TYR A 1 239 ? 1.803   13.238  36.576  1.00 19.61 ? 261  TYR A C   1 
+ATOM   1888 O  O   . TYR A 1 239 ? 1.961   12.023  36.568  1.00 19.69 ? 261  TYR A O   1 
+ATOM   1889 C  CB  . TYR A 1 239 ? 3.918   14.564  36.728  1.00 19.53 ? 261  TYR A CB  1 
+ATOM   1890 C  CG  . TYR A 1 239 ? 4.461   15.855  37.287  1.00 19.87 ? 261  TYR A CG  1 
+ATOM   1891 C  CD1 . TYR A 1 239 ? 3.918   17.088  36.881  1.00 21.76 ? 261  TYR A CD1 1 
+ATOM   1892 C  CD2 . TYR A 1 239 ? 5.417   15.863  38.325  1.00 21.37 ? 261  TYR A CD2 1 
+ATOM   1893 C  CE1 . TYR A 1 239 ? 4.336   18.280  37.455  1.00 24.64 ? 261  TYR A CE1 1 
+ATOM   1894 C  CE2 . TYR A 1 239 ? 5.860   17.073  38.876  1.00 24.89 ? 261  TYR A CE2 1 
+ATOM   1895 C  CZ  . TYR A 1 239 ? 5.314   18.267  38.440  1.00 28.76 ? 261  TYR A CZ  1 
+ATOM   1896 O  OH  . TYR A 1 239 ? 5.733   19.454  39.020  1.00 34.95 ? 261  TYR A OH  1 
+ATOM   1897 N  N   . HIS A 1 240 ? 0.916   13.871  35.812  1.00 19.46 ? 262  HIS A N   1 
+ATOM   1898 C  CA  . HIS A 1 240 ? 0.168   13.145  34.816  1.00 19.13 ? 262  HIS A CA  1 
+ATOM   1899 C  C   . HIS A 1 240 ? 1.070   12.757  33.674  1.00 18.55 ? 262  HIS A C   1 
+ATOM   1900 O  O   . HIS A 1 240 ? 1.957   13.520  33.300  1.00 20.39 ? 262  HIS A O   1 
+ATOM   1901 C  CB  . HIS A 1 240 ? -0.911  14.070  34.247  1.00 21.17 ? 262  HIS A CB  1 
+ATOM   1902 C  CG  . HIS A 1 240 ? -1.978  13.331  33.521  1.00 27.34 ? 262  HIS A CG  1 
+ATOM   1903 N  ND1 . HIS A 1 240 ? -2.999  12.696  34.208  1.00 32.53 ? 262  HIS A ND1 1 
+ATOM   1904 C  CD2 . HIS A 1 240 ? -2.101  12.980  32.229  1.00 30.19 ? 262  HIS A CD2 1 
+ATOM   1905 C  CE1 . HIS A 1 240 ? -3.739  12.032  33.329  1.00 33.19 ? 262  HIS A CE1 1 
+ATOM   1906 N  NE2 . HIS A 1 240 ? -3.236  12.208  32.125  1.00 33.10 ? 262  HIS A NE2 1 
+ATOM   1907 N  N   . LYS A 1 241 ? 0.860   11.573  33.130  1.00 16.03 ? 263  LYS A N   1 
+ATOM   1908 C  CA  . LYS A 1 241 ? 1.768   11.121  32.047  1.00 16.46 ? 263  LYS A CA  1 
+ATOM   1909 C  C   . LYS A 1 241 ? 1.485   11.809  30.727  1.00 15.19 ? 263  LYS A C   1 
+ATOM   1910 O  O   . LYS A 1 241 ? 0.332   11.758  30.229  1.00 18.35 ? 263  LYS A O   1 
+ATOM   1911 C  CB  . LYS A 1 241 ? 1.632   9.622   31.835  1.00 16.74 ? 263  LYS A CB  1 
+ATOM   1912 C  CG  . LYS A 1 241 ? 2.626   9.096   30.812  1.00 18.55 ? 263  LYS A CG  1 
+ATOM   1913 C  CD  . LYS A 1 241 ? 2.708   7.620   30.658  1.00 24.55 ? 263  LYS A CD  1 
+ATOM   1914 C  CE  . LYS A 1 241 ? 3.537   7.369   29.406  1.00 24.67 ? 263  LYS A CE  1 
+ATOM   1915 N  NZ  . LYS A 1 241 ? 3.360   6.066   28.854  1.00 30.59 ? 263  LYS A NZ  1 
+ATOM   1916 N  N   . ILE A 1 242 ? 2.532   12.379  30.133  1.00 14.56 ? 264  ILE A N   1 
+ATOM   1917 C  CA  . ILE A 1 242 ? 2.487   12.881  28.727  1.00 15.54 ? 264  ILE A CA  1 
+ATOM   1918 C  C   . ILE A 1 242 ? 3.624   12.102  28.055  1.00 17.22 ? 264  ILE A C   1 
+ATOM   1919 O  O   . ILE A 1 242 ? 4.779   12.260  28.415  1.00 16.64 ? 264  ILE A O   1 
+ATOM   1920 C  CB  . ILE A 1 242 ? 2.740   14.389  28.644  1.00 14.45 ? 264  ILE A CB  1 
+ATOM   1921 C  CG1 . ILE A 1 242 ? 1.653   15.171  29.399  1.00 16.42 ? 264  ILE A CG1 1 
+ATOM   1922 C  CG2 . ILE A 1 242 ? 2.863   14.836  27.137  1.00 16.00 ? 264  ILE A CG2 1 
+ATOM   1923 C  CD1 . ILE A 1 242 ? 1.913   16.665  29.552  1.00 16.29 ? 264  ILE A CD1 1 
+ATOM   1924 N  N   . PRO A 1 243 ? 3.289   11.234  27.056  1.00 15.63 ? 265  PRO A N   1 
+ATOM   1925 C  CA  . PRO A 1 243 ? 4.347   10.422  26.470  1.00 17.75 ? 265  PRO A CA  1 
+ATOM   1926 C  C   . PRO A 1 243 ? 5.476   11.290  25.891  1.00 16.80 ? 265  PRO A C   1 
+ATOM   1927 O  O   . PRO A 1 243 ? 5.263   12.399  25.390  1.00 15.84 ? 265  PRO A O   1 
+ATOM   1928 C  CB  . PRO A 1 243 ? 3.631   9.673   25.350  1.00 19.51 ? 265  PRO A CB  1 
+ATOM   1929 C  CG  . PRO A 1 243 ? 2.204   9.993   25.377  1.00 19.55 ? 265  PRO A CG  1 
+ATOM   1930 C  CD  . PRO A 1 243 ? 1.976   11.012  26.426  1.00 16.48 ? 265  PRO A CD  1 
+ATOM   1931 N  N   . HIS A 1 244 ? 6.696   10.749  25.912  1.00 15.66 ? 266  HIS A N   1 
+ATOM   1932 C  CA  . HIS A 1 244 ? 7.889   11.526  25.496  1.00 14.95 ? 266  HIS A CA  1 
+ATOM   1933 C  C   . HIS A 1 244 ? 7.854   12.026  24.030  1.00 14.62 ? 266  HIS A C   1 
+ATOM   1934 O  O   . HIS A 1 244 ? 8.240   13.159  23.737  1.00 14.46 ? 266  HIS A O   1 
+ATOM   1935 C  CB  . HIS A 1 244 ? 9.180   10.720  25.746  1.00 16.97 ? 266  HIS A CB  1 
+ATOM   1936 C  CG  . HIS A 1 244 ? 9.333   9.508   24.870  1.00 16.56 ? 266  HIS A CG  1 
+ATOM   1937 N  ND1 . HIS A 1 244 ? 9.998   9.569   23.671  1.00 17.58 ? 266  HIS A ND1 1 
+ATOM   1938 C  CD2 . HIS A 1 244 ? 8.814   8.262   24.969  1.00 17.77 ? 266  HIS A CD2 1 
+ATOM   1939 C  CE1 . HIS A 1 244 ? 9.940   8.357   23.095  1.00 17.96 ? 266  HIS A CE1 1 
+ATOM   1940 N  NE2 . HIS A 1 244 ? 9.212   7.550   23.856  1.00 18.04 ? 266  HIS A NE2 1 
+ATOM   1941 N  N   . ASP A 1 245 ? 7.234   11.209  23.183  1.00 15.16 ? 267  ASP A N   1 
+ATOM   1942 C  CA  . ASP A 1 245 ? 7.061   11.530  21.767  1.00 13.88 ? 267  ASP A CA  1 
+ATOM   1943 C  C   . ASP A 1 245 ? 6.077   12.652  21.586  1.00 14.30 ? 267  ASP A C   1 
+ATOM   1944 O  O   . ASP A 1 245 ? 5.926   13.191  20.455  1.00 15.68 ? 267  ASP A O   1 
+ATOM   1945 C  CB  . ASP A 1 245 ? 6.630   10.314  20.963  1.00 16.56 ? 267  ASP A CB  1 
+ATOM   1946 C  CG  . ASP A 1 245 ? 5.369   9.625   21.528  1.00 17.95 ? 267  ASP A CG  1 
+ATOM   1947 O  OD1 . ASP A 1 245 ? 5.457   9.050   22.607  1.00 21.65 ? 267  ASP A OD1 1 
+ATOM   1948 O  OD2 . ASP A 1 245 ? 4.312   9.563   20.838  1.00 23.18 ? 267  ASP A OD2 1 
+ATOM   1949 N  N   . LYS A 1 246 ? 5.406   13.057  22.674  1.00 14.87 ? 268  LYS A N   1 
+ATOM   1950 C  CA  . LYS A 1 246 ? 4.363   14.088  22.683  1.00 13.19 ? 268  LYS A CA  1 
+ATOM   1951 C  C   . LYS A 1 246 ? 4.659   15.244  23.676  1.00 12.01 ? 268  LYS A C   1 
+ATOM   1952 O  O   . LYS A 1 246 ? 3.792   16.048  23.988  1.00 15.09 ? 268  LYS A O   1 
+ATOM   1953 C  CB  . LYS A 1 246 ? 2.976   13.524  22.953  1.00 16.83 ? 268  LYS A CB  1 
+ATOM   1954 C  CG  . LYS A 1 246 ? 2.559   12.576  21.771  1.00 17.52 ? 268  LYS A CG  1 
+ATOM   1955 C  CD  . LYS A 1 246 ? 1.107   12.090  21.812  1.00 21.09 ? 268  LYS A CD  1 
+ATOM   1956 C  CE  . LYS A 1 246 ? 0.685   11.432  20.536  1.00 26.87 ? 268  LYS A CE  1 
+ATOM   1957 N  NZ  . LYS A 1 246 ? -0.103  10.297  21.023  1.00 35.87 ? 268  LYS A NZ  1 
+ATOM   1958 N  N   . LEU A 1 247 ? 5.888   15.283  24.187  1.00 12.49 ? 269  LEU A N   1 
+ATOM   1959 C  CA  . LEU A 1 247 ? 6.287   16.323  25.142  1.00 12.82 ? 269  LEU A CA  1 
+ATOM   1960 C  C   . LEU A 1 247 ? 7.312   17.275  24.522  1.00 13.68 ? 269  LEU A C   1 
+ATOM   1961 O  O   . LEU A 1 247 ? 8.388   16.886  24.102  1.00 12.92 ? 269  LEU A O   1 
+ATOM   1962 C  CB  . LEU A 1 247 ? 6.824   15.738  26.446  1.00 14.68 ? 269  LEU A CB  1 
+ATOM   1963 C  CG  . LEU A 1 247 ? 7.146   16.787  27.547  1.00 14.51 ? 269  LEU A CG  1 
+ATOM   1964 C  CD1 . LEU A 1 247 ? 5.931   17.524  27.989  1.00 16.60 ? 269  LEU A CD1 1 
+ATOM   1965 C  CD2 . LEU A 1 247 ? 7.869   16.111  28.717  1.00 14.34 ? 269  LEU A CD2 1 
+ATOM   1966 N  N   . VAL A 1 248 ? 6.932   18.547  24.504  1.00 12.71 ? 270  VAL A N   1 
+ATOM   1967 C  CA  . VAL A 1 248 ? 7.693   19.657  23.966  1.00 12.16 ? 270  VAL A CA  1 
+ATOM   1968 C  C   . VAL A 1 248 ? 7.969   20.672  25.086  1.00 13.56 ? 270  VAL A C   1 
+ATOM   1969 O  O   . VAL A 1 248 ? 7.037   21.021  25.789  1.00 12.43 ? 270  VAL A O   1 
+ATOM   1970 C  CB  . VAL A 1 248 ? 6.867   20.300  22.824  1.00 11.60 ? 270  VAL A CB  1 
+ATOM   1971 C  CG1 . VAL A 1 248 ? 7.495   21.577  22.298  1.00 12.52 ? 270  VAL A CG1 1 
+ATOM   1972 C  CG2 . VAL A 1 248 ? 6.761   19.277  21.658  1.00 12.06 ? 270  VAL A CG2 1 
+ATOM   1973 N  N   . PHE A 1 249 ? 9.226   21.059  25.299  1.00 13.65 ? 271  PHE A N   1 
+ATOM   1974 C  CA  . PHE A 1 249 ? 9.577   21.811  26.541  1.00 10.71 ? 271  PHE A CA  1 
+ATOM   1975 C  C   . PHE A 1 249 ? 9.465   23.305  26.303  1.00 11.35 ? 271  PHE A C   1 
+ATOM   1976 O  O   . PHE A 1 249 ? 10.214  23.884  25.516  1.00 11.96 ? 271  PHE A O   1 
+ATOM   1977 C  CB  . PHE A 1 249 ? 10.985  21.418  26.921  1.00 12.37 ? 271  PHE A CB  1 
+ATOM   1978 C  CG  . PHE A 1 249 ? 11.272  21.606  28.421  1.00 12.91 ? 271  PHE A CG  1 
+ATOM   1979 C  CD1 . PHE A 1 249 ? 11.008  20.585  29.283  1.00 13.49 ? 271  PHE A CD1 1 
+ATOM   1980 C  CD2 . PHE A 1 249 ? 11.698  22.832  28.920  1.00 14.42 ? 271  PHE A CD2 1 
+ATOM   1981 C  CE1 . PHE A 1 249 ? 11.254  20.761  30.641  1.00 13.11 ? 271  PHE A CE1 1 
+ATOM   1982 C  CE2 . PHE A 1 249 ? 11.906  23.029  30.262  1.00 14.48 ? 271  PHE A CE2 1 
+ATOM   1983 C  CZ  . PHE A 1 249 ? 11.662  21.974  31.104  1.00 15.97 ? 271  PHE A CZ  1 
+ATOM   1984 N  N   . GLY A 1 250 ? 8.453   23.933  26.912  1.00 12.06 ? 272  GLY A N   1 
+ATOM   1985 C  CA  . GLY A 1 250 ? 8.161   25.351  26.664  1.00 12.18 ? 272  GLY A CA  1 
+ATOM   1986 C  C   . GLY A 1 250 ? 9.020   26.299  27.522  1.00 12.35 ? 272  GLY A C   1 
+ATOM   1987 O  O   . GLY A 1 250 ? 9.070   26.136  28.789  1.00 12.59 ? 272  GLY A O   1 
+ATOM   1988 N  N   . LEU A 1 251 ? 9.545   27.356  26.878  1.00 12.11 ? 273  LEU A N   1 
+ATOM   1989 C  CA  . LEU A 1 251 ? 10.541  28.245  27.498  1.00 13.14 ? 273  LEU A CA  1 
+ATOM   1990 C  C   . LEU A 1 251 ? 10.365  29.672  27.065  1.00 11.34 ? 273  LEU A C   1 
+ATOM   1991 O  O   . LEU A 1 251 ? 9.910   29.941  25.930  1.00 12.42 ? 273  LEU A O   1 
+ATOM   1992 C  CB  . LEU A 1 251 ? 11.926  27.824  27.001  1.00 15.06 ? 273  LEU A CB  1 
+ATOM   1993 C  CG  . LEU A 1 251 ? 12.438  26.427  27.431  1.00 14.22 ? 273  LEU A CG  1 
+ATOM   1994 C  CD1 . LEU A 1 251 ? 13.657  25.969  26.622  1.00 16.92 ? 273  LEU A CD1 1 
+ATOM   1995 C  CD2 . LEU A 1 251 ? 12.790  26.489  28.960  1.00 16.46 ? 273  LEU A CD2 1 
+ATOM   1996 N  N   . PRO A 1 252 ? 10.847  30.616  27.849  1.00 12.21 ? 274  PRO A N   1 
+ATOM   1997 C  CA  . PRO A 1 252 ? 10.872  32.008  27.382  1.00 12.26 ? 274  PRO A CA  1 
+ATOM   1998 C  C   . PRO A 1 252 ? 12.052  32.235  26.451  1.00 12.88 ? 274  PRO A C   1 
+ATOM   1999 O  O   . PRO A 1 252 ? 13.117  31.639  26.651  1.00 14.51 ? 274  PRO A O   1 
+ATOM   2000 C  CB  . PRO A 1 252 ? 11.140  32.776  28.689  1.00 15.26 ? 274  PRO A CB  1 
+ATOM   2001 C  CG  . PRO A 1 252 ? 11.141  31.881  29.733  1.00 16.39 ? 274  PRO A CG  1 
+ATOM   2002 C  CD  . PRO A 1 252 ? 11.389  30.513  29.235  1.00 11.61 ? 274  PRO A CD  1 
+ATOM   2003 N  N   . SER A 1 253 ? 11.929  33.080  25.442  1.00 13.81 ? 275  SER A N   1 
+ATOM   2004 C  CA  A SER A 1 253 ? 12.993  33.315  24.513  0.66 12.66 ? 275  SER A CA  1 
+ATOM   2005 C  CA  B SER A 1 253 ? 13.020  33.246  24.522  0.34 13.64 ? 275  SER A CA  1 
+ATOM   2006 C  C   . SER A 1 253 ? 14.199  33.984  25.160  1.00 12.67 ? 275  SER A C   1 
+ATOM   2007 O  O   . SER A 1 253 ? 15.308  33.763  24.743  1.00 16.88 ? 275  SER A O   1 
+ATOM   2008 C  CB  A SER A 1 253 ? 12.539  34.193  23.347  0.66 12.54 ? 275  SER A CB  1 
+ATOM   2009 C  CB  B SER A 1 253 ? 12.579  33.891  23.194  0.34 14.11 ? 275  SER A CB  1 
+ATOM   2010 O  OG  A SER A 1 253 ? 11.569  33.555  22.546  0.66 13.18 ? 275  SER A OG  1 
+ATOM   2011 O  OG  B SER A 1 253 ? 11.806  35.054  23.356  0.34 16.74 ? 275  SER A OG  1 
+ATOM   2012 N  N   . ASN A 1 254 ? 13.896  34.802  26.166  1.00 13.95 ? 276  ASN A N   1 
+ATOM   2013 C  CA  . ASN A 1 254 ? 14.898  35.666  26.825  1.00 14.95 ? 276  ASN A CA  1 
+ATOM   2014 C  C   . ASN A 1 254 ? 14.234  36.264  28.087  1.00 14.10 ? 276  ASN A C   1 
+ATOM   2015 O  O   . ASN A 1 254 ? 13.081  35.943  28.384  1.00 14.29 ? 276  ASN A O   1 
+ATOM   2016 C  CB  . ASN A 1 254 ? 15.390  36.818  25.881  1.00 16.97 ? 276  ASN A CB  1 
+ATOM   2017 C  CG  . ASN A 1 254 ? 14.246  37.609  25.280  1.00 16.42 ? 276  ASN A CG  1 
+ATOM   2018 O  OD1 . ASN A 1 254 ? 13.439  38.155  26.003  1.00 16.17 ? 276  ASN A OD1 1 
+ATOM   2019 N  ND2 . ASN A 1 254 ? 14.131  37.617  23.919  1.00 14.91 ? 276  ASN A ND2 1 
+ATOM   2020 N  N   . ILE A 1 255 ? 15.020  37.037  28.832  1.00 16.10 ? 277  ILE A N   1 
+ATOM   2021 C  CA  . ILE A 1 255 ? 14.547  37.582  30.101  1.00 15.76 ? 277  ILE A CA  1 
+ATOM   2022 C  C   . ILE A 1 255 ? 13.407  38.591  30.008  1.00 16.23 ? 277  ILE A C   1 
+ATOM   2023 O  O   . ILE A 1 255 ? 12.759  38.864  31.002  1.00 16.35 ? 277  ILE A O   1 
+ATOM   2024 C  CB  . ILE A 1 255 ? 15.707  38.133  30.933  1.00 18.53 ? 277  ILE A CB  1 
+ATOM   2025 C  CG1 . ILE A 1 255 ? 16.387  39.318  30.283  1.00 20.15 ? 277  ILE A CG1 1 
+ATOM   2026 C  CG2 . ILE A 1 255 ? 16.721  36.996  31.244  1.00 19.84 ? 277  ILE A CG2 1 
+ATOM   2027 C  CD1 . ILE A 1 255 ? 17.499  39.896  31.160  1.00 23.24 ? 277  ILE A CD1 1 
+ATOM   2028 N  N   . ASP A 1 256 ? 13.167  39.158  28.819  1.00 14.29 ? 278  ASP A N   1 
+ATOM   2029 C  CA  . ASP A 1 256 ? 12.048  40.046  28.651  1.00 16.60 ? 278  ASP A CA  1 
+ATOM   2030 C  C   . ASP A 1 256 ? 10.781  39.288  28.437  1.00 14.15 ? 278  ASP A C   1 
+ATOM   2031 O  O   . ASP A 1 256 ? 9.690   39.812  28.668  1.00 14.83 ? 278  ASP A O   1 
+ATOM   2032 C  CB  . ASP A 1 256 ? 12.274  41.035  27.500  1.00 15.27 ? 278  ASP A CB  1 
+ATOM   2033 C  CG  . ASP A 1 256 ? 12.925  42.340  27.975  1.00 14.47 ? 278  ASP A CG  1 
+ATOM   2034 O  OD1 . ASP A 1 256 ? 12.266  42.966  28.844  1.00 16.57 ? 278  ASP A OD1 1 
+ATOM   2035 O  OD2 . ASP A 1 256 ? 14.083  42.691  27.514  1.00 16.93 ? 278  ASP A OD2 1 
+ATOM   2036 N  N   . ALA A 1 257 ? 10.883  38.074  27.889  1.00 12.87 ? 279  ALA A N   1 
+ATOM   2037 C  CA  . ALA A 1 257 ? 9.680   37.338  27.484  1.00 12.93 ? 279  ALA A CA  1 
+ATOM   2038 C  C   . ALA A 1 257 ? 8.865   36.744  28.637  1.00 13.65 ? 279  ALA A C   1 
+ATOM   2039 O  O   . ALA A 1 257 ? 7.677   36.496  28.480  1.00 13.82 ? 279  ALA A O   1 
+ATOM   2040 C  CB  . ALA A 1 257 ? 10.065  36.223  26.500  1.00 13.42 ? 279  ALA A CB  1 
+ATOM   2041 N  N   . ALA A 1 258 ? 9.511   36.503  29.774  1.00 14.83 ? 280  ALA A N   1 
+ATOM   2042 C  CA  . ALA A 1 258 ? 8.820   35.926  30.957  1.00 15.18 ? 280  ALA A CA  1 
+ATOM   2043 C  C   . ALA A 1 258 ? 9.592   36.418  32.188  1.00 14.87 ? 280  ALA A C   1 
+ATOM   2044 O  O   . ALA A 1 258 ? 10.762  36.786  32.102  1.00 15.58 ? 280  ALA A O   1 
+ATOM   2045 C  CB  . ALA A 1 258 ? 8.809   34.391  30.960  1.00 14.13 ? 280  ALA A CB  1 
+ATOM   2046 N  N   . ALA A 1 259 ? 8.925   36.439  33.325  1.00 15.20 ? 281  ALA A N   1 
+ATOM   2047 C  CA  . ALA A 1 259 ? 9.568   36.884  34.563  1.00 17.09 ? 281  ALA A CA  1 
+ATOM   2048 C  C   . ALA A 1 259 ? 10.699  35.976  34.950  1.00 16.10 ? 281  ALA A C   1 
+ATOM   2049 O  O   . ALA A 1 259 ? 11.746  36.457  35.435  1.00 16.26 ? 281  ALA A O   1 
+ATOM   2050 C  CB  . ALA A 1 259 ? 8.572   36.972  35.670  1.00 17.85 ? 281  ALA A CB  1 
+ATOM   2051 N  N   . THR A 1 260 ? 10.423  34.662  34.938  1.00 15.42 ? 282  THR A N   1 
+ATOM   2052 C  CA  . THR A 1 260 ? 11.377  33.666  35.282  1.00 15.25 ? 282  THR A CA  1 
+ATOM   2053 C  C   . THR A 1 260 ? 11.249  32.512  34.329  1.00 14.73 ? 282  THR A C   1 
+ATOM   2054 O  O   . THR A 1 260 ? 10.240  32.364  33.639  1.00 14.01 ? 282  THR A O   1 
+ATOM   2055 C  CB  . THR A 1 260 ? 11.142  33.069  36.697  1.00 17.30 ? 282  THR A CB  1 
+ATOM   2056 O  OG1 . THR A 1 260 ? 9.853   32.476  36.784  1.00 16.83 ? 282  THR A OG1 1 
+ATOM   2057 C  CG2 . THR A 1 260 ? 11.249  34.182  37.750  1.00 17.10 ? 282  THR A CG2 1 
+ATOM   2058 N  N   . GLY A 1 261 ? 12.315  31.688  34.294  1.00 15.90 ? 283  GLY A N   1 
+ATOM   2059 C  CA  . GLY A 1 261 ? 12.338  30.468  33.468  1.00 14.34 ? 283  GLY A CA  1 
+ATOM   2060 C  C   . GLY A 1 261 ? 13.310  30.483  32.313  1.00 14.89 ? 283  GLY A C   1 
+ATOM   2061 O  O   . GLY A 1 261 ? 13.608  29.432  31.753  1.00 14.14 ? 283  GLY A O   1 
+ATOM   2062 N  N   . TYR A 1 262 ? 13.846  31.644  31.972  1.00 16.28 ? 284  TYR A N   1 
+ATOM   2063 C  CA  . TYR A 1 262 ? 14.865  31.705  30.926  1.00 14.92 ? 284  TYR A CA  1 
+ATOM   2064 C  C   . TYR A 1 262 ? 16.076  30.842  31.259  1.00 13.77 ? 284  TYR A C   1 
+ATOM   2065 O  O   . TYR A 1 262 ? 16.556  30.888  32.403  1.00 15.62 ? 284  TYR A O   1 
+ATOM   2066 C  CB  . TYR A 1 262 ? 15.279  33.172  30.673  1.00 15.54 ? 284  TYR A CB  1 
+ATOM   2067 C  CG  . TYR A 1 262 ? 16.440  33.346  29.741  1.00 16.67 ? 284  TYR A CG  1 
+ATOM   2068 C  CD1 . TYR A 1 262 ? 16.317  33.042  28.376  1.00 15.91 ? 284  TYR A CD1 1 
+ATOM   2069 C  CD2 . TYR A 1 262 ? 17.700  33.716  30.223  1.00 17.23 ? 284  TYR A CD2 1 
+ATOM   2070 C  CE1 . TYR A 1 262 ? 17.408  33.166  27.550  1.00 18.28 ? 284  TYR A CE1 1 
+ATOM   2071 C  CE2 . TYR A 1 262 ? 18.743  33.855  29.397  1.00 17.40 ? 284  TYR A CE2 1 
+ATOM   2072 C  CZ  . TYR A 1 262 ? 18.629  33.570  28.063  1.00 21.09 ? 284  TYR A CZ  1 
+ATOM   2073 O  OH  . TYR A 1 262 ? 19.693  33.711  27.147  1.00 27.98 ? 284  TYR A OH  1 
+ATOM   2074 N  N   . ILE A 1 263 ? 16.579  30.093  30.269  1.00 15.26 ? 285  ILE A N   1 
+ATOM   2075 C  CA  . ILE A 1 263 ? 17.763  29.276  30.407  1.00 14.58 ? 285  ILE A CA  1 
+ATOM   2076 C  C   . ILE A 1 263 ? 18.973  30.096  30.109  1.00 15.21 ? 285  ILE A C   1 
+ATOM   2077 O  O   . ILE A 1 263 ? 19.204  30.512  28.955  1.00 15.97 ? 285  ILE A O   1 
+ATOM   2078 C  CB  . ILE A 1 263 ? 17.738  28.054  29.555  1.00 15.13 ? 285  ILE A CB  1 
+ATOM   2079 C  CG1 . ILE A 1 263 ? 16.527  27.158  29.982  1.00 16.08 ? 285  ILE A CG1 1 
+ATOM   2080 C  CG2 . ILE A 1 263 ? 19.079  27.298  29.605  1.00 16.70 ? 285  ILE A CG2 1 
+ATOM   2081 C  CD1 . ILE A 1 263 ? 16.387  25.849  29.103  1.00 17.47 ? 285  ILE A CD1 1 
+ATOM   2082 N  N   . GLN A 1 264 ? 19.752  30.364  31.160  1.00 15.98 ? 286  GLN A N   1 
+ATOM   2083 C  CA  . GLN A 1 264 ? 20.946  31.140  31.018  1.00 17.75 ? 286  GLN A CA  1 
+ATOM   2084 C  C   . GLN A 1 264 ? 21.995  30.432  30.191  1.00 17.36 ? 286  GLN A C   1 
+ATOM   2085 O  O   . GLN A 1 264 ? 22.736  31.096  29.417  1.00 18.94 ? 286  GLN A O   1 
+ATOM   2086 C  CB  . GLN A 1 264 ? 21.549  31.429  32.422  1.00 20.70 ? 286  GLN A CB  1 
+ATOM   2087 C  CG  . GLN A 1 264 ? 20.607  32.217  33.263  1.00 23.72 ? 286  GLN A CG  1 
+ATOM   2088 C  CD  . GLN A 1 264 ? 20.657  33.723  32.920  1.00 31.03 ? 286  GLN A CD  1 
+ATOM   2089 O  OE1 . GLN A 1 264 ? 21.677  34.196  32.370  1.00 34.90 ? 286  GLN A OE1 1 
+ATOM   2090 N  NE2 . GLN A 1 264 ? 19.558  34.470  33.197  1.00 32.20 ? 286  GLN A NE2 1 
+ATOM   2091 N  N   . ASP A 1 265 ? 22.154  29.128  30.398  1.00 17.38 ? 287  ASP A N   1 
+ATOM   2092 C  CA  . ASP A 1 265 ? 23.196  28.367  29.697  1.00 17.98 ? 287  ASP A CA  1 
+ATOM   2093 C  C   . ASP A 1 265 ? 22.516  27.222  28.941  1.00 18.28 ? 287  ASP A C   1 
+ATOM   2094 O  O   . ASP A 1 265 ? 22.068  26.240  29.528  1.00 18.24 ? 287  ASP A O   1 
+ATOM   2095 C  CB  . ASP A 1 265 ? 24.166  27.767  30.706  1.00 19.48 ? 287  ASP A CB  1 
+ATOM   2096 C  CG  . ASP A 1 265 ? 25.325  27.045  30.031  1.00 22.04 ? 287  ASP A CG  1 
+ATOM   2097 O  OD1 . ASP A 1 265 ? 25.311  26.936  28.770  1.00 20.67 ? 287  ASP A OD1 1 
+ATOM   2098 O  OD2 . ASP A 1 265 ? 26.221  26.603  30.801  1.00 26.09 ? 287  ASP A OD2 1 
+ATOM   2099 N  N   . PRO A 1 266 ? 22.431  27.349  27.617  1.00 18.40 ? 288  PRO A N   1 
+ATOM   2100 C  CA  . PRO A 1 266 ? 21.742  26.326  26.803  1.00 18.37 ? 288  PRO A CA  1 
+ATOM   2101 C  C   . PRO A 1 266 ? 22.314  24.905  26.989  1.00 16.94 ? 288  PRO A C   1 
+ATOM   2102 O  O   . PRO A 1 266 ? 21.618  23.905  26.750  1.00 17.20 ? 288  PRO A O   1 
+ATOM   2103 C  CB  . PRO A 1 266 ? 21.985  26.820  25.350  1.00 17.79 ? 288  PRO A CB  1 
+ATOM   2104 C  CG  . PRO A 1 266 ? 22.162  28.251  25.460  1.00 20.92 ? 288  PRO A CG  1 
+ATOM   2105 C  CD  . PRO A 1 266 ? 22.875  28.495  26.796  1.00 18.93 ? 288  PRO A CD  1 
+ATOM   2106 N  N   . GLN A 1 267 ? 23.580  24.814  27.410  1.00 17.16 ? 289  GLN A N   1 
+ATOM   2107 C  CA  . GLN A 1 267 ? 24.147  23.519  27.712  1.00 18.18 ? 289  GLN A CA  1 
+ATOM   2108 C  C   . GLN A 1 267 ? 23.278  22.706  28.709  1.00 15.24 ? 289  GLN A C   1 
+ATOM   2109 O  O   . GLN A 1 267 ? 23.189  21.465  28.635  1.00 16.69 ? 289  GLN A O   1 
+ATOM   2110 C  CB  . GLN A 1 267 ? 25.564  23.667  28.297  1.00 21.81 ? 289  GLN A CB  1 
+ATOM   2111 C  CG  . GLN A 1 267 ? 26.556  24.213  27.361  1.00 21.20 ? 289  GLN A CG  1 
+ATOM   2112 C  CD  . GLN A 1 267 ? 27.021  23.217  26.305  1.00 23.68 ? 289  GLN A CD  1 
+ATOM   2113 O  OE1 . GLN A 1 267 ? 27.179  22.033  26.601  1.00 28.01 ? 289  GLN A OE1 1 
+ATOM   2114 N  NE2 . GLN A 1 267 ? 27.249  23.690  25.090  1.00 24.08 ? 289  GLN A NE2 1 
+ATOM   2115 N  N   . ASP A 1 268 ? 22.630  23.376  29.627  1.00 17.78 ? 290  ASP A N   1 
+ATOM   2116 C  CA  . ASP A 1 268 ? 21.806  22.689  30.619  1.00 18.48 ? 290  ASP A CA  1 
+ATOM   2117 C  C   . ASP A 1 268 ? 20.648  21.946  29.916  1.00 17.80 ? 290  ASP A C   1 
+ATOM   2118 O  O   . ASP A 1 268 ? 20.291  20.816  30.270  1.00 17.70 ? 290  ASP A O   1 
+ATOM   2119 C  CB  . ASP A 1 268 ? 21.219  23.699  31.602  1.00 19.71 ? 290  ASP A CB  1 
+ATOM   2120 C  CG  . ASP A 1 268 ? 22.257  24.185  32.628  1.00 21.80 ? 290  ASP A CG  1 
+ATOM   2121 O  OD1 . ASP A 1 268 ? 23.247  23.454  32.798  1.00 26.12 ? 290  ASP A OD1 1 
+ATOM   2122 O  OD2 . ASP A 1 268 ? 22.146  25.287  33.204  1.00 24.30 ? 290  ASP A OD2 1 
+ATOM   2123 N  N   . LEU A 1 269 ? 20.103  22.560  28.851  1.00 16.64 ? 291  LEU A N   1 
+ATOM   2124 C  CA  . LEU A 1 269 ? 19.056  21.897  28.082  1.00 17.11 ? 291  LEU A CA  1 
+ATOM   2125 C  C   . LEU A 1 269 ? 19.613  20.767  27.200  1.00 16.47 ? 291  LEU A C   1 
+ATOM   2126 O  O   . LEU A 1 269 ? 19.042  19.696  27.154  1.00 15.82 ? 291  LEU A O   1 
+ATOM   2127 C  CB  . LEU A 1 269 ? 18.276  22.898  27.238  1.00 15.89 ? 291  LEU A CB  1 
+ATOM   2128 C  CG  . LEU A 1 269 ? 17.093  22.262  26.465  1.00 16.85 ? 291  LEU A CG  1 
+ATOM   2129 C  CD1 . LEU A 1 269 ? 15.935  23.238  26.351  1.00 16.96 ? 291  LEU A CD1 1 
+ATOM   2130 C  CD2 . LEU A 1 269 ? 17.480  21.732  25.055  1.00 16.71 ? 291  LEU A CD2 1 
+ATOM   2131 N  N   . TYR A 1 270 ? 20.703  21.036  26.509  1.00 15.68 ? 292  TYR A N   1 
+ATOM   2132 C  CA  . TYR A 1 270 ? 21.299  20.023  25.639  1.00 16.81 ? 292  TYR A CA  1 
+ATOM   2133 C  C   . TYR A 1 270 ? 21.532  18.751  26.465  1.00 16.85 ? 292  TYR A C   1 
+ATOM   2134 O  O   . TYR A 1 270 ? 21.228  17.657  26.026  1.00 16.39 ? 292  TYR A O   1 
+ATOM   2135 C  CB  . TYR A 1 270 ? 22.634  20.463  25.002  1.00 15.47 ? 292  TYR A CB  1 
+ATOM   2136 C  CG  . TYR A 1 270 ? 22.613  21.772  24.234  1.00 15.88 ? 292  TYR A CG  1 
+ATOM   2137 C  CD1 . TYR A 1 270 ? 21.467  22.229  23.567  1.00 14.25 ? 292  TYR A CD1 1 
+ATOM   2138 C  CD2 . TYR A 1 270 ? 23.753  22.553  24.183  1.00 15.80 ? 292  TYR A CD2 1 
+ATOM   2139 C  CE1 . TYR A 1 270 ? 21.482  23.466  22.894  1.00 14.74 ? 292  TYR A CE1 1 
+ATOM   2140 C  CE2 . TYR A 1 270 ? 23.791  23.749  23.551  1.00 15.79 ? 292  TYR A CE2 1 
+ATOM   2141 C  CZ  . TYR A 1 270 ? 22.655  24.209  22.886  1.00 15.03 ? 292  TYR A CZ  1 
+ATOM   2142 O  OH  . TYR A 1 270 ? 22.708  25.380  22.196  1.00 18.62 ? 292  TYR A OH  1 
+ATOM   2143 N  N   . LYS A 1 271 ? 22.130  18.909  27.656  1.00 17.00 ? 293  LYS A N   1 
+ATOM   2144 C  CA  . LYS A 1 271 ? 22.488  17.762  28.479  1.00 16.10 ? 293  LYS A CA  1 
+ATOM   2145 C  C   . LYS A 1 271 ? 21.283  17.019  29.031  1.00 16.49 ? 293  LYS A C   1 
+ATOM   2146 O  O   . LYS A 1 271 ? 21.261  15.786  29.017  1.00 18.05 ? 293  LYS A O   1 
+ATOM   2147 C  CB  . LYS A 1 271 ? 23.420  18.257  29.608  1.00 19.63 ? 293  LYS A CB  1 
+ATOM   2148 C  CG  . LYS A 1 271 ? 24.791  18.698  29.109  1.00 21.89 ? 293  LYS A CG  1 
+ATOM   2149 C  CD  . LYS A 1 271 ? 25.745  19.203  30.182  1.00 22.94 ? 293  LYS A CD  1 
+ATOM   2150 C  CE  . LYS A 1 271 ? 27.080  19.625  29.484  1.00 23.59 ? 293  LYS A CE  1 
+ATOM   2151 N  NZ  . LYS A 1 271 ? 28.141  20.091  30.499  1.00 28.15 ? 293  LYS A NZ  1 
+ATOM   2152 N  N   . ALA A 1 272 ? 20.286  17.776  29.510  1.00 14.95 ? 294  ALA A N   1 
+ATOM   2153 C  CA  . ALA A 1 272 ? 19.071  17.162  29.952  1.00 14.86 ? 294  ALA A CA  1 
+ATOM   2154 C  C   . ALA A 1 272 ? 18.356  16.369  28.840  1.00 15.10 ? 294  ALA A C   1 
+ATOM   2155 O  O   . ALA A 1 272 ? 17.960  15.214  29.055  1.00 16.40 ? 294  ALA A O   1 
+ATOM   2156 C  CB  . ALA A 1 272 ? 18.107  18.182  30.544  1.00 17.20 ? 294  ALA A CB  1 
+ATOM   2157 N  N   . PHE A 1 273 ? 18.228  16.976  27.658  1.00 14.91 ? 295  PHE A N   1 
+ATOM   2158 C  CA  . PHE A 1 273 ? 17.639  16.259  26.536  1.00 14.37 ? 295  PHE A CA  1 
+ATOM   2159 C  C   . PHE A 1 273 ? 18.482  15.021  26.197  1.00 17.71 ? 295  PHE A C   1 
+ATOM   2160 O  O   . PHE A 1 273 ? 17.916  13.997  25.872  1.00 17.57 ? 295  PHE A O   1 
+ATOM   2161 C  CB  . PHE A 1 273 ? 17.514  17.191  25.316  1.00 13.69 ? 295  PHE A CB  1 
+ATOM   2162 C  CG  . PHE A 1 273 ? 16.253  18.003  25.297  1.00 13.78 ? 295  PHE A CG  1 
+ATOM   2163 C  CD1 . PHE A 1 273 ? 15.883  18.778  26.382  1.00 15.79 ? 295  PHE A CD1 1 
+ATOM   2164 C  CD2 . PHE A 1 273 ? 15.461  18.011  24.179  1.00 14.39 ? 295  PHE A CD2 1 
+ATOM   2165 C  CE1 . PHE A 1 273 ? 14.685  19.523  26.343  1.00 16.93 ? 295  PHE A CE1 1 
+ATOM   2166 C  CE2 . PHE A 1 273 ? 14.293  18.773  24.145  1.00 15.46 ? 295  PHE A CE2 1 
+ATOM   2167 C  CZ  . PHE A 1 273 ? 13.911  19.526  25.223  1.00 16.74 ? 295  PHE A CZ  1 
+ATOM   2168 N  N   . ASP A 1 274 ? 19.803  15.121  26.238  1.00 15.12 ? 296  ASP A N   1 
+ATOM   2169 C  CA  . ASP A 1 274 ? 20.618  13.965  25.932  1.00 17.30 ? 296  ASP A CA  1 
+ATOM   2170 C  C   . ASP A 1 274 ? 20.374  12.852  26.965  1.00 16.81 ? 296  ASP A C   1 
+ATOM   2171 O  O   . ASP A 1 274 ? 20.344  11.656  26.609  1.00 17.41 ? 296  ASP A O   1 
+ATOM   2172 C  CB  . ASP A 1 274 ? 22.074  14.376  25.888  1.00 17.31 ? 296  ASP A CB  1 
+ATOM   2173 C  CG  . ASP A 1 274 ? 22.428  15.203  24.613  1.00 19.43 ? 296  ASP A CG  1 
+ATOM   2174 O  OD1 . ASP A 1 274 ? 21.616  15.218  23.639  1.00 18.90 ? 296  ASP A OD1 1 
+ATOM   2175 O  OD2 . ASP A 1 274 ? 23.533  15.784  24.556  1.00 20.55 ? 296  ASP A OD2 1 
+ATOM   2176 N  N   . ARG A 1 275 ? 20.251  13.241  28.233  1.00 17.19 ? 297  ARG A N   1 
+ATOM   2177 C  CA  . ARG A 1 275 ? 19.989  12.243  29.247  1.00 17.56 ? 297  ARG A CA  1 
+ATOM   2178 C  C   . ARG A 1 275 ? 18.641  11.525  29.028  1.00 18.98 ? 297  ARG A C   1 
+ATOM   2179 O  O   . ARG A 1 275 ? 18.508  10.310  29.237  1.00 18.92 ? 297  ARG A O   1 
+ATOM   2180 C  CB  . ARG A 1 275 ? 20.037  12.939  30.625  1.00 19.26 ? 297  ARG A CB  1 
+ATOM   2181 C  CG  . ARG A 1 275 ? 21.473  13.235  31.036  1.00 19.61 ? 297  ARG A CG  1 
+ATOM   2182 C  CD  . ARG A 1 275 ? 21.589  14.209  32.234  1.00 22.86 ? 297  ARG A CD  1 
+ATOM   2183 N  NE  . ARG A 1 275 ? 21.005  13.560  33.410  1.00 23.81 ? 297  ARG A NE  1 
+ATOM   2184 C  CZ  . ARG A 1 275 ? 20.935  14.133  34.617  1.00 25.53 ? 297  ARG A CZ  1 
+ATOM   2185 N  NH1 . ARG A 1 275 ? 21.398  15.369  34.789  1.00 26.95 ? 297  ARG A NH1 1 
+ATOM   2186 N  NH2 . ARG A 1 275 ? 20.388  13.483  35.641  1.00 27.65 ? 297  ARG A NH2 1 
+ATOM   2187 N  N   . LEU A 1 276 ? 17.644  12.279  28.607  1.00 17.21 ? 298  LEU A N   1 
+ATOM   2188 C  CA  . LEU A 1 276 ? 16.363  11.691  28.312  1.00 17.73 ? 298  LEU A CA  1 
+ATOM   2189 C  C   . LEU A 1 276 ? 16.437  10.749  27.115  1.00 18.17 ? 298  LEU A C   1 
+ATOM   2190 O  O   . LEU A 1 276 ? 15.922  9.626   27.138  1.00 18.20 ? 298  LEU A O   1 
+ATOM   2191 C  CB  . LEU A 1 276 ? 15.307  12.780  28.093  1.00 14.85 ? 298  LEU A CB  1 
+ATOM   2192 C  CG  . LEU A 1 276 ? 15.095  13.618  29.404  1.00 16.61 ? 298  LEU A CG  1 
+ATOM   2193 C  CD1 . LEU A 1 276 ? 14.364  14.898  29.020  1.00 15.83 ? 298  LEU A CD1 1 
+ATOM   2194 C  CD2 . LEU A 1 276 ? 14.221  12.850  30.394  1.00 19.92 ? 298  LEU A CD2 1 
+ATOM   2195 N  N   . LYS A 1 277 ? 17.186  11.150  26.106  1.00 18.24 ? 299  LYS A N   1 
+ATOM   2196 C  CA  . LYS A 1 277 ? 17.480  10.228  24.982  1.00 19.14 ? 299  LYS A CA  1 
+ATOM   2197 C  C   . LYS A 1 277 ? 18.212  8.932   25.456  1.00 18.51 ? 299  LYS A C   1 
+ATOM   2198 O  O   . LYS A 1 277 ? 17.908  7.804   25.002  1.00 18.48 ? 299  LYS A O   1 
+ATOM   2199 C  CB  . LYS A 1 277 ? 18.326  10.951  23.949  1.00 19.74 ? 299  LYS A CB  1 
+ATOM   2200 C  CG  A LYS A 1 277 ? 18.854  10.115  22.806  0.38 17.77 ? 299  LYS A CG  1 
+ATOM   2201 C  CG  C LYS A 1 277 ? 17.695  12.030  23.154  0.62 22.63 ? 299  LYS A CG  1 
+ATOM   2202 C  CD  A LYS A 1 277 ? 19.365  10.896  21.610  0.38 16.98 ? 299  LYS A CD  1 
+ATOM   2203 C  CD  C LYS A 1 277 ? 18.247  12.127  21.773  0.62 26.11 ? 299  LYS A CD  1 
+ATOM   2204 C  CE  A LYS A 1 277 ? 20.377  12.018  21.830  0.38 18.50 ? 299  LYS A CE  1 
+ATOM   2205 C  CE  C LYS A 1 277 ? 19.754  12.441  21.653  0.62 27.10 ? 299  LYS A CE  1 
+ATOM   2206 N  NZ  A LYS A 1 277 ? 20.573  12.907  20.642  0.38 18.33 ? 299  LYS A NZ  1 
+ATOM   2207 N  NZ  C LYS A 1 277 ? 20.287  12.528  20.243  0.62 28.28 ? 299  LYS A NZ  1 
+ATOM   2208 N  N   . ALA A 1 278 ? 19.110  9.090   26.425  1.00 19.10 ? 300  ALA A N   1 
+ATOM   2209 C  CA  . ALA A 1 278 ? 19.931  7.960   26.845  1.00 21.82 ? 300  ALA A CA  1 
+ATOM   2210 C  C   . ALA A 1 278 ? 19.082  6.908   27.521  1.00 22.45 ? 300  ALA A C   1 
+ATOM   2211 O  O   . ALA A 1 278 ? 19.525  5.741   27.625  1.00 24.10 ? 300  ALA A O   1 
+ATOM   2212 C  CB  . ALA A 1 278 ? 21.036  8.431   27.798  1.00 21.57 ? 300  ALA A CB  1 
+ATOM   2213 N  N   . GLN A 1 279 ? 18.005  7.310   28.183  1.00 20.47 ? 301  GLN A N   1 
+ATOM   2214 C  CA  . GLN A 1 279 ? 17.107  6.338   28.823  1.00 20.16 ? 301  GLN A CA  1 
+ATOM   2215 C  C   . GLN A 1 279 ? 15.993  5.854   27.888  1.00 19.19 ? 301  GLN A C   1 
+ATOM   2216 O  O   . GLN A 1 279 ? 15.014  5.243   28.339  1.00 21.31 ? 301  GLN A O   1 
+ATOM   2217 C  CB  . GLN A 1 279 ? 16.543  6.859   30.172  1.00 20.00 ? 301  GLN A CB  1 
+ATOM   2218 C  CG  . GLN A 1 279 ? 15.572  7.992   29.984  1.00 18.81 ? 301  GLN A CG  1 
+ATOM   2219 C  CD  . GLN A 1 279 ? 15.160  8.640   31.273  1.00 19.29 ? 301  GLN A CD  1 
+ATOM   2220 O  OE1 . GLN A 1 279 ? 16.023  8.883   32.101  1.00 23.04 ? 301  GLN A OE1 1 
+ATOM   2221 N  NE2 . GLN A 1 279 ? 13.847  8.929   31.433  1.00 20.66 ? 301  GLN A NE2 1 
+ATOM   2222 N  N   . GLY A 1 280 ? 16.128  6.101   26.585  1.00 20.78 ? 302  GLY A N   1 
+ATOM   2223 C  CA  . GLY A 1 280 ? 15.161  5.650   25.648  1.00 19.80 ? 302  GLY A CA  1 
+ATOM   2224 C  C   . GLY A 1 280 ? 13.962  6.511   25.390  1.00 17.18 ? 302  GLY A C   1 
+ATOM   2225 O  O   . GLY A 1 280 ? 13.013  6.037   24.794  1.00 19.91 ? 302  GLY A O   1 
+ATOM   2226 N  N   . GLN A 1 281 ? 13.970  7.755   25.863  1.00 18.24 ? 303  GLN A N   1 
+ATOM   2227 C  CA  . GLN A 1 281 ? 12.780  8.596   25.828  1.00 16.42 ? 303  GLN A CA  1 
+ATOM   2228 C  C   . GLN A 1 281 ? 13.055  10.024  25.320  1.00 15.92 ? 303  GLN A C   1 
+ATOM   2229 O  O   . GLN A 1 281 ? 12.880  11.005  26.027  1.00 17.75 ? 303  GLN A O   1 
+ATOM   2230 C  CB  . GLN A 1 281 ? 12.143  8.650   27.258  1.00 17.94 ? 303  GLN A CB  1 
+ATOM   2231 C  CG  . GLN A 1 281 ? 11.765  7.263   27.747  1.00 17.95 ? 303  GLN A CG  1 
+ATOM   2232 C  CD  . GLN A 1 281 ? 11.101  7.309   29.109  1.00 19.98 ? 303  GLN A CD  1 
+ATOM   2233 O  OE1 . GLN A 1 281 ? 11.688  7.861   30.064  1.00 18.43 ? 303  GLN A OE1 1 
+ATOM   2234 N  NE2 . GLN A 1 281 ? 9.894   6.747   29.190  1.00 23.03 ? 303  GLN A NE2 1 
+ATOM   2235 N  N   . PRO A 1 282 ? 13.491  10.158  24.088  1.00 16.31 ? 304  PRO A N   1 
+ATOM   2236 C  CA  . PRO A 1 282 ? 13.790  11.502  23.576  1.00 16.30 ? 304  PRO A CA  1 
+ATOM   2237 C  C   . PRO A 1 282 ? 12.526  12.328  23.526  1.00 14.66 ? 304  PRO A C   1 
+ATOM   2238 O  O   . PRO A 1 282 ? 11.482  11.831  23.235  1.00 16.04 ? 304  PRO A O   1 
+ATOM   2239 C  CB  . PRO A 1 282 ? 14.247  11.234  22.142  1.00 17.51 ? 304  PRO A CB  1 
+ATOM   2240 C  CG  . PRO A 1 282 ? 14.309  9.802   21.970  1.00 17.07 ? 304  PRO A CG  1 
+ATOM   2241 C  CD  . PRO A 1 282 ? 13.759  9.083   23.119  1.00 18.00 ? 304  PRO A CD  1 
+ATOM   2242 N  N   . LEU A 1 283 ? 12.675  13.603  23.823  1.00 14.95 ? 305  LEU A N   1 
+ATOM   2243 C  CA  . LEU A 1 283 ? 11.557  14.535  23.780  1.00 14.51 ? 305  LEU A CA  1 
+ATOM   2244 C  C   . LEU A 1 283 ? 11.244  14.963  22.351  1.00 13.86 ? 305  LEU A C   1 
+ATOM   2245 O  O   . LEU A 1 283 ? 12.023  14.698  21.427  1.00 16.21 ? 305  LEU A O   1 
+ATOM   2246 C  CB  . LEU A 1 283 ? 11.828  15.785  24.661  1.00 14.23 ? 305  LEU A CB  1 
+ATOM   2247 C  CG  . LEU A 1 283 ? 12.066  15.511  26.140  1.00 15.91 ? 305  LEU A CG  1 
+ATOM   2248 C  CD1 . LEU A 1 283 ? 11.958  16.803  26.946  1.00 14.41 ? 305  LEU A CD1 1 
+ATOM   2249 C  CD2 . LEU A 1 283 ? 11.094  14.461  26.653  1.00 16.17 ? 305  LEU A CD2 1 
+ATOM   2250 N  N   . ARG A 1 284 ? 10.110  15.614  22.185  1.00 12.33 ? 306  ARG A N   1 
+ATOM   2251 C  CA  . ARG A 1 284 ? 9.567   15.936  20.839  1.00 12.33 ? 306  ARG A CA  1 
+ATOM   2252 C  C   . ARG A 1 284 ? 9.973   17.342  20.379  1.00 12.77 ? 306  ARG A C   1 
+ATOM   2253 O  O   . ARG A 1 284 ? 9.848   17.651  19.175  1.00 13.11 ? 306  ARG A O   1 
+ATOM   2254 C  CB  . ARG A 1 284 ? 8.067   15.796  20.901  1.00 14.36 ? 306  ARG A CB  1 
+ATOM   2255 C  CG  . ARG A 1 284 ? 7.305   16.124  19.636  1.00 14.01 ? 306  ARG A CG  1 
+ATOM   2256 C  CD  . ARG A 1 284 ? 7.737   15.173  18.491  1.00 14.57 ? 306  ARG A CD  1 
+ATOM   2257 N  NE  . ARG A 1 284 ? 6.927   15.446  17.275  1.00 15.45 ? 306  ARG A NE  1 
+ATOM   2258 C  CZ  . ARG A 1 284 ? 5.673   15.047  17.088  1.00 16.90 ? 306  ARG A CZ  1 
+ATOM   2259 N  NH1 . ARG A 1 284 ? 5.047   15.385  15.950  1.00 20.36 ? 306  ARG A NH1 1 
+ATOM   2260 N  NH2 . ARG A 1 284 ? 5.005   14.291  17.968  1.00 18.40 ? 306  ARG A NH2 1 
+ATOM   2261 N  N   . GLY A 1 285 ? 10.573  18.173  21.228  1.00 12.78 ? 307  GLY A N   1 
+ATOM   2262 C  CA  . GLY A 1 285 ? 11.037  19.496  20.793  1.00 13.69 ? 307  GLY A CA  1 
+ATOM   2263 C  C   . GLY A 1 285 ? 11.040  20.487  21.920  1.00 12.67 ? 307  GLY A C   1 
+ATOM   2264 O  O   . GLY A 1 285 ? 11.012  20.118  23.118  1.00 13.41 ? 307  GLY A O   1 
+ATOM   2265 N  N   . VAL A 1 286 ? 11.084  21.757  21.501  1.00 12.19 ? 308  VAL A N   1 
+ATOM   2266 C  CA  . VAL A 1 286 ? 10.948  22.908  22.417  1.00 10.13 ? 308  VAL A CA  1 
+ATOM   2267 C  C   . VAL A 1 286 ? 9.898   23.861  21.861  1.00 11.03 ? 308  VAL A C   1 
+ATOM   2268 O  O   . VAL A 1 286 ? 9.568   23.821  20.664  1.00 12.67 ? 308  VAL A O   1 
+ATOM   2269 C  CB  . VAL A 1 286 ? 12.307  23.659  22.637  1.00 13.98 ? 308  VAL A CB  1 
+ATOM   2270 C  CG1 . VAL A 1 286 ? 13.397  22.756  23.282  1.00 15.84 ? 308  VAL A CG1 1 
+ATOM   2271 C  CG2 . VAL A 1 286 ? 12.749  24.389  21.363  1.00 13.65 ? 308  VAL A CG2 1 
+ATOM   2272 N  N   . MET A 1 287 ? 9.407   24.688  22.741  1.00 12.26 ? 309  MET A N   1 
+ATOM   2273 C  CA  . MET A 1 287 ? 8.479   25.728  22.409  1.00 12.06 ? 309  MET A CA  1 
+ATOM   2274 C  C   . MET A 1 287 ? 8.957   27.039  23.070  1.00 11.19 ? 309  MET A C   1 
+ATOM   2275 O  O   . MET A 1 287 ? 9.659   27.011  24.077  1.00 10.86 ? 309  MET A O   1 
+ATOM   2276 C  CB  . MET A 1 287 ? 7.103   25.363  22.940  1.00 13.31 ? 309  MET A CB  1 
+ATOM   2277 C  CG  . MET A 1 287 ? 6.081   26.455  22.941  1.00 13.04 ? 309  MET A CG  1 
+ATOM   2278 S  SD  . MET A 1 287 ? 6.221   27.643  24.364  1.00 12.14 ? 309  MET A SD  1 
+ATOM   2279 C  CE  . MET A 1 287 ? 4.988   26.942  25.499  1.00 12.04 ? 309  MET A CE  1 
+ATOM   2280 N  N   . THR A 1 288 ? 8.622   28.166  22.465  1.00 11.49 ? 310  THR A N   1 
+ATOM   2281 C  CA  . THR A 1 288 ? 8.958   29.427  23.068  1.00 11.73 ? 310  THR A CA  1 
+ATOM   2282 C  C   . THR A 1 288 ? 7.886   30.498  22.935  1.00 11.83 ? 310  THR A C   1 
+ATOM   2283 O  O   . THR A 1 288 ? 7.251   30.655  21.903  1.00 11.99 ? 310  THR A O   1 
+ATOM   2284 C  CB  . THR A 1 288 ? 10.319  29.974  22.559  1.00 12.22 ? 310  THR A CB  1 
+ATOM   2285 O  OG1 . THR A 1 288 ? 10.757  31.059  23.390  1.00 11.94 ? 310  THR A OG1 1 
+ATOM   2286 C  CG2 . THR A 1 288 ? 10.227  30.480  21.159  1.00 14.33 ? 310  THR A CG2 1 
+ATOM   2287 N  N   . TRP A 1 289 ? 7.724   31.247  24.065  1.00 11.14 ? 311  TRP A N   1 
+ATOM   2288 C  CA  . TRP A 1 289 ? 7.130   32.578  24.047  1.00 11.67 ? 311  TRP A CA  1 
+ATOM   2289 C  C   . TRP A 1 289 ? 8.366   33.455  23.909  1.00 12.96 ? 311  TRP A C   1 
+ATOM   2290 O  O   . TRP A 1 289 ? 9.132   33.618  24.867  1.00 12.48 ? 311  TRP A O   1 
+ATOM   2291 C  CB  . TRP A 1 289 ? 6.368   32.885  25.359  1.00 11.71 ? 311  TRP A CB  1 
+ATOM   2292 C  CG  . TRP A 1 289 ? 5.614   34.140  25.263  1.00 11.55 ? 311  TRP A CG  1 
+ATOM   2293 C  CD1 . TRP A 1 289 ? 5.977   35.352  25.692  1.00 12.36 ? 311  TRP A CD1 1 
+ATOM   2294 C  CD2 . TRP A 1 289 ? 4.371   34.286  24.630  1.00 11.54 ? 311  TRP A CD2 1 
+ATOM   2295 N  NE1 . TRP A 1 289 ? 5.046   36.291  25.338  1.00 12.96 ? 311  TRP A NE1 1 
+ATOM   2296 C  CE2 . TRP A 1 289 ? 4.030   35.656  24.674  1.00 12.05 ? 311  TRP A CE2 1 
+ATOM   2297 C  CE3 . TRP A 1 289 ? 3.503   33.401  24.013  1.00 12.99 ? 311  TRP A CE3 1 
+ATOM   2298 C  CZ2 . TRP A 1 289 ? 2.859   36.130  24.135  1.00 13.14 ? 311  TRP A CZ2 1 
+ATOM   2299 C  CZ3 . TRP A 1 289 ? 2.341   33.895  23.457  1.00 12.78 ? 311  TRP A CZ3 1 
+ATOM   2300 C  CH2 . TRP A 1 289 ? 2.039   35.256  23.509  1.00 13.70 ? 311  TRP A CH2 1 
+ATOM   2301 N  N   . SER A 1 290 ? 8.654   33.978  22.704  1.00 12.71 ? 312  SER A N   1 
+ATOM   2302 C  CA  . SER A 1 290 ? 7.793   33.992  21.502  1.00 12.26 ? 312  SER A CA  1 
+ATOM   2303 C  C   . SER A 1 290 ? 8.688   34.403  20.321  1.00 11.85 ? 312  SER A C   1 
+ATOM   2304 O  O   . SER A 1 290 ? 9.785   34.923  20.536  1.00 12.94 ? 312  SER A O   1 
+ATOM   2305 C  CB  . SER A 1 290 ? 6.683   35.038  21.596  1.00 12.32 ? 312  SER A CB  1 
+ATOM   2306 O  OG  . SER A 1 290 ? 7.218   36.369  21.702  1.00 13.16 ? 312  SER A OG  1 
+ATOM   2307 N  N   . VAL A 1 291 ? 8.215   34.200  19.086  1.00 12.50 ? 313  VAL A N   1 
+ATOM   2308 C  CA  . VAL A 1 291 ? 9.081   34.631  17.975  1.00 12.52 ? 313  VAL A CA  1 
+ATOM   2309 C  C   . VAL A 1 291 ? 9.258   36.143  18.019  1.00 14.42 ? 313  VAL A C   1 
+ATOM   2310 O  O   . VAL A 1 291 ? 10.320  36.677  17.683  1.00 13.86 ? 313  VAL A O   1 
+ATOM   2311 C  CB  . VAL A 1 291 ? 8.533   34.160  16.585  1.00 13.05 ? 313  VAL A CB  1 
+ATOM   2312 C  CG1 . VAL A 1 291 ? 8.262   32.661  16.599  1.00 13.04 ? 313  VAL A CG1 1 
+ATOM   2313 C  CG2 . VAL A 1 291 ? 7.270   34.914  16.174  1.00 12.95 ? 313  VAL A CG2 1 
+ATOM   2314 N  N   . ASN A 1 292 ? 8.230   36.835  18.487  1.00 12.26 ? 314  ASN A N   1 
+ATOM   2315 C  CA  . ASN A 1 292 ? 8.338   38.317  18.610  1.00 13.07 ? 314  ASN A CA  1 
+ATOM   2316 C  C   . ASN A 1 292 ? 9.432   38.762  19.612  1.00 11.60 ? 314  ASN A C   1 
+ATOM   2317 O  O   . ASN A 1 292 ? 10.173  39.694  19.336  1.00 14.38 ? 314  ASN A O   1 
+ATOM   2318 C  CB  . ASN A 1 292 ? 6.979   38.956  18.973  1.00 13.85 ? 314  ASN A CB  1 
+ATOM   2319 C  CG  . ASN A 1 292 ? 5.903   38.616  17.981  1.00 14.50 ? 314  ASN A CG  1 
+ATOM   2320 O  OD1 . ASN A 1 292 ? 5.515   37.466  17.894  1.00 13.98 ? 314  ASN A OD1 1 
+ATOM   2321 N  ND2 . ASN A 1 292 ? 5.502   39.574  17.150  1.00 14.43 ? 314  ASN A ND2 1 
+ATOM   2322 N  N   . TRP A 1 293 ? 9.509   38.054  20.751  1.00 11.86 ? 315  TRP A N   1 
+ATOM   2323 C  CA  . TRP A 1 293 ? 10.561  38.339  21.722  1.00 13.88 ? 315  TRP A CA  1 
+ATOM   2324 C  C   . TRP A 1 293 ? 11.937  37.940  21.156  1.00 13.80 ? 315  TRP A C   1 
+ATOM   2325 O  O   . TRP A 1 293 ? 12.909  38.654  21.374  1.00 13.88 ? 315  TRP A O   1 
+ATOM   2326 C  CB  . TRP A 1 293 ? 10.289  37.670  23.079  1.00 13.16 ? 315  TRP A CB  1 
+ATOM   2327 C  CG  . TRP A 1 293 ? 9.348   38.514  23.882  1.00 12.93 ? 315  TRP A CG  1 
+ATOM   2328 C  CD1 . TRP A 1 293 ? 8.102   38.222  24.283  1.00 13.68 ? 315  TRP A CD1 1 
+ATOM   2329 C  CD2 . TRP A 1 293 ? 9.622   39.848  24.280  1.00 13.62 ? 315  TRP A CD2 1 
+ATOM   2330 N  NE1 . TRP A 1 293 ? 7.534   39.341  24.908  1.00 15.08 ? 315  TRP A NE1 1 
+ATOM   2331 C  CE2 . TRP A 1 293 ? 8.464   40.347  24.893  1.00 15.53 ? 315  TRP A CE2 1 
+ATOM   2332 C  CE3 . TRP A 1 293 ? 10.729  40.692  24.094  1.00 14.73 ? 315  TRP A CE3 1 
+ATOM   2333 C  CZ2 . TRP A 1 293 ? 8.386   41.647  25.377  1.00 14.86 ? 315  TRP A CZ2 1 
+ATOM   2334 C  CZ3 . TRP A 1 293 ? 10.634  42.019  24.553  1.00 15.65 ? 315  TRP A CZ3 1 
+ATOM   2335 C  CH2 . TRP A 1 293 ? 9.459   42.454  25.213  1.00 15.10 ? 315  TRP A CH2 1 
+ATOM   2336 N  N   . ASP A 1 294 ? 12.009  36.826  20.401  1.00 13.98 ? 316  ASP A N   1 
+ATOM   2337 C  CA  . ASP A 1 294 ? 13.261  36.423  19.780  1.00 13.31 ? 316  ASP A CA  1 
+ATOM   2338 C  C   . ASP A 1 294 ? 13.764  37.460  18.790  1.00 14.05 ? 316  ASP A C   1 
+ATOM   2339 O  O   . ASP A 1 294 ? 14.976  37.525  18.513  1.00 16.36 ? 316  ASP A O   1 
+ATOM   2340 C  CB  . ASP A 1 294 ? 13.133  35.034  19.163  1.00 12.48 ? 316  ASP A CB  1 
+ATOM   2341 C  CG  . ASP A 1 294 ? 14.458  34.288  19.100  1.00 13.29 ? 316  ASP A CG  1 
+ATOM   2342 O  OD1 . ASP A 1 294 ? 15.360  34.521  19.937  1.00 15.42 ? 316  ASP A OD1 1 
+ATOM   2343 O  OD2 . ASP A 1 294 ? 14.564  33.356  18.226  1.00 13.78 ? 316  ASP A OD2 1 
+ATOM   2344 N  N   . MET A 1 295 ? 12.862  38.257  18.235  1.00 14.04 ? 317  MET A N   1 
+ATOM   2345 C  CA  . MET A 1 295 ? 13.177  39.314  17.288  1.00 14.85 ? 317  MET A CA  1 
+ATOM   2346 C  C   . MET A 1 295 ? 13.003  40.720  17.893  1.00 15.80 ? 317  MET A C   1 
+ATOM   2347 O  O   . MET A 1 295 ? 12.934  41.727  17.173  1.00 17.98 ? 317  MET A O   1 
+ATOM   2348 C  CB  . MET A 1 295 ? 12.184  39.173  16.109  1.00 15.80 ? 317  MET A CB  1 
+ATOM   2349 C  CG  . MET A 1 295 ? 12.244  37.807  15.435  1.00 16.72 ? 317  MET A CG  1 
+ATOM   2350 S  SD  . MET A 1 295 ? 10.843  37.444  14.299  1.00 21.58 ? 317  MET A SD  1 
+ATOM   2351 C  CE  . MET A 1 295 ? 11.354  38.383  12.904  1.00 24.12 ? 317  MET A CE  1 
+ATOM   2352 N  N   . GLY A 1 296 ? 12.985  40.766  19.221  1.00 15.61 ? 318  GLY A N   1 
+ATOM   2353 C  CA  . GLY A 1 296 ? 12.709  41.972  19.968  1.00 15.86 ? 318  GLY A CA  1 
+ATOM   2354 C  C   . GLY A 1 296 ? 13.955  42.695  20.426  1.00 16.90 ? 318  GLY A C   1 
+ATOM   2355 O  O   . GLY A 1 296 ? 15.104  42.406  20.002  1.00 17.26 ? 318  GLY A O   1 
+ATOM   2356 N  N   . THR A 1 297 ? 13.725  43.681  21.275  1.00 16.44 ? 319  THR A N   1 
+ATOM   2357 C  CA  . THR A 1 297 ? 14.822  44.495  21.834  1.00 18.44 ? 319  THR A CA  1 
+ATOM   2358 C  C   . THR A 1 297 ? 14.760  44.516  23.336  1.00 17.54 ? 319  THR A C   1 
+ATOM   2359 O  O   . THR A 1 297 ? 13.685  44.426  23.927  1.00 18.40 ? 319  THR A O   1 
+ATOM   2360 C  CB  . THR A 1 297 ? 14.832  45.977  21.328  1.00 19.39 ? 319  THR A CB  1 
+ATOM   2361 O  OG1 . THR A 1 297 ? 13.537  46.529  21.455  1.00 22.26 ? 319  THR A OG1 1 
+ATOM   2362 C  CG2 . THR A 1 297 ? 15.228  45.992  19.867  1.00 21.58 ? 319  THR A CG2 1 
+ATOM   2363 N  N   . ASP A 1 298 ? 15.909  44.762  23.954  1.00 19.44 ? 320  ASP A N   1 
+ATOM   2364 C  CA  . ASP A 1 298 ? 15.931  44.968  25.413  1.00 19.71 ? 320  ASP A CA  1 
+ATOM   2365 C  C   . ASP A 1 298 ? 15.771  46.445  25.757  1.00 20.32 ? 320  ASP A C   1 
+ATOM   2366 O  O   . ASP A 1 298 ? 15.511  47.252  24.881  1.00 21.11 ? 320  ASP A O   1 
+ATOM   2367 C  CB  . ASP A 1 298 ? 17.206  44.356  25.997  1.00 22.21 ? 320  ASP A CB  1 
+ATOM   2368 C  CG  . ASP A 1 298 ? 18.489  45.108  25.603  1.00 25.01 ? 320  ASP A CG  1 
+ATOM   2369 O  OD1 . ASP A 1 298 ? 18.407  46.227  25.127  1.00 23.14 ? 320  ASP A OD1 1 
+ATOM   2370 O  OD2 . ASP A 1 298 ? 19.608  44.574  25.850  1.00 28.80 ? 320  ASP A OD2 1 
+ATOM   2371 N  N   . ALA A 1 299 ? 15.862  46.745  27.047  1.00 22.12 ? 321  ALA A N   1 
+ATOM   2372 C  CA  . ALA A 1 299 ? 15.592  48.083  27.524  1.00 23.28 ? 321  ALA A CA  1 
+ATOM   2373 C  C   . ALA A 1 299 ? 16.602  49.056  27.049  1.00 23.97 ? 321  ALA A C   1 
+ATOM   2374 O  O   . ALA A 1 299 ? 16.330  50.266  27.041  1.00 27.24 ? 321  ALA A O   1 
+ATOM   2375 C  CB  . ALA A 1 299 ? 15.523  48.094  29.090  1.00 25.89 ? 321  ALA A CB  1 
+ATOM   2376 N  N   . ALA A 1 300 ? 17.766  48.589  26.656  1.00 25.12 ? 322  ALA A N   1 
+ATOM   2377 C  CA  . ALA A 1 300 ? 18.777  49.477  26.123  1.00 27.25 ? 322  ALA A CA  1 
+ATOM   2378 C  C   . ALA A 1 300 ? 18.651  49.587  24.595  1.00 27.31 ? 322  ALA A C   1 
+ATOM   2379 O  O   . ALA A 1 300 ? 19.537  50.145  23.930  1.00 30.06 ? 322  ALA A O   1 
+ATOM   2380 C  CB  . ALA A 1 300 ? 20.191  48.965  26.520  1.00 27.09 ? 322  ALA A CB  1 
+ATOM   2381 N  N   . ASN A 1 301 ? 17.568  49.054  24.038  1.00 26.53 ? 323  ASN A N   1 
+ATOM   2382 C  CA  A ASN A 1 301 ? 17.367  49.061  22.587  0.45 26.91 ? 323  ASN A CA  1 
+ATOM   2383 C  CA  B ASN A 1 301 ? 17.327  49.020  22.560  0.55 29.06 ? 323  ASN A CA  1 
+ATOM   2384 C  C   . ASN A 1 301 ? 18.354  48.168  21.799  1.00 27.78 ? 323  ASN A C   1 
+ATOM   2385 O  O   . ASN A 1 301 ? 18.526  48.325  20.590  1.00 29.11 ? 323  ASN A O   1 
+ATOM   2386 C  CB  A ASN A 1 301 ? 17.338  50.507  22.093  0.45 27.61 ? 323  ASN A CB  1 
+ATOM   2387 C  CB  B ASN A 1 301 ? 17.115  50.409  21.881  0.55 33.19 ? 323  ASN A CB  1 
+ATOM   2388 C  CG  A ASN A 1 301 ? 16.358  51.338  22.875  0.45 27.08 ? 323  ASN A CG  1 
+ATOM   2389 C  CG  B ASN A 1 301 ? 16.326  50.327  20.503  0.55 36.20 ? 323  ASN A CG  1 
+ATOM   2390 O  OD1 A ASN A 1 301 ? 15.213  50.916  23.090  0.45 28.14 ? 323  ASN A OD1 1 
+ATOM   2391 O  OD1 B ASN A 1 301 ? 15.283  49.652  20.362  0.55 35.79 ? 323  ASN A OD1 1 
+ATOM   2392 N  ND2 A ASN A 1 301 ? 16.813  52.484  23.387  0.45 26.25 ? 323  ASN A ND2 1 
+ATOM   2393 N  ND2 B ASN A 1 301 ? 16.844  51.033  19.502  0.55 38.79 ? 323  ASN A ND2 1 
+ATOM   2394 N  N   . ASN A 1 302 ? 18.980  47.215  22.475  1.00 23.91 ? 324  ASN A N   1 
+ATOM   2395 C  CA  . ASN A 1 302 ? 19.783  46.199  21.785  1.00 21.94 ? 324  ASN A CA  1 
+ATOM   2396 C  C   . ASN A 1 302 ? 18.924  45.031  21.340  1.00 20.63 ? 324  ASN A C   1 
+ATOM   2397 O  O   . ASN A 1 302 ? 18.091  44.580  22.053  1.00 21.75 ? 324  ASN A O   1 
+ATOM   2398 C  CB  . ASN A 1 302 ? 20.886  45.684  22.665  1.00 26.19 ? 324  ASN A CB  1 
+ATOM   2399 C  CG  . ASN A 1 302 ? 21.772  46.822  23.208  1.00 28.49 ? 324  ASN A CG  1 
+ATOM   2400 O  OD1 . ASN A 1 302 ? 21.947  46.986  24.436  1.00 33.98 ? 324  ASN A OD1 1 
+ATOM   2401 N  ND2 . ASN A 1 302 ? 22.232  47.625  22.334  1.00 28.55 ? 324  ASN A ND2 1 
+ATOM   2402 N  N   A SER A 1 303 ? 19.201  44.546  20.149  0.52 19.48 ? 325  SER A N   1 
+ATOM   2403 N  N   B SER A 1 303 ? 19.167  44.565  20.124  0.48 21.03 ? 325  SER A N   1 
+ATOM   2404 C  CA  A SER A 1 303 ? 18.416  43.452  19.573  0.52 18.20 ? 325  SER A CA  1 
+ATOM   2405 C  CA  B SER A 1 303 ? 18.393  43.440  19.566  0.48 20.58 ? 325  SER A CA  1 
+ATOM   2406 C  C   . SER A 1 303 ? 18.785  42.098  20.135  1.00 18.33 ? 325  SER A C   1 
+ATOM   2407 O  O   . SER A 1 303 ? 19.976  41.756  20.235  1.00 21.23 ? 325  SER A O   1 
+ATOM   2408 C  CB  A SER A 1 303 ? 18.587  43.457  18.058  0.52 19.64 ? 325  SER A CB  1 
+ATOM   2409 C  CB  B SER A 1 303 ? 18.489  43.393  18.037  0.48 24.69 ? 325  SER A CB  1 
+ATOM   2410 O  OG  A SER A 1 303 ? 18.213  44.704  17.484  0.52 19.71 ? 325  SER A OG  1 
+ATOM   2411 O  OG  B SER A 1 303 ? 17.823  42.235  17.489  0.48 27.55 ? 325  SER A OG  1 
+ATOM   2412 N  N   . TYR A 1 304 ? 17.753  41.325  20.466  1.00 17.14 ? 326  TYR A N   1 
+ATOM   2413 C  CA  . TYR A 1 304 ? 17.957  39.920  20.839  1.00 15.79 ? 326  TYR A CA  1 
+ATOM   2414 C  C   . TYR A 1 304 ? 18.491  39.112  19.682  1.00 19.11 ? 326  TYR A C   1 
+ATOM   2415 O  O   . TYR A 1 304 ? 19.203  38.142  19.863  1.00 19.12 ? 326  TYR A O   1 
+ATOM   2416 C  CB  . TYR A 1 304 ? 16.667  39.292  21.432  1.00 17.66 ? 326  TYR A CB  1 
+ATOM   2417 C  CG  . TYR A 1 304 ? 16.417  39.789  22.876  1.00 17.50 ? 326  TYR A CG  1 
+ATOM   2418 C  CD1 . TYR A 1 304 ? 17.214  39.319  23.879  1.00 16.63 ? 326  TYR A CD1 1 
+ATOM   2419 C  CD2 . TYR A 1 304 ? 15.406  40.654  23.182  1.00 17.26 ? 326  TYR A CD2 1 
+ATOM   2420 C  CE1 . TYR A 1 304 ? 17.046  39.719  25.192  1.00 18.29 ? 326  TYR A CE1 1 
+ATOM   2421 C  CE2 . TYR A 1 304 ? 15.228  41.120  24.510  1.00 17.17 ? 326  TYR A CE2 1 
+ATOM   2422 C  CZ  . TYR A 1 304 ? 16.053  40.611  25.510  1.00 18.34 ? 326  TYR A CZ  1 
+ATOM   2423 O  OH  . TYR A 1 304 ? 15.931  40.973  26.852  1.00 18.28 ? 326  TYR A OH  1 
+ATOM   2424 N  N   . ASN A 1 305 ? 18.145  39.534  18.478  1.00 16.48 ? 327  ASN A N   1 
+ATOM   2425 C  CA  . ASN A 1 305 ? 18.719  38.955  17.291  1.00 16.93 ? 327  ASN A CA  1 
+ATOM   2426 C  C   . ASN A 1 305 ? 18.677  37.417  17.196  1.00 16.01 ? 327  ASN A C   1 
+ATOM   2427 O  O   . ASN A 1 305 ? 19.663  36.790  16.803  1.00 18.13 ? 327  ASN A O   1 
+ATOM   2428 C  CB  . ASN A 1 305 ? 20.111  39.505  17.087  1.00 20.98 ? 327  ASN A CB  1 
+ATOM   2429 C  CG  . ASN A 1 305 ? 20.531  39.456  15.635  1.00 25.23 ? 327  ASN A CG  1 
+ATOM   2430 O  OD1 . ASN A 1 305 ? 19.679  39.500  14.721  1.00 24.93 ? 327  ASN A OD1 1 
+ATOM   2431 N  ND2 . ASN A 1 305 ? 21.831  39.319  15.398  1.00 28.28 ? 327  ASN A ND2 1 
+ATOM   2432 N  N   . GLN A 1 306 ? 17.521  36.856  17.504  1.00 16.13 ? 328  GLN A N   1 
+ATOM   2433 C  CA  . GLN A 1 306 ? 17.197  35.466  17.257  1.00 14.36 ? 328  GLN A CA  1 
+ATOM   2434 C  C   . GLN A 1 306 ? 18.019  34.514  18.138  1.00 13.83 ? 328  GLN A C   1 
+ATOM   2435 O  O   . GLN A 1 306 ? 18.257  33.385  17.743  1.00 14.24 ? 328  GLN A O   1 
+ATOM   2436 C  CB  . GLN A 1 306 ? 17.411  35.105  15.802  1.00 15.04 ? 328  GLN A CB  1 
+ATOM   2437 C  CG  . GLN A 1 306 ? 16.705  36.001  14.822  1.00 17.96 ? 328  GLN A CG  1 
+ATOM   2438 C  CD  . GLN A 1 306 ? 16.626  35.304  13.494  1.00 18.44 ? 328  GLN A CD  1 
+ATOM   2439 O  OE1 . GLN A 1 306 ? 15.850  34.365  13.330  1.00 17.49 ? 328  GLN A OE1 1 
+ATOM   2440 N  NE2 . GLN A 1 306 ? 17.521  35.670  12.585  1.00 17.26 ? 328  GLN A NE2 1 
+ATOM   2441 N  N   . GLN A 1 307 ? 18.447  34.963  19.336  1.00 15.19 ? 329  GLN A N   1 
+ATOM   2442 C  CA  . GLN A 1 307 ? 19.301  34.110  20.158  1.00 16.62 ? 329  GLN A CA  1 
+ATOM   2443 C  C   . GLN A 1 307 ? 18.656  32.761  20.524  1.00 16.12 ? 329  GLN A C   1 
+ATOM   2444 O  O   . GLN A 1 307 ? 19.338  31.743  20.681  1.00 15.50 ? 329  GLN A O   1 
+ATOM   2445 C  CB  . GLN A 1 307 ? 19.744  34.847  21.446  1.00 17.63 ? 329  GLN A CB  1 
+ATOM   2446 C  CG  . GLN A 1 307 ? 20.927  34.111  22.112  1.00 18.85 ? 329  GLN A CG  1 
+ATOM   2447 C  CD  . GLN A 1 307 ? 22.093  34.023  21.173  1.00 20.27 ? 329  GLN A CD  1 
+ATOM   2448 O  OE1 . GLN A 1 307 ? 22.553  35.046  20.658  1.00 20.67 ? 329  GLN A OE1 1 
+ATOM   2449 N  NE2 . GLN A 1 307 ? 22.593  32.820  20.922  1.00 21.56 ? 329  GLN A NE2 1 
+ATOM   2450 N  N   . PHE A 1 308 ? 17.350  32.754  20.686  1.00 12.84 ? 330  PHE A N   1 
+ATOM   2451 C  CA  . PHE A 1 308 ? 16.710  31.491  21.095  1.00 12.71 ? 330  PHE A CA  1 
+ATOM   2452 C  C   . PHE A 1 308 ? 16.833  30.406  19.978  1.00 13.31 ? 330  PHE A C   1 
+ATOM   2453 O  O   . PHE A 1 308 ? 17.233  29.281  20.207  1.00 14.53 ? 330  PHE A O   1 
+ATOM   2454 C  CB  . PHE A 1 308 ? 15.258  31.690  21.547  1.00 13.52 ? 330  PHE A CB  1 
+ATOM   2455 C  CG  . PHE A 1 308 ? 14.613  30.436  22.078  1.00 13.23 ? 330  PHE A CG  1 
+ATOM   2456 C  CD1 . PHE A 1 308 ? 14.687  30.080  23.415  1.00 15.20 ? 330  PHE A CD1 1 
+ATOM   2457 C  CD2 . PHE A 1 308 ? 13.980  29.584  21.208  1.00 14.15 ? 330  PHE A CD2 1 
+ATOM   2458 C  CE1 . PHE A 1 308 ? 14.075  28.917  23.884  1.00 12.73 ? 330  PHE A CE1 1 
+ATOM   2459 C  CE2 . PHE A 1 308 ? 13.403  28.402  21.649  1.00 13.26 ? 330  PHE A CE2 1 
+ATOM   2460 C  CZ  . PHE A 1 308 ? 13.424  28.087  23.023  1.00 13.78 ? 330  PHE A CZ  1 
+ATOM   2461 N  N   . ILE A 1 309 ? 16.466  30.811  18.767  1.00 13.27 ? 331  ILE A N   1 
+ATOM   2462 C  CA  . ILE A 1 309 ? 16.522  29.859  17.647  1.00 12.65 ? 331  ILE A CA  1 
+ATOM   2463 C  C   . ILE A 1 309 ? 17.980  29.481  17.358  1.00 13.55 ? 331  ILE A C   1 
+ATOM   2464 O  O   . ILE A 1 309 ? 18.257  28.356  16.943  1.00 13.38 ? 331  ILE A O   1 
+ATOM   2465 C  CB  . ILE A 1 309 ? 15.692  30.318  16.407  1.00 12.54 ? 331  ILE A CB  1 
+ATOM   2466 C  CG1 . ILE A 1 309 ? 15.371  29.152  15.461  1.00 14.41 ? 331  ILE A CG1 1 
+ATOM   2467 C  CG2 . ILE A 1 309 ? 16.318  31.477  15.733  1.00 12.69 ? 331  ILE A CG2 1 
+ATOM   2468 C  CD1 . ILE A 1 309 ? 14.481  28.084  16.054  1.00 14.91 ? 331  ILE A CD1 1 
+ATOM   2469 N  N   . LYS A 1 310 ? 18.888  30.412  17.571  1.00 14.43 ? 332  LYS A N   1 
+ATOM   2470 C  CA  . LYS A 1 310 ? 20.311  30.133  17.465  1.00 14.89 ? 332  LYS A CA  1 
+ATOM   2471 C  C   . LYS A 1 310 ? 20.700  29.063  18.446  1.00 14.81 ? 332  LYS A C   1 
+ATOM   2472 O  O   . LYS A 1 310 ? 21.410  28.099  18.082  1.00 17.11 ? 332  LYS A O   1 
+ATOM   2473 C  CB  . LYS A 1 310 ? 21.181  31.381  17.658  1.00 15.65 ? 332  LYS A CB  1 
+ATOM   2474 C  CG  . LYS A 1 310 ? 21.073  32.413  16.583  1.00 16.37 ? 332  LYS A CG  1 
+ATOM   2475 C  CD  . LYS A 1 310 ? 21.771  33.665  16.926  1.00 18.37 ? 332  LYS A CD  1 
+ATOM   2476 C  CE  . LYS A 1 310 ? 21.756  34.632  15.743  1.00 19.93 ? 332  LYS A CE  1 
+ATOM   2477 N  NZ  . LYS A 1 310 ? 22.369  35.955  16.009  1.00 20.09 ? 332  LYS A NZ  1 
+ATOM   2478 N  N   . ASP A 1 311 ? 20.230  29.180  19.684  1.00 14.79 ? 333  ASP A N   1 
+ATOM   2479 C  CA  . ASP A 1 311 ? 20.616  28.190  20.680  1.00 15.22 ? 333  ASP A CA  1 
+ATOM   2480 C  C   . ASP A 1 311 ? 19.963  26.824  20.501  1.00 15.27 ? 333  ASP A C   1 
+ATOM   2481 O  O   . ASP A 1 311 ? 20.601  25.801  20.783  1.00 15.55 ? 333  ASP A O   1 
+ATOM   2482 C  CB  . ASP A 1 311 ? 20.264  28.723  22.095  1.00 16.12 ? 333  ASP A CB  1 
+ATOM   2483 C  CG  . ASP A 1 311 ? 21.182  29.886  22.525  1.00 17.56 ? 333  ASP A CG  1 
+ATOM   2484 O  OD1 . ASP A 1 311 ? 22.295  30.067  21.959  1.00 21.21 ? 333  ASP A OD1 1 
+ATOM   2485 O  OD2 . ASP A 1 311 ? 20.791  30.637  23.441  1.00 19.55 ? 333  ASP A OD2 1 
+ATOM   2486 N  N   . TYR A 1 312 ? 18.721  26.764  19.984  1.00 13.69 ? 334  TYR A N   1 
+ATOM   2487 C  CA  . TYR A 1 312 ? 17.977  25.512  20.040  1.00 13.21 ? 334  TYR A CA  1 
+ATOM   2488 C  C   . TYR A 1 312 ? 17.483  24.922  18.690  1.00 12.88 ? 334  TYR A C   1 
+ATOM   2489 O  O   . TYR A 1 312 ? 17.187  23.724  18.641  1.00 12.88 ? 334  TYR A O   1 
+ATOM   2490 C  CB  . TYR A 1 312 ? 16.762  25.613  20.973  1.00 14.54 ? 334  TYR A CB  1 
+ATOM   2491 C  CG  . TYR A 1 312 ? 17.188  26.044  22.355  1.00 13.57 ? 334  TYR A CG  1 
+ATOM   2492 C  CD1 . TYR A 1 312 ? 18.010  25.241  23.130  1.00 15.93 ? 334  TYR A CD1 1 
+ATOM   2493 C  CD2 . TYR A 1 312 ? 16.872  27.281  22.847  1.00 11.86 ? 334  TYR A CD2 1 
+ATOM   2494 C  CE1 . TYR A 1 312 ? 18.447  25.685  24.364  1.00 15.46 ? 334  TYR A CE1 1 
+ATOM   2495 C  CE2 . TYR A 1 312 ? 17.307  27.728  24.106  1.00 15.74 ? 334  TYR A CE2 1 
+ATOM   2496 C  CZ  . TYR A 1 312 ? 18.102  26.894  24.867  1.00 15.17 ? 334  TYR A CZ  1 
+ATOM   2497 O  OH  . TYR A 1 312 ? 18.609  27.313  26.124  1.00 16.87 ? 334  TYR A OH  1 
+ATOM   2498 N  N   . GLY A 1 313 ? 17.457  25.735  17.620  1.00 13.89 ? 335  GLY A N   1 
+ATOM   2499 C  CA  . GLY A 1 313 ? 16.881  25.234  16.367  1.00 13.77 ? 335  GLY A CA  1 
+ATOM   2500 C  C   . GLY A 1 313 ? 17.583  23.979  15.843  1.00 14.46 ? 335  GLY A C   1 
+ATOM   2501 O  O   . GLY A 1 313 ? 17.003  22.929  15.608  1.00 15.08 ? 335  GLY A O   1 
+ATOM   2502 N  N   . ASN A 1 314 ? 18.863  24.116  15.653  1.00 15.72 ? 336  ASN A N   1 
+ATOM   2503 C  CA  . ASN A 1 314 ? 19.609  23.037  15.083  1.00 14.65 ? 336  ASN A CA  1 
+ATOM   2504 C  C   . ASN A 1 314 ? 19.667  21.824  16.036  1.00 16.36 ? 336  ASN A C   1 
+ATOM   2505 O  O   . ASN A 1 314 ? 19.557  20.665  15.622  1.00 15.52 ? 336  ASN A O   1 
+ATOM   2506 C  CB  . ASN A 1 314 ? 21.009  23.492  14.722  1.00 17.72 ? 336  ASN A CB  1 
+ATOM   2507 C  CG  . ASN A 1 314 ? 21.805  22.390  13.993  1.00 22.57 ? 336  ASN A CG  1 
+ATOM   2508 O  OD1 . ASN A 1 314 ? 21.422  21.941  12.941  1.00 27.46 ? 336  ASN A OD1 1 
+ATOM   2509 N  ND2 . ASN A 1 314 ? 22.900  21.957  14.601  1.00 27.05 ? 336  ASN A ND2 1 
+ATOM   2510 N  N   . PHE A 1 315 ? 19.842  22.099  17.330  1.00 15.55 ? 337  PHE A N   1 
+ATOM   2511 C  CA  . PHE A 1 315 ? 19.852  21.018  18.299  1.00 14.85 ? 337  PHE A CA  1 
+ATOM   2512 C  C   . PHE A 1 315 ? 18.595  20.147  18.233  1.00 13.42 ? 337  PHE A C   1 
+ATOM   2513 O  O   . PHE A 1 315 ? 18.652  18.911  18.280  1.00 15.30 ? 337  PHE A O   1 
+ATOM   2514 C  CB  . PHE A 1 315 ? 20.016  21.574  19.720  1.00 16.36 ? 337  PHE A CB  1 
+ATOM   2515 C  CG  . PHE A 1 315 ? 20.039  20.503  20.748  1.00 14.64 ? 337  PHE A CG  1 
+ATOM   2516 C  CD1 . PHE A 1 315 ? 21.174  19.770  20.935  1.00 14.53 ? 337  PHE A CD1 1 
+ATOM   2517 C  CD2 . PHE A 1 315 ? 18.946  20.223  21.512  1.00 15.52 ? 337  PHE A CD2 1 
+ATOM   2518 C  CE1 . PHE A 1 315 ? 21.181  18.720  21.849  1.00 16.11 ? 337  PHE A CE1 1 
+ATOM   2519 C  CE2 . PHE A 1 315 ? 18.981  19.227  22.441  1.00 15.55 ? 337  PHE A CE2 1 
+ATOM   2520 C  CZ  . PHE A 1 315 ? 20.108  18.449  22.608  1.00 16.15 ? 337  PHE A CZ  1 
+ATOM   2521 N  N   . ILE A 1 316 ? 17.449  20.779  18.145  1.00 14.30 ? 338  ILE A N   1 
+ATOM   2522 C  CA  . ILE A 1 316 ? 16.208  20.029  18.131  1.00 14.44 ? 338  ILE A CA  1 
+ATOM   2523 C  C   . ILE A 1 316 ? 15.882  19.400  16.787  1.00 13.84 ? 338  ILE A C   1 
+ATOM   2524 O  O   . ILE A 1 316 ? 15.360  18.296  16.735  1.00 15.19 ? 338  ILE A O   1 
+ATOM   2525 C  CB  . ILE A 1 316 ? 15.056  20.982  18.524  1.00 14.19 ? 338  ILE A CB  1 
+ATOM   2526 C  CG1 . ILE A 1 316 ? 15.249  21.422  20.006  1.00 15.11 ? 338  ILE A CG1 1 
+ATOM   2527 C  CG2 . ILE A 1 316 ? 13.696  20.345  18.320  1.00 15.71 ? 338  ILE A CG2 1 
+ATOM   2528 C  CD1 . ILE A 1 316 ? 15.176  20.282  20.994  1.00 13.57 ? 338  ILE A CD1 1 
+ATOM   2529 N  N   . HIS A 1 317 ? 16.187  20.077  15.710  1.00 13.86 ? 339  HIS A N   1 
+ATOM   2530 C  CA  . HIS A 1 317 ? 15.884  19.490  14.397  1.00 14.34 ? 339  HIS A CA  1 
+ATOM   2531 C  C   . HIS A 1 317 ? 16.818  18.375  14.005  1.00 15.20 ? 339  HIS A C   1 
+ATOM   2532 O  O   . HIS A 1 317 ? 16.410  17.453  13.299  1.00 15.69 ? 339  HIS A O   1 
+ATOM   2533 C  CB  . HIS A 1 317 ? 15.872  20.560  13.308  1.00 14.04 ? 339  HIS A CB  1 
+ATOM   2534 C  CG  . HIS A 1 317 ? 14.744  21.514  13.392  1.00 12.61 ? 339  HIS A CG  1 
+ATOM   2535 N  ND1 . HIS A 1 317 ? 13.428  21.108  13.329  1.00 15.12 ? 339  HIS A ND1 1 
+ATOM   2536 C  CD2 . HIS A 1 317 ? 14.729  22.865  13.500  1.00 13.76 ? 339  HIS A CD2 1 
+ATOM   2537 C  CE1 . HIS A 1 317 ? 12.644  22.165  13.419  1.00 14.08 ? 339  HIS A CE1 1 
+ATOM   2538 N  NE2 . HIS A 1 317 ? 13.411  23.247  13.530  1.00 14.13 ? 339  HIS A NE2 1 
+ATOM   2539 N  N   . ASN A 1 318 ? 18.064  18.430  14.473  1.00 15.76 ? 340  ASN A N   1 
+ATOM   2540 C  CA  . ASN A 1 318 ? 19.042  17.401  14.166  1.00 17.08 ? 340  ASN A CA  1 
+ATOM   2541 C  C   . ASN A 1 318 ? 18.901  16.211  15.117  1.00 16.29 ? 340  ASN A C   1 
+ATOM   2542 O  O   . ASN A 1 318 ? 19.789  15.939  15.895  1.00 20.29 ? 340  ASN A O   1 
+ATOM   2543 C  CB  . ASN A 1 318 ? 20.452  17.944  14.153  1.00 21.41 ? 340  ASN A CB  1 
+ATOM   2544 C  CG  . ASN A 1 318 ? 21.434  16.925  13.664  1.00 26.46 ? 340  ASN A CG  1 
+ATOM   2545 O  OD1 . ASN A 1 318 ? 21.071  16.030  12.911  1.00 27.79 ? 340  ASN A OD1 1 
+ATOM   2546 N  ND2 . ASN A 1 318 ? 22.687  17.037  14.105  1.00 32.50 ? 340  ASN A ND2 1 
+ATOM   2547 N  N   . GLN A 1 319 ? 17.728  15.576  15.066  1.00 15.77 ? 341  GLN A N   1 
+ATOM   2548 C  CA  . GLN A 1 319 ? 17.362  14.449  15.889  1.00 16.85 ? 341  GLN A CA  1 
+ATOM   2549 C  C   . GLN A 1 319 ? 16.541  13.455  15.071  1.00 15.99 ? 341  GLN A C   1 
+ATOM   2550 O  O   . GLN A 1 319 ? 15.841  13.840  14.121  1.00 18.07 ? 341  GLN A O   1 
+ATOM   2551 C  CB  . GLN A 1 319 ? 16.498  14.938  17.071  1.00 16.91 ? 341  GLN A CB  1 
+ATOM   2552 C  CG  . GLN A 1 319 ? 17.116  15.957  18.047  1.00 18.48 ? 341  GLN A CG  1 
+ATOM   2553 C  CD  . GLN A 1 319 ? 18.262  15.383  18.882  1.00 19.69 ? 341  GLN A CD  1 
+ATOM   2554 O  OE1 . GLN A 1 319 ? 18.402  14.161  19.039  1.00 19.91 ? 341  GLN A OE1 1 
+ATOM   2555 N  NE2 . GLN A 1 319 ? 19.059  16.276  19.469  1.00 21.33 ? 341  GLN A NE2 1 
+ATOM   2556 N  N   . LEU A 1 320 ? 16.550  12.189  15.492  1.00 16.75 ? 342  LEU A N   1 
+ATOM   2557 C  CA  . LEU A 1 320 ? 15.693  11.204  14.876  1.00 16.76 ? 342  LEU A CA  1 
+ATOM   2558 C  C   . LEU A 1 320 ? 14.223  11.504  15.042  1.00 16.79 ? 342  LEU A C   1 
+ATOM   2559 O  O   . LEU A 1 320 ? 13.803  12.206  16.022  1.00 16.79 ? 342  LEU A O   1 
+ATOM   2560 C  CB  . LEU A 1 320 ? 15.926  9.810   15.483  1.00 18.24 ? 342  LEU A CB  1 
+ATOM   2561 C  CG  . LEU A 1 320 ? 17.340  9.268   15.221  1.00 21.81 ? 342  LEU A CG  1 
+ATOM   2562 C  CD1 . LEU A 1 320 ? 17.606  8.034   16.085  1.00 22.38 ? 342  LEU A CD1 1 
+ATOM   2563 C  CD2 . LEU A 1 320 ? 17.557  8.974   13.725  1.00 24.66 ? 342  LEU A CD2 1 
+ATOM   2564 N  N   . PRO A 1 321 ? 13.414  10.976  14.091  1.00 16.75 ? 343  PRO A N   1 
+ATOM   2565 C  CA  . PRO A 1 321 ? 11.997  11.187  14.253  1.00 16.56 ? 343  PRO A CA  1 
+ATOM   2566 C  C   . PRO A 1 321 ? 11.490  10.534  15.555  1.00 16.06 ? 343  PRO A C   1 
+ATOM   2567 O  O   . PRO A 1 321 ? 12.090  9.561   16.048  1.00 16.17 ? 343  PRO A O   1 
+ATOM   2568 C  CB  . PRO A 1 321 ? 11.410  10.412  13.083  1.00 19.59 ? 343  PRO A CB  1 
+ATOM   2569 C  CG  . PRO A 1 321 ? 12.463  10.413  12.102  1.00 22.22 ? 343  PRO A CG  1 
+ATOM   2570 C  CD  . PRO A 1 321 ? 13.700  10.233  12.846  1.00 18.61 ? 343  PRO A CD  1 
+ATOM   2571 N  N   . PRO A 1 322 ? 10.320  10.972  15.988  1.00 15.61 ? 344  PRO A N   1 
+ATOM   2572 C  CA  . PRO A 1 322 ? 9.746   10.395  17.218  1.00 14.79 ? 344  PRO A CA  1 
+ATOM   2573 C  C   . PRO A 1 322 ? 9.350   8.932   17.057  1.00 15.95 ? 344  PRO A C   1 
+ATOM   2574 O  O   . PRO A 1 322 ? 8.993   8.483   15.970  1.00 18.43 ? 344  PRO A O   1 
+ATOM   2575 C  CB  . PRO A 1 322 ? 8.515   11.263  17.514  1.00 18.53 ? 344  PRO A CB  1 
+ATOM   2576 C  CG  . PRO A 1 322 ? 8.350   12.212  16.348  1.00 21.60 ? 344  PRO A CG  1 
+ATOM   2577 C  CD  . PRO A 1 322 ? 9.510   12.094  15.435  1.00 18.70 ? 344  PRO A CD  1 
+ATOM   2578 N  N   . VAL A 1 323 ? 9.414   8.234   18.181  1.00 17.74 ? 345  VAL A N   1 
+ATOM   2579 C  CA  . VAL A 1 323 ? 8.981   6.829   18.278  1.00 19.34 ? 345  VAL A CA  1 
+ATOM   2580 C  C   . VAL A 1 323 ? 7.792   6.784   19.236  1.00 17.58 ? 345  VAL A C   1 
+ATOM   2581 O  O   . VAL A 1 323 ? 7.916   7.143   20.432  1.00 19.80 ? 345  VAL A O   1 
+ATOM   2582 C  CB  . VAL A 1 323 ? 10.135  5.936   18.845  1.00 20.12 ? 345  VAL A CB  1 
+ATOM   2583 C  CG1 . VAL A 1 323 ? 9.698   4.479   19.010  1.00 22.56 ? 345  VAL A CG1 1 
+ATOM   2584 C  CG2 . VAL A 1 323 ? 11.334  5.953   17.896  1.00 21.15 ? 345  VAL A CG2 1 
+ATOM   2585 N  N   . THR A 1 324 ? 6.649   6.329   18.742  1.00 20.62 ? 346  THR A N   1 
+ATOM   2586 C  CA  . THR A 1 324 ? 5.419   6.464   19.491  1.00 19.26 ? 346  THR A CA  1 
+ATOM   2587 C  C   . THR A 1 324 ? 5.398   5.571   20.708  1.00 20.48 ? 346  THR A C   1 
+ATOM   2588 O  O   . THR A 1 324 ? 5.747   4.391   20.580  1.00 20.76 ? 346  THR A O   1 
+ATOM   2589 C  CB  . THR A 1 324 ? 4.255   6.085   18.616  1.00 22.36 ? 346  THR A CB  1 
+ATOM   2590 O  OG1 . THR A 1 324 ? 4.308   6.922   17.484  1.00 24.92 ? 346  THR A OG1 1 
+ATOM   2591 C  CG2 . THR A 1 324 ? 2.925   6.317   19.334  1.00 24.19 ? 346  THR A CG2 1 
+ATOM   2592 N  N   . ASP A 1 325 ? 5.040   6.128   21.877  1.00 19.93 ? 347  ASP A N   1 
+ATOM   2593 C  CA  . ASP A 1 325 ? 4.753   5.349   23.045  1.00 21.19 ? 347  ASP A CA  1 
+ATOM   2594 C  C   . ASP A 1 325 ? 3.309   4.859   22.967  1.00 23.27 ? 347  ASP A C   1 
+ATOM   2595 O  O   . ASP A 1 325 ? 2.394   5.671   23.100  1.00 22.34 ? 347  ASP A O   1 
+ATOM   2596 C  CB  . ASP A 1 325 ? 4.979   6.239   24.299  1.00 22.47 ? 347  ASP A CB  1 
+ATOM   2597 C  CG  . ASP A 1 325 ? 4.653   5.522   25.618  1.00 24.57 ? 347  ASP A CG  1 
+ATOM   2598 O  OD1 . ASP A 1 325 ? 3.873   4.543   25.617  1.00 24.83 ? 347  ASP A OD1 1 
+ATOM   2599 O  OD2 . ASP A 1 325 ? 5.200   5.985   26.670  1.00 27.35 ? 347  ASP A OD2 1 
+ATOM   2600 N  N   . MET A 1 326 ? 3.111   3.552   22.760  1.00 20.90 ? 348  MET A N   1 
+ATOM   2601 C  CA  . MET A 1 326 ? 1.783   2.991   22.458  1.00 22.75 ? 348  MET A CA  1 
+ATOM   2602 C  C   . MET A 1 326 ? 1.113   2.370   23.702  1.00 23.16 ? 348  MET A C   1 
+ATOM   2603 O  O   . MET A 1 326 ? 0.203   1.562   23.603  1.00 24.68 ? 348  MET A O   1 
+ATOM   2604 C  CB  . MET A 1 326 ? 1.851   1.943   21.312  1.00 24.19 ? 348  MET A CB  1 
+ATOM   2605 C  CG  . MET A 1 326 ? 2.249   2.575   19.999  1.00 26.34 ? 348  MET A CG  1 
+ATOM   2606 S  SD  . MET A 1 326 ? 2.234   1.350   18.679  1.00 30.46 ? 348  MET A SD  1 
+ATOM   2607 C  CE  . MET A 1 326 ? 2.867   2.245   17.309  1.00 34.58 ? 348  MET A CE  1 
+ATOM   2608 N  N   . THR A 1 327 ? 1.541   2.796   24.880  1.00 23.04 ? 349  THR A N   1 
+ATOM   2609 C  CA  . THR A 1 327 ? 0.943   2.230   26.074  1.00 21.12 ? 349  THR A CA  1 
+ATOM   2610 C  C   . THR A 1 327 ? -0.483  2.720   26.235  1.00 20.82 ? 349  THR A C   1 
+ATOM   2611 O  O   . THR A 1 327 ? -0.797  3.914   25.995  1.00 22.47 ? 349  THR A O   1 
+ATOM   2612 C  CB  . THR A 1 327 ? 1.749   2.598   27.296  1.00 24.32 ? 349  THR A CB  1 
+ATOM   2613 O  OG1 . THR A 1 327 ? 1.738   4.012   27.440  1.00 28.81 ? 349  THR A OG1 1 
+ATOM   2614 C  CG2 . THR A 1 327 ? 3.166   2.135   27.186  1.00 23.57 ? 349  THR A CG2 1 
+ATOM   2615 N  N   . PRO A 1 328 ? -1.390  1.819   26.602  1.00 19.75 ? 350  PRO A N   1 
+ATOM   2616 C  CA  . PRO A 1 328 ? -2.773  2.221   26.877  1.00 20.44 ? 350  PRO A CA  1 
+ATOM   2617 C  C   . PRO A 1 328 ? -2.914  2.919   28.235  1.00 19.65 ? 350  PRO A C   1 
+ATOM   2618 O  O   . PRO A 1 328 ? -1.928  2.977   29.015  1.00 20.16 ? 350  PRO A O   1 
+ATOM   2619 C  CB  . PRO A 1 328 ? -3.551  0.911   26.828  1.00 21.17 ? 350  PRO A CB  1 
+ATOM   2620 C  CG  . PRO A 1 328 ? -2.553  -0.145  27.365  1.00 20.66 ? 350  PRO A CG  1 
+ATOM   2621 C  CD  . PRO A 1 328 ? -1.176  0.374   26.775  1.00 19.60 ? 350  PRO A CD  1 
+ATOM   2622 N  N   . THR A 1 329 ? -4.100  3.465   28.487  1.00 17.65 ? 351  THR A N   1 
+ATOM   2623 C  CA  . THR A 1 329 ? -4.389  4.118   29.768  1.00 17.84 ? 351  THR A CA  1 
+ATOM   2624 C  C   . THR A 1 329 ? -5.588  3.486   30.452  1.00 18.45 ? 351  THR A C   1 
+ATOM   2625 O  O   . THR A 1 329 ? -6.488  2.915   29.822  1.00 19.21 ? 351  THR A O   1 
+ATOM   2626 C  CB  . THR A 1 329 ? -4.655  5.590   29.576  1.00 19.52 ? 351  THR A CB  1 
+ATOM   2627 O  OG1 . THR A 1 329 ? -5.716  5.782   28.626  1.00 21.70 ? 351  THR A OG1 1 
+ATOM   2628 C  CG2 . THR A 1 329 ? -3.445  6.284   29.123  1.00 21.44 ? 351  THR A CG2 1 
+ATOM   2629 N  N   . LEU A 1 330 ? -5.577  3.576   31.768  1.00 19.14 ? 352  LEU A N   1 
+ATOM   2630 C  CA  . LEU A 1 330 ? -6.719  3.234   32.610  1.00 18.25 ? 352  LEU A CA  1 
+ATOM   2631 C  C   . LEU A 1 330 ? -7.240  4.505   33.268  1.00 19.36 ? 352  LEU A C   1 
+ATOM   2632 O  O   . LEU A 1 330 ? -6.470  5.361   33.615  1.00 20.98 ? 352  LEU A O   1 
+ATOM   2633 C  CB  . LEU A 1 330 ? -6.285  2.300   33.756  1.00 18.20 ? 352  LEU A CB  1 
+ATOM   2634 C  CG  . LEU A 1 330 ? -5.955  0.874   33.325  1.00 18.63 ? 352  LEU A CG  1 
+ATOM   2635 C  CD1 . LEU A 1 330 ? -5.117  0.105   34.344  1.00 18.97 ? 352  LEU A CD1 1 
+ATOM   2636 C  CD2 . LEU A 1 330 ? -7.286  0.126   32.985  1.00 19.41 ? 352  LEU A CD2 1 
+ATOM   2637 N  N   . SER A 1 331 ? -8.534  4.606   33.476  1.00 18.64 ? 353  SER A N   1 
+ATOM   2638 C  CA  . SER A 1 331 ? -9.113  5.790   34.113  1.00 17.85 ? 353  SER A CA  1 
+ATOM   2639 C  C   . SER A 1 331 ? -10.121 5.365   35.131  1.00 18.61 ? 353  SER A C   1 
+ATOM   2640 O  O   . SER A 1 331 ? -10.781 4.308   35.007  1.00 20.66 ? 353  SER A O   1 
+ATOM   2641 C  CB  . SER A 1 331 ? -9.797  6.657   33.091  1.00 21.66 ? 353  SER A CB  1 
+ATOM   2642 O  OG  . SER A 1 331 ? -8.808  7.151   32.140  1.00 24.62 ? 353  SER A OG  1 
+ATOM   2643 N  N   . GLY A 1 332 ? -10.268 6.212   36.139  1.00 19.29 ? 354  GLY A N   1 
+ATOM   2644 C  CA  . GLY A 1 332 ? -11.311 6.042   37.113  1.00 20.07 ? 354  GLY A CA  1 
+ATOM   2645 C  C   . GLY A 1 332 ? -10.978 5.259   38.350  1.00 20.58 ? 354  GLY A C   1 
+ATOM   2646 O  O   . GLY A 1 332 ? -11.844 5.143   39.242  1.00 21.99 ? 354  GLY A O   1 
+ATOM   2647 N  N   . ILE A 1 333 ? -9.751  4.760   38.455  1.00 18.82 ? 355  ILE A N   1 
+ATOM   2648 C  CA  . ILE A 1 333 ? -9.390  3.868   39.567  1.00 19.23 ? 355  ILE A CA  1 
+ATOM   2649 C  C   . ILE A 1 333 ? -8.958  4.697   40.792  1.00 17.43 ? 355  ILE A C   1 
+ATOM   2650 O  O   . ILE A 1 333 ? -8.022  5.534   40.733  1.00 19.46 ? 355  ILE A O   1 
+ATOM   2651 C  CB  . ILE A 1 333 ? -8.265  2.929   39.153  1.00 19.22 ? 355  ILE A CB  1 
+ATOM   2652 C  CG1 . ILE A 1 333 ? -8.747  2.009   38.030  1.00 20.31 ? 355  ILE A CG1 1 
+ATOM   2653 C  CG2 . ILE A 1 333 ? -7.815  2.045   40.362  1.00 20.81 ? 355  ILE A CG2 1 
+ATOM   2654 C  CD1 . ILE A 1 333 ? -7.628  1.312   37.342  1.00 20.75 ? 355  ILE A CD1 1 
+ATOM   2655 N  N   . VAL A 1 334 ? -9.675  4.491   41.882  1.00 17.67 ? 356  VAL A N   1 
+ATOM   2656 C  CA  . VAL A 1 334 ? -9.360  5.187   43.144  1.00 17.56 ? 356  VAL A CA  1 
+ATOM   2657 C  C   . VAL A 1 334 ? -9.605  4.253   44.314  1.00 18.21 ? 356  VAL A C   1 
+ATOM   2658 O  O   . VAL A 1 334 ? -10.604 3.537   44.358  1.00 18.55 ? 356  VAL A O   1 
+ATOM   2659 C  CB  . VAL A 1 334 ? -10.234 6.429   43.322  1.00 19.41 ? 356  VAL A CB  1 
+ATOM   2660 C  CG1 . VAL A 1 334 ? -9.758  7.269   44.583  1.00 20.30 ? 356  VAL A CG1 1 
+ATOM   2661 C  CG2 . VAL A 1 334 ? -10.224 7.244   42.022  1.00 24.78 ? 356  VAL A CG2 1 
+ATOM   2662 N  N   . ASP A 1 335 ? -8.702  4.259   45.279  1.00 17.60 ? 357  ASP A N   1 
+ATOM   2663 C  CA  . ASP A 1 335 ? -8.874  3.431   46.475  1.00 18.03 ? 357  ASP A CA  1 
+ATOM   2664 C  C   . ASP A 1 335 ? -10.235 3.786   47.064  1.00 18.24 ? 357  ASP A C   1 
+ATOM   2665 O  O   . ASP A 1 335 ? -10.627 4.957   47.119  1.00 18.39 ? 357  ASP A O   1 
+ATOM   2666 C  CB  . ASP A 1 335 ? -7.808  3.742   47.519  1.00 18.11 ? 357  ASP A CB  1 
+ATOM   2667 C  CG  . ASP A 1 335 ? -6.407  3.352   47.141  1.00 17.86 ? 357  ASP A CG  1 
+ATOM   2668 O  OD1 . ASP A 1 335 ? -6.228  2.610   46.146  1.00 17.43 ? 357  ASP A OD1 1 
+ATOM   2669 O  OD2 . ASP A 1 335 ? -5.462  3.867   47.861  1.00 19.39 ? 357  ASP A OD2 1 
+ATOM   2670 N  N   . THR A 1 336 ? -10.974 2.776   47.505  1.00 17.63 ? 358  THR A N   1 
+ATOM   2671 C  CA  . THR A 1 336 ? -12.356 2.961   47.891  1.00 20.04 ? 358  THR A CA  1 
+ATOM   2672 C  C   . THR A 1 336 ? -12.639 2.271   49.221  1.00 20.09 ? 358  THR A C   1 
+ATOM   2673 O  O   . THR A 1 336 ? -12.134 1.182   49.453  1.00 20.67 ? 358  THR A O   1 
+ATOM   2674 C  CB  . THR A 1 336 ? -13.274 2.391   46.758  1.00 21.03 ? 358  THR A CB  1 
+ATOM   2675 O  OG1 . THR A 1 336 ? -13.101 3.219   45.603  1.00 19.28 ? 358  THR A OG1 1 
+ATOM   2676 C  CG2 . THR A 1 336 ? -14.727 2.429   47.127  1.00 23.15 ? 358  THR A CG2 1 
+ATOM   2677 N  N   . ARG A 1 337 ? -13.408 2.958   50.070  1.00 18.50 ? 359  ARG A N   1 
+ATOM   2678 C  CA  . ARG A 1 337 ? -13.903 2.416   51.343  1.00 17.85 ? 359  ARG A CA  1 
+ATOM   2679 C  C   . ARG A 1 337 ? -15.337 1.955   51.157  1.00 19.42 ? 359  ARG A C   1 
+ATOM   2680 O  O   . ARG A 1 337 ? -16.188 2.617   50.579  1.00 20.70 ? 359  ARG A O   1 
+ATOM   2681 C  CB  . ARG A 1 337 ? -13.785 3.482   52.462  1.00 18.65 ? 359  ARG A CB  1 
+ATOM   2682 C  CG  . ARG A 1 337 ? -12.374 3.889   52.699  1.00 17.56 ? 359  ARG A CG  1 
+ATOM   2683 C  CD  . ARG A 1 337 ? -12.243 4.986   53.790  1.00 18.77 ? 359  ARG A CD  1 
+ATOM   2684 N  NE  . ARG A 1 337 ? -12.718 4.506   55.138  1.00 19.52 ? 359  ARG A NE  1 
+ATOM   2685 C  CZ  . ARG A 1 337 ? -12.029 3.781   56.012  1.00 19.72 ? 359  ARG A CZ  1 
+ATOM   2686 N  NH1 . ARG A 1 337 ? -10.794 3.318   55.743  1.00 21.22 ? 359  ARG A NH1 1 
+ATOM   2687 N  NH2 . ARG A 1 337 ? -12.625 3.464   57.159  1.00 21.63 ? 359  ARG A NH2 1 
+ATOM   2688 N  N   . VAL A 1 338 ? -15.587 0.754   51.654  1.00 20.24 ? 360  VAL A N   1 
+ATOM   2689 C  CA  A VAL A 1 338 ? -16.877 0.114   51.501  0.35 20.49 ? 360  VAL A CA  1 
+ATOM   2690 C  CA  B VAL A 1 338 ? -16.836 0.033   51.491  0.65 21.38 ? 360  VAL A CA  1 
+ATOM   2691 C  C   . VAL A 1 338 ? -17.343 -0.431  52.857  1.00 21.44 ? 360  VAL A C   1 
+ATOM   2692 O  O   . VAL A 1 338 ? -16.611 -1.088  53.592  1.00 22.40 ? 360  VAL A O   1 
+ATOM   2693 C  CB  A VAL A 1 338 ? -16.881 -0.989  50.400  0.35 19.33 ? 360  VAL A CB  1 
+ATOM   2694 C  CB  B VAL A 1 338 ? -16.636 -1.228  50.644  0.65 22.85 ? 360  VAL A CB  1 
+ATOM   2695 C  CG1 A VAL A 1 338 ? -16.439 -0.410  49.051  0.35 19.57 ? 360  VAL A CG1 1 
+ATOM   2696 C  CG1 B VAL A 1 338 ? -17.916 -2.081  50.607  0.65 22.54 ? 360  VAL A CG1 1 
+ATOM   2697 C  CG2 A VAL A 1 338 ? -16.029 -2.180  50.797  0.35 19.72 ? 360  VAL A CG2 1 
+ATOM   2698 C  CG2 B VAL A 1 338 ? -16.174 -0.877  49.238  0.65 24.71 ? 360  VAL A CG2 1 
+ATOM   2699 N  N   . GLU A 1 339 ? -18.591 -0.142  53.180  1.00 22.27 ? 361  GLU A N   1 
+ATOM   2700 C  CA  . GLU A 1 339 ? -19.121 -0.554  54.487  1.00 24.96 ? 361  GLU A CA  1 
+ATOM   2701 C  C   . GLU A 1 339 ? -19.377 -2.068  54.509  1.00 24.46 ? 361  GLU A C   1 
+ATOM   2702 O  O   . GLU A 1 339 ? -19.750 -2.675  53.514  1.00 26.44 ? 361  GLU A O   1 
+ATOM   2703 C  CB  . GLU A 1 339 ? -20.400 0.222   54.809  1.00 30.21 ? 361  GLU A CB  1 
+ATOM   2704 C  CG  . GLU A 1 339 ? -20.830 0.242   56.286  1.00 33.42 ? 361  GLU A CG  1 
+ATOM   2705 C  CD  . GLU A 1 339 ? -21.886 1.358   56.596  1.00 39.75 ? 361  GLU A CD  1 
+ATOM   2706 O  OE1 . GLU A 1 339 ? -22.485 1.968   55.650  1.00 41.72 ? 361  GLU A OE1 1 
+ATOM   2707 O  OE2 . GLU A 1 339 ? -22.142 1.569   57.785  1.00 42.16 ? 361  GLU A OE2 1 
+ATOM   2708 N  N   . LEU A 1 340 ? -19.149 -2.665  55.658  1.00 23.72 ? 362  LEU A N   1 
+ATOM   2709 C  CA  . LEU A 1 340 ? -19.372 -4.098  55.854  1.00 25.46 ? 362  LEU A CA  1 
+ATOM   2710 C  C   . LEU A 1 340 ? -20.706 -4.492  55.268  1.00 27.26 ? 362  LEU A C   1 
+ATOM   2711 O  O   . LEU A 1 340 ? -21.745 -3.879  55.547  1.00 26.90 ? 362  LEU A O   1 
+ATOM   2712 C  CB  . LEU A 1 340 ? -19.316 -4.358  57.356  1.00 26.02 ? 362  LEU A CB  1 
+ATOM   2713 C  CG  . LEU A 1 340 ? -19.341 -5.835  57.776  1.00 27.31 ? 362  LEU A CG  1 
+ATOM   2714 C  CD1 . LEU A 1 340 ? -18.131 -6.674  57.342  1.00 27.40 ? 362  LEU A CD1 1 
+ATOM   2715 C  CD2 . LEU A 1 340 ? -19.427 -5.831  59.304  1.00 30.03 ? 362  LEU A CD2 1 
+ATOM   2716 N  N   . ASP A 1 341 ? -20.651 -5.573  54.501  1.00 28.44 ? 363  ASP A N   1 
+ATOM   2717 C  CA  . ASP A 1 341 ? -21.782 -6.237  53.879  1.00 30.76 ? 363  ASP A CA  1 
+ATOM   2718 C  C   . ASP A 1 341 ? -22.498 -5.466  52.769  1.00 32.16 ? 363  ASP A C   1 
+ATOM   2719 O  O   . ASP A 1 341 ? -23.533 -5.902  52.297  1.00 33.82 ? 363  ASP A O   1 
+ATOM   2720 C  CB  . ASP A 1 341 ? -22.771 -6.710  54.909  1.00 32.43 ? 363  ASP A CB  1 
+ATOM   2721 C  CG  . ASP A 1 341 ? -22.208 -7.841  55.757  1.00 35.62 ? 363  ASP A CG  1 
+ATOM   2722 O  OD1 . ASP A 1 341 ? -21.521 -8.745  55.215  1.00 37.04 ? 363  ASP A OD1 1 
+ATOM   2723 O  OD2 . ASP A 1 341 ? -22.482 -7.848  56.952  1.00 37.43 ? 363  ASP A OD2 1 
+ATOM   2724 N  N   . SER A 1 342 ? -21.933 -4.335  52.343  1.00 31.32 ? 364  SER A N   1 
+ATOM   2725 C  CA  . SER A 1 342 ? -22.522 -3.610  51.225  1.00 35.98 ? 364  SER A CA  1 
+ATOM   2726 C  C   . SER A 1 342 ? -22.114 -4.289  49.915  1.00 38.19 ? 364  SER A C   1 
+ATOM   2727 O  O   . SER A 1 342 ? -21.229 -5.147  49.910  1.00 39.53 ? 364  SER A O   1 
+ATOM   2728 C  CB  . SER A 1 342 ? -22.076 -2.163  51.282  1.00 39.15 ? 364  SER A CB  1 
+ATOM   2729 O  OG  . SER A 1 342 ? -20.691 -2.075  51.003  1.00 39.62 ? 364  SER A OG  1 
+ATOM   2730 N  N   . HIS A 1 343 ? -22.798 -3.973  48.820  1.00 40.67 ? 365  HIS A N   1 
+ATOM   2731 C  CA  . HIS A 1 343 ? -22.428 -4.589  47.534  1.00 42.17 ? 365  HIS A CA  1 
+ATOM   2732 C  C   . HIS A 1 343 ? -21.290 -3.813  46.911  1.00 37.77 ? 365  HIS A C   1 
+ATOM   2733 O  O   . HIS A 1 343 ? -21.260 -2.587  46.968  1.00 39.44 ? 365  HIS A O   1 
+ATOM   2734 C  CB  . HIS A 1 343 ? -23.602 -4.631  46.544  1.00 47.65 ? 365  HIS A CB  1 
+ATOM   2735 C  CG  . HIS A 1 343 ? -23.297 -5.351  45.263  1.00 51.18 ? 365  HIS A CG  1 
+ATOM   2736 N  ND1 . HIS A 1 343 ? -23.249 -4.714  44.032  1.00 52.25 ? 365  HIS A ND1 1 
+ATOM   2737 C  CD2 . HIS A 1 343 ? -23.057 -6.663  45.011  1.00 53.42 ? 365  HIS A CD2 1 
+ATOM   2738 C  CE1 . HIS A 1 343 ? -22.974 -5.601  43.085  1.00 52.59 ? 365  HIS A CE1 1 
+ATOM   2739 N  NE2 . HIS A 1 343 ? -22.858 -6.792  43.654  1.00 53.53 ? 365  HIS A NE2 1 
+ATOM   2740 N  N   . PHE A 1 344 ? -20.357 -4.527  46.293  1.00 34.56 ? 366  PHE A N   1 
+ATOM   2741 C  CA  . PHE A 1 344 ? -19.216 -3.878  45.675  1.00 32.29 ? 366  PHE A CA  1 
+ATOM   2742 C  C   . PHE A 1 344 ? -19.032 -4.472  44.288  1.00 31.69 ? 366  PHE A C   1 
+ATOM   2743 O  O   . PHE A 1 344 ? -18.994 -5.683  44.107  1.00 31.04 ? 366  PHE A O   1 
+ATOM   2744 C  CB  . PHE A 1 344 ? -17.960 -4.077  46.511  1.00 28.15 ? 366  PHE A CB  1 
+ATOM   2745 C  CG  . PHE A 1 344 ? -16.739 -3.625  45.844  1.00 25.61 ? 366  PHE A CG  1 
+ATOM   2746 C  CD1 . PHE A 1 344 ? -16.539 -2.282  45.604  1.00 24.65 ? 366  PHE A CD1 1 
+ATOM   2747 C  CD2 . PHE A 1 344 ? -15.859 -4.549  45.308  1.00 28.79 ? 366  PHE A CD2 1 
+ATOM   2748 C  CE1 . PHE A 1 344 ? -15.404 -1.863  44.901  1.00 25.58 ? 366  PHE A CE1 1 
+ATOM   2749 C  CE2 . PHE A 1 344 ? -14.762 -4.145  44.620  1.00 27.70 ? 366  PHE A CE2 1 
+ATOM   2750 C  CZ  . PHE A 1 344 ? -14.527 -2.792  44.419  1.00 27.23 ? 366  PHE A CZ  1 
+ATOM   2751 N  N   . ASP A 1 345 ? -18.958 -3.588  43.311  1.00 31.19 ? 367  ASP A N   1 
+ATOM   2752 C  CA  . ASP A 1 345 ? -18.754 -3.982  41.932  1.00 30.53 ? 367  ASP A CA  1 
+ATOM   2753 C  C   . ASP A 1 345 ? -17.458 -3.376  41.474  1.00 26.64 ? 367  ASP A C   1 
+ATOM   2754 O  O   . ASP A 1 345 ? -17.332 -2.174  41.355  1.00 26.27 ? 367  ASP A O   1 
+ATOM   2755 C  CB  . ASP A 1 345 ? -19.897 -3.474  41.072  1.00 34.91 ? 367  ASP A CB  1 
+ATOM   2756 C  CG  . ASP A 1 345 ? -19.744 -3.838  39.623  1.00 37.82 ? 367  ASP A CG  1 
+ATOM   2757 O  OD1 . ASP A 1 345 ? -18.611 -4.125  39.155  1.00 37.23 ? 367  ASP A OD1 1 
+ATOM   2758 O  OD2 . ASP A 1 345 ? -20.778 -3.813  38.911  1.00 39.94 ? 367  ASP A OD2 1 
+ATOM   2759 N  N   . PRO A 1 346 ? -16.473 -4.215  41.204  1.00 26.16 ? 368  PRO A N   1 
+ATOM   2760 C  CA  . PRO A 1 346 ? -15.121 -3.762  40.894  1.00 24.71 ? 368  PRO A CA  1 
+ATOM   2761 C  C   . PRO A 1 346 ? -14.964 -3.109  39.506  1.00 24.79 ? 368  PRO A C   1 
+ATOM   2762 O  O   . PRO A 1 346 ? -13.921 -2.471  39.255  1.00 24.77 ? 368  PRO A O   1 
+ATOM   2763 C  CB  . PRO A 1 346 ? -14.309 -5.054  40.978  1.00 27.02 ? 368  PRO A CB  1 
+ATOM   2764 C  CG  . PRO A 1 346 ? -15.303 -6.095  40.589  1.00 29.78 ? 368  PRO A CG  1 
+ATOM   2765 C  CD  . PRO A 1 346 ? -16.539 -5.671  41.286  1.00 27.30 ? 368  PRO A CD  1 
+ATOM   2766 N  N   . LEU A 1 347 ? -15.961 -3.174  38.647  1.00 25.38 ? 369  LEU A N   1 
+ATOM   2767 C  CA  . LEU A 1 347 ? -15.835 -2.603  37.314  1.00 25.05 ? 369  LEU A CA  1 
+ATOM   2768 C  C   . LEU A 1 347 ? -16.458 -1.211  37.194  1.00 24.36 ? 369  LEU A C   1 
+ATOM   2769 O  O   . LEU A 1 347 ? -16.167 -0.434  36.283  1.00 25.35 ? 369  LEU A O   1 
+ATOM   2770 C  CB  . LEU A 1 347 ? -16.521 -3.542  36.309  1.00 25.90 ? 369  LEU A CB  1 
+ATOM   2771 C  CG  . LEU A 1 347 ? -15.863 -4.930  36.213  1.00 27.47 ? 369  LEU A CG  1 
+ATOM   2772 C  CD1 . LEU A 1 347 ? -16.390 -5.720  35.077  1.00 28.67 ? 369  LEU A CD1 1 
+ATOM   2773 C  CD2 . LEU A 1 347 ? -14.379 -4.737  36.020  1.00 27.02 ? 369  LEU A CD2 1 
+ATOM   2774 N  N   . ILE A 1 348 ? -17.375 -0.876  38.096  1.00 27.72 ? 370  ILE A N   1 
+ATOM   2775 C  CA  . ILE A 1 348 ? -18.106 0.369   37.932  1.00 27.67 ? 370  ILE A CA  1 
+ATOM   2776 C  C   . ILE A 1 348 ? -17.160 1.572   38.018  1.00 27.36 ? 370  ILE A C   1 
+ATOM   2777 O  O   . ILE A 1 348 ? -16.327 1.621   38.904  1.00 24.37 ? 370  ILE A O   1 
+ATOM   2778 C  CB  . ILE A 1 348 ? -19.180 0.474   38.999  1.00 33.14 ? 370  ILE A CB  1 
+ATOM   2779 C  CG1 . ILE A 1 348 ? -20.174 -0.652  38.813  1.00 38.95 ? 370  ILE A CG1 1 
+ATOM   2780 C  CG2 . ILE A 1 348 ? -19.889 1.778   38.836  1.00 35.54 ? 370  ILE A CG2 1 
+ATOM   2781 C  CD1 . ILE A 1 348 ? -21.208 -0.709  39.911  1.00 42.02 ? 370  ILE A CD1 1 
+ATOM   2782 N  N   . GLY A 1 349 ? -17.277 2.505   37.071  1.00 28.38 ? 371  GLY A N   1 
+ATOM   2783 C  CA  . GLY A 1 349 ? -16.496 3.729   37.006  1.00 25.62 ? 371  GLY A CA  1 
+ATOM   2784 C  C   . GLY A 1 349 ? -15.126 3.646   36.367  1.00 22.89 ? 371  GLY A C   1 
+ATOM   2785 O  O   . GLY A 1 349 ? -14.432 4.698   36.202  1.00 22.35 ? 371  GLY A O   1 
+ATOM   2786 N  N   . ILE A 1 350 ? -14.755 2.448   35.953  1.00 21.93 ? 372  ILE A N   1 
+ATOM   2787 C  CA  . ILE A 1 350 ? -13.422 2.231   35.433  1.00 20.50 ? 372  ILE A CA  1 
+ATOM   2788 C  C   . ILE A 1 350 ? -13.464 2.011   33.932  1.00 19.53 ? 372  ILE A C   1 
+ATOM   2789 O  O   . ILE A 1 350 ? -14.325 1.270   33.419  1.00 21.13 ? 372  ILE A O   1 
+ATOM   2790 C  CB  . ILE A 1 350 ? -12.791 1.096   36.169  1.00 24.48 ? 372  ILE A CB  1 
+ATOM   2791 C  CG1 . ILE A 1 350 ? -12.626 1.564   37.671  1.00 27.81 ? 372  ILE A CG1 1 
+ATOM   2792 C  CG2 . ILE A 1 350 ? -11.450 0.667   35.517  1.00 24.16 ? 372  ILE A CG2 1 
+ATOM   2793 C  CD1 . ILE A 1 350 ? -12.202 0.495   38.577  1.00 32.52 ? 372  ILE A CD1 1 
+ATOM   2794 N  N   . THR A 1 351 ? -12.619 2.741   33.219  1.00 20.18 ? 373  THR A N   1 
+ATOM   2795 C  CA  . THR A 1 351 ? -12.551 2.649   31.771  1.00 17.88 ? 373  THR A CA  1 
+ATOM   2796 C  C   . THR A 1 351 ? -11.103 2.541   31.299  1.00 18.73 ? 373  THR A C   1 
+ATOM   2797 O  O   . THR A 1 351 ? -10.124 2.719   32.095  1.00 19.70 ? 373  THR A O   1 
+ATOM   2798 C  CB  . THR A 1 351 ? -13.224 3.889   31.114  1.00 19.97 ? 373  THR A CB  1 
+ATOM   2799 O  OG1 . THR A 1 351 ? -12.592 5.088   31.572  1.00 20.86 ? 373  THR A OG1 1 
+ATOM   2800 C  CG2 . THR A 1 351 ? -14.710 3.964   31.487  1.00 22.97 ? 373  THR A CG2 1 
+ATOM   2801 N  N   . ALA A 1 352 ? -10.944 2.285   29.994  1.00 19.64 ? 374  ALA A N   1 
+ATOM   2802 C  CA  . ALA A 1 352 ? -9.604  2.181   29.412  1.00 19.03 ? 374  ALA A CA  1 
+ATOM   2803 C  C   . ALA A 1 352 ? -9.607  2.622   27.949  1.00 18.34 ? 374  ALA A C   1 
+ATOM   2804 O  O   . ALA A 1 352 ? -10.637 2.563   27.284  1.00 19.18 ? 374  ALA A O   1 
+ATOM   2805 C  CB  . ALA A 1 352 ? -9.109  0.750   29.462  1.00 17.76 ? 374  ALA A CB  1 
+ATOM   2806 N  N   . LYS A 1 353 ? -8.459  3.144   27.505  1.00 18.92 ? 375  LYS A N   1 
+ATOM   2807 C  CA  . LYS A 1 353 ? -8.270  3.563   26.097  1.00 19.04 ? 375  LYS A CA  1 
+ATOM   2808 C  C   . LYS A 1 353 ? -6.940  3.072   25.584  1.00 20.01 ? 375  LYS A C   1 
+ATOM   2809 O  O   . LYS A 1 353 ? -5.964  2.970   26.323  1.00 20.54 ? 375  LYS A O   1 
+ATOM   2810 C  CB  . LYS A 1 353 ? -8.249  5.082   25.953  1.00 22.06 ? 375  LYS A CB  1 
+ATOM   2811 C  CG  . LYS A 1 353 ? -9.506  5.730   26.274  1.00 22.66 ? 375  LYS A CG  1 
+ATOM   2812 C  CD  . LYS A 1 353 ? -9.384  7.271   26.238  1.00 25.31 ? 375  LYS A CD  1 
+ATOM   2813 C  CE  . LYS A 1 353 ? -10.681 7.904   26.541  1.00 29.03 ? 375  LYS A CE  1 
+ATOM   2814 N  NZ  . LYS A 1 353 ? -10.420 9.309   26.829  1.00 30.63 ? 375  LYS A NZ  1 
+ATOM   2815 N  N   . ASP A 1 354 ? -6.881  2.759   24.295  1.00 20.23 ? 376  ASP A N   1 
+ATOM   2816 C  CA  . ASP A 1 354 ? -5.600  2.531   23.651  1.00 20.07 ? 376  ASP A CA  1 
+ATOM   2817 C  C   . ASP A 1 354 ? -4.947  3.860   23.365  1.00 21.04 ? 376  ASP A C   1 
+ATOM   2818 O  O   . ASP A 1 354 ? -5.490  4.939   23.706  1.00 20.17 ? 376  ASP A O   1 
+ATOM   2819 C  CB  . ASP A 1 354 ? -5.803  1.626   22.398  1.00 19.78 ? 376  ASP A CB  1 
+ATOM   2820 C  CG  . ASP A 1 354 ? -6.439  2.354   21.199  1.00 23.58 ? 376  ASP A CG  1 
+ATOM   2821 O  OD1 . ASP A 1 354 ? -6.572  3.595   21.243  1.00 22.28 ? 376  ASP A OD1 1 
+ATOM   2822 O  OD2 . ASP A 1 354 ? -6.800  1.623   20.235  1.00 23.22 ? 376  ASP A OD2 1 
+ATOM   2823 N  N   . TYR A 1 355 ? -3.733  3.810   22.830  1.00 21.75 ? 377  TYR A N   1 
+ATOM   2824 C  CA  . TYR A 1 355 ? -2.926  5.026   22.666  1.00 22.25 ? 377  TYR A CA  1 
+ATOM   2825 C  C   . TYR A 1 355 ? -3.528  6.008   21.657  1.00 21.95 ? 377  TYR A C   1 
+ATOM   2826 O  O   . TYR A 1 355 ? -3.135  7.160   21.631  1.00 23.81 ? 377  TYR A O   1 
+ATOM   2827 C  CB  . TYR A 1 355 ? -1.484  4.699   22.292  1.00 22.84 ? 377  TYR A CB  1 
+ATOM   2828 C  CG  . TYR A 1 355 ? -1.248  4.384   20.823  1.00 25.24 ? 377  TYR A CG  1 
+ATOM   2829 C  CD1 . TYR A 1 355 ? -0.763  5.350   19.982  1.00 24.02 ? 377  TYR A CD1 1 
+ATOM   2830 C  CD2 . TYR A 1 355 ? -1.490  3.114   20.300  1.00 26.01 ? 377  TYR A CD2 1 
+ATOM   2831 C  CE1 . TYR A 1 355 ? -0.557  5.092   18.651  1.00 25.37 ? 377  TYR A CE1 1 
+ATOM   2832 C  CE2 . TYR A 1 355 ? -1.286  2.837   18.943  1.00 28.48 ? 377  TYR A CE2 1 
+ATOM   2833 C  CZ  . TYR A 1 355 ? -0.806  3.833   18.125  1.00 26.98 ? 377  TYR A CZ  1 
+ATOM   2834 O  OH  . TYR A 1 355 ? -0.566  3.589   16.773  1.00 30.80 ? 377  TYR A OH  1 
+ATOM   2835 N  N   . GLN A 1 356 ? -4.475  5.544   20.837  1.00 21.92 ? 378  GLN A N   1 
+ATOM   2836 C  CA  . GLN A 1 356 ? -5.189  6.351   19.885  1.00 23.23 ? 378  GLN A CA  1 
+ATOM   2837 C  C   . GLN A 1 356 ? -6.523  6.871   20.384  1.00 22.82 ? 378  GLN A C   1 
+ATOM   2838 O  O   . GLN A 1 356 ? -7.259  7.548   19.644  1.00 24.93 ? 378  GLN A O   1 
+ATOM   2839 C  CB  . GLN A 1 356 ? -5.381  5.582   18.548  1.00 25.67 ? 378  GLN A CB  1 
+ATOM   2840 C  CG  . GLN A 1 356 ? -4.123  5.087   17.963  1.00 26.29 ? 378  GLN A CG  1 
+ATOM   2841 C  CD  . GLN A 1 356 ? -4.358  4.372   16.632  1.00 32.16 ? 378  GLN A CD  1 
+ATOM   2842 O  OE1 . GLN A 1 356 ? -4.401  3.130   16.558  1.00 36.33 ? 378  GLN A OE1 1 
+ATOM   2843 N  NE2 . GLN A 1 356 ? -4.504  5.150   15.591  1.00 33.93 ? 378  GLN A NE2 1 
+ATOM   2844 N  N   . GLY A 1 357 ? -6.801  6.627   21.669  1.00 22.53 ? 379  GLY A N   1 
+ATOM   2845 C  CA  . GLY A 1 357 ? -8.039  7.051   22.277  1.00 22.17 ? 379  GLY A CA  1 
+ATOM   2846 C  C   . GLY A 1 357 ? -9.259  6.195   22.036  1.00 20.99 ? 379  GLY A C   1 
+ATOM   2847 O  O   . GLY A 1 357 ? -10.347 6.579   22.491  1.00 25.03 ? 379  GLY A O   1 
+ATOM   2848 N  N   . ASN A 1 358 ? -9.090  5.009   21.436  1.00 21.92 ? 380  ASN A N   1 
+ATOM   2849 C  CA  . ASN A 1 358 ? -10.233 4.124   21.261  1.00 22.07 ? 380  ASN A CA  1 
+ATOM   2850 C  C   . ASN A 1 358 ? -10.592 3.508   22.608  1.00 21.19 ? 380  ASN A C   1 
+ATOM   2851 O  O   . ASN A 1 358 ? -9.714  3.137   23.358  1.00 22.79 ? 380  ASN A O   1 
+ATOM   2852 C  CB  . ASN A 1 358 ? -9.933  3.017   20.275  1.00 24.42 ? 380  ASN A CB  1 
+ATOM   2853 C  CG  . ASN A 1 358 ? -9.616  3.541   18.885  1.00 28.75 ? 380  ASN A CG  1 
+ATOM   2854 O  OD1 . ASN A 1 358 ? -10.379 4.324   18.273  1.00 34.52 ? 380  ASN A OD1 1 
+ATOM   2855 N  ND2 . ASN A 1 358 ? -8.450  3.161   18.415  1.00 27.13 ? 380  ASN A ND2 1 
+ATOM   2856 N  N   . ASP A 1 359 ? -11.875 3.350   22.885  1.00 23.05 ? 381  ASP A N   1 
+ATOM   2857 C  CA  . ASP A 1 359 ? -12.286 2.716   24.127  1.00 22.60 ? 381  ASP A CA  1 
+ATOM   2858 C  C   . ASP A 1 359 ? -11.963 1.232   24.110  1.00 21.83 ? 381  ASP A C   1 
+ATOM   2859 O  O   . ASP A 1 359 ? -12.407 0.521   23.188  1.00 24.04 ? 381  ASP A O   1 
+ATOM   2860 C  CB  . ASP A 1 359 ? -13.773 2.884   24.266  1.00 26.56 ? 381  ASP A CB  1 
+ATOM   2861 C  CG  . ASP A 1 359 ? -14.306 2.387   25.565  1.00 31.21 ? 381  ASP A CG  1 
+ATOM   2862 O  OD1 . ASP A 1 359 ? -13.608 2.223   26.554  1.00 32.47 ? 381  ASP A OD1 1 
+ATOM   2863 O  OD2 . ASP A 1 359 ? -15.489 2.147   25.596  1.00 38.30 ? 381  ASP A OD2 1 
+ATOM   2864 N  N   . ILE A 1 360 ? -11.205 0.773   25.100  1.00 21.32 ? 382  ILE A N   1 
+ATOM   2865 C  CA  . ILE A 1 360 ? -10.964 -0.639  25.270  1.00 23.41 ? 382  ILE A CA  1 
+ATOM   2866 C  C   . ILE A 1 360 ? -11.351 -1.113  26.667  1.00 20.42 ? 382  ILE A C   1 
+ATOM   2867 O  O   . ILE A 1 360 ? -10.843 -2.100  27.187  1.00 20.24 ? 382  ILE A O   1 
+ATOM   2868 C  CB  . ILE A 1 360 ? -9.525  -0.996  24.972  1.00 23.08 ? 382  ILE A CB  1 
+ATOM   2869 C  CG1 . ILE A 1 360 ? -8.576  -0.194  25.860  1.00 22.70 ? 382  ILE A CG1 1 
+ATOM   2870 C  CG2 . ILE A 1 360 ? -9.235  -0.686  23.514  1.00 23.93 ? 382  ILE A CG2 1 
+ATOM   2871 C  CD1 . ILE A 1 360 ? -7.162  -0.563  25.682  1.00 22.75 ? 382  ILE A CD1 1 
+ATOM   2872 N  N   . THR A 1 361 ? -12.362 -0.453  27.228  1.00 20.24 ? 383  THR A N   1 
+ATOM   2873 C  CA  . THR A 1 361 ? -12.844 -0.855  28.551  1.00 19.19 ? 383  THR A CA  1 
+ATOM   2874 C  C   . THR A 1 361 ? -13.160 -2.350  28.710  1.00 21.56 ? 383  THR A C   1 
+ATOM   2875 O  O   . THR A 1 361 ? -12.916 -2.925  29.764  1.00 21.61 ? 383  THR A O   1 
+ATOM   2876 C  CB  . THR A 1 361 ? -14.037 0.018   28.942  1.00 20.68 ? 383  THR A CB  1 
+ATOM   2877 O  OG1 . THR A 1 361 ? -13.591 1.396   28.979  1.00 21.55 ? 383  THR A OG1 1 
+ATOM   2878 C  CG2 . THR A 1 361 ? -14.630 -0.320  30.305  1.00 21.82 ? 383  THR A CG2 1 
+ATOM   2879 N  N   . ALA A 1 362 ? -13.741 -2.935  27.680  1.00 23.39 ? 384  ALA A N   1 
+ATOM   2880 C  CA  . ALA A 1 362 ? -14.188 -4.316  27.745  1.00 25.10 ? 384  ALA A CA  1 
+ATOM   2881 C  C   . ALA A 1 362 ? -13.050 -5.263  27.915  1.00 23.30 ? 384  ALA A C   1 
+ATOM   2882 O  O   . ALA A 1 362 ? -13.276 -6.429  28.310  1.00 23.09 ? 384  ALA A O   1 
+ATOM   2883 C  CB  . ALA A 1 362 ? -14.922 -4.696  26.488  1.00 28.81 ? 384  ALA A CB  1 
+ATOM   2884 N  N   . ASP A 1 363 ? -11.850 -4.787  27.612  1.00 24.23 ? 385  ASP A N   1 
+ATOM   2885 C  CA  . ASP A 1 363 ? -10.625 -5.568  27.693  1.00 22.44 ? 385  ASP A CA  1 
+ATOM   2886 C  C   . ASP A 1 363 ? -9.909  -5.493  29.054  1.00 21.97 ? 385  ASP A C   1 
+ATOM   2887 O  O   . ASP A 1 363 ? -8.989  -6.266  29.302  1.00 23.04 ? 385  ASP A O   1 
+ATOM   2888 C  CB  . ASP A 1 363 ? -9.657  -5.160  26.591  1.00 23.07 ? 385  ASP A CB  1 
+ATOM   2889 C  CG  . ASP A 1 363 ? -10.203 -5.438  25.187  1.00 26.21 ? 385  ASP A CG  1 
+ATOM   2890 O  OD1 . ASP A 1 363 ? -10.913 -6.448  24.995  1.00 27.17 ? 385  ASP A OD1 1 
+ATOM   2891 O  OD2 . ASP A 1 363 ? -9.862  -4.656  24.266  1.00 30.55 ? 385  ASP A OD2 1 
+ATOM   2892 N  N   . VAL A 1 364 ? -10.386 -4.629  29.950  1.00 21.60 ? 386  VAL A N   1 
+ATOM   2893 C  CA  . VAL A 1 364 ? -9.834  -4.563  31.305  1.00 20.69 ? 386  VAL A CA  1 
+ATOM   2894 C  C   . VAL A 1 364 ? -10.054 -5.896  32.053  1.00 21.87 ? 386  VAL A C   1 
+ATOM   2895 O  O   . VAL A 1 364 ? -11.125 -6.504  31.952  1.00 24.72 ? 386  VAL A O   1 
+ATOM   2896 C  CB  . VAL A 1 364 ? -10.501 -3.427  32.080  1.00 21.10 ? 386  VAL A CB  1 
+ATOM   2897 C  CG1 . VAL A 1 364 ? -9.980  -3.370  33.542  1.00 21.35 ? 386  VAL A CG1 1 
+ATOM   2898 C  CG2 . VAL A 1 364 ? -10.140 -2.113  31.408  1.00 21.98 ? 386  VAL A CG2 1 
+ATOM   2899 N  N   . THR A 1 365 ? -9.019  -6.353  32.745  1.00 22.39 ? 387  THR A N   1 
+ATOM   2900 C  CA  . THR A 1 365 ? -9.167  -7.501  33.645  1.00 24.58 ? 387  THR A CA  1 
+ATOM   2901 C  C   . THR A 1 365 ? -8.769  -7.074  35.047  1.00 23.39 ? 387  THR A C   1 
+ATOM   2902 O  O   . THR A 1 365 ? -8.045  -6.075  35.230  1.00 23.18 ? 387  THR A O   1 
+ATOM   2903 C  CB  . THR A 1 365 ? -8.372  -8.673  33.161  1.00 27.33 ? 387  THR A CB  1 
+ATOM   2904 O  OG1 . THR A 1 365 ? -6.975  -8.371  33.118  1.00 27.48 ? 387  THR A OG1 1 
+ATOM   2905 C  CG2 . THR A 1 365 ? -8.881  -9.032  31.761  1.00 29.06 ? 387  THR A CG2 1 
+ATOM   2906 N  N   . VAL A 1 366 ? -9.313  -7.812  36.025  1.00 25.09 ? 388  VAL A N   1 
+ATOM   2907 C  CA  . VAL A 1 366 ? -9.049  -7.501  37.426  1.00 26.40 ? 388  VAL A CA  1 
+ATOM   2908 C  C   . VAL A 1 366 ? -8.546  -8.712  38.143  1.00 27.13 ? 388  VAL A C   1 
+ATOM   2909 O  O   . VAL A 1 366 ? -9.074  -9.810  37.990  1.00 27.73 ? 388  VAL A O   1 
+ATOM   2910 C  CB  . VAL A 1 366 ? -10.285 -7.040  38.132  1.00 28.22 ? 388  VAL A CB  1 
+ATOM   2911 C  CG1 . VAL A 1 366 ? -9.872  -6.539  39.526  1.00 29.02 ? 388  VAL A CG1 1 
+ATOM   2912 C  CG2 . VAL A 1 366 ? -10.991 -5.964  37.308  1.00 30.35 ? 388  VAL A CG2 1 
+ATOM   2913 N  N   . SER A 1 367 ? -7.485  -8.542  38.903  1.00 26.14 ? 389  SER A N   1 
+ATOM   2914 C  CA  . SER A 1 367 ? -7.107  -9.661  39.736  1.00 29.28 ? 389  SER A CA  1 
+ATOM   2915 C  C   . SER A 1 367 ? -7.125  -9.292  41.214  1.00 27.68 ? 389  SER A C   1 
+ATOM   2916 O  O   . SER A 1 367 ? -6.983  -8.125  41.595  1.00 26.36 ? 389  SER A O   1 
+ATOM   2917 C  CB  . SER A 1 367 ? -5.805  -10.242 39.263  1.00 35.68 ? 389  SER A CB  1 
+ATOM   2918 O  OG  . SER A 1 367 ? -4.743  -9.654  39.901  1.00 40.00 ? 389  SER A OG  1 
+ATOM   2919 N  N   . GLY A 1 368 ? -7.423  -10.293 42.038  1.00 27.19 ? 390  GLY A N   1 
+ATOM   2920 C  CA  . GLY A 1 368 ? -7.699  -10.014 43.440  1.00 29.95 ? 390  GLY A CA  1 
+ATOM   2921 C  C   . GLY A 1 368 ? -9.193  -10.068 43.712  1.00 32.84 ? 390  GLY A C   1 
+ATOM   2922 O  O   . GLY A 1 368 ? -10.016 -10.073 42.797  1.00 35.41 ? 390  GLY A O   1 
+ATOM   2923 N  N   . SER A 1 369 ? -9.594  -10.085 44.959  1.00 32.61 ? 391  SER A N   1 
+ATOM   2924 C  CA  A SER A 1 369 ? -11.016 -10.085 45.255  0.27 33.79 ? 391  SER A CA  1 
+ATOM   2925 C  CA  B SER A 1 369 ? -11.011 -10.116 45.264  0.73 34.54 ? 391  SER A CA  1 
+ATOM   2926 C  C   . SER A 1 369 ? -11.268 -9.459  46.599  1.00 33.64 ? 391  SER A C   1 
+ATOM   2927 O  O   . SER A 1 369 ? -10.399 -9.415  47.464  1.00 35.02 ? 391  SER A O   1 
+ATOM   2928 C  CB  A SER A 1 369 ? -11.615 -11.497 45.218  0.27 35.68 ? 391  SER A CB  1 
+ATOM   2929 C  CB  B SER A 1 369 ? -11.527 -11.553 45.322  0.73 39.12 ? 391  SER A CB  1 
+ATOM   2930 O  OG  A SER A 1 369 ? -13.021 -11.453 45.444  0.27 36.45 ? 391  SER A OG  1 
+ATOM   2931 O  OG  B SER A 1 369 ? -10.964 -12.207 46.428  0.73 40.73 ? 391  SER A OG  1 
+ATOM   2932 N  N   . VAL A 1 370 ? -12.478 -8.960  46.743  1.00 33.73 ? 392  VAL A N   1 
+ATOM   2933 C  CA  . VAL A 1 370 ? -12.881 -8.270  47.930  1.00 31.65 ? 392  VAL A CA  1 
+ATOM   2934 C  C   . VAL A 1 370 ? -13.940 -9.116  48.608  1.00 32.23 ? 392  VAL A C   1 
+ATOM   2935 O  O   . VAL A 1 370 ? -14.860 -9.636  47.947  1.00 35.55 ? 392  VAL A O   1 
+ATOM   2936 C  CB  . VAL A 1 370 ? -13.492 -6.933  47.560  1.00 31.56 ? 392  VAL A CB  1 
+ATOM   2937 C  CG1 . VAL A 1 370 ? -13.977 -6.206  48.790  1.00 33.74 ? 392  VAL A CG1 1 
+ATOM   2938 C  CG2 . VAL A 1 370 ? -12.469 -6.077  46.834  1.00 32.09 ? 392  VAL A CG2 1 
+ATOM   2939 N  N   . ASN A 1 371 ? -13.780 -9.262  49.912  1.00 31.24 ? 393  ASN A N   1 
+ATOM   2940 C  CA  . ASN A 1 371 ? -14.795 -9.886  50.767  1.00 31.07 ? 393  ASN A CA  1 
+ATOM   2941 C  C   . ASN A 1 371 ? -15.463 -8.845  51.640  1.00 29.76 ? 393  ASN A C   1 
+ATOM   2942 O  O   . ASN A 1 371 ? -14.893 -8.425  52.651  1.00 30.42 ? 393  ASN A O   1 
+ATOM   2943 C  CB  . ASN A 1 371 ? -14.159 -10.911 51.676  1.00 33.27 ? 393  ASN A CB  1 
+ATOM   2944 C  CG  . ASN A 1 371 ? -15.177 -11.630 52.521  1.00 35.95 ? 393  ASN A CG  1 
+ATOM   2945 O  OD1 . ASN A 1 371 ? -16.373 -11.355 52.433  1.00 34.56 ? 393  ASN A OD1 1 
+ATOM   2946 N  ND2 . ASN A 1 371 ? -14.720 -12.581 53.314  1.00 37.62 ? 393  ASN A ND2 1 
+ATOM   2947 N  N   . THR A 1 372 ? -16.631 -8.379  51.210  1.00 30.16 ? 394  THR A N   1 
+ATOM   2948 C  CA  . THR A 1 372 ? -17.279 -7.295  51.921  1.00 31.00 ? 394  THR A CA  1 
+ATOM   2949 C  C   . THR A 1 372 ? -17.853 -7.789  53.243  1.00 29.54 ? 394  THR A C   1 
+ATOM   2950 O  O   . THR A 1 372 ? -18.364 -6.993  53.987  1.00 28.72 ? 394  THR A O   1 
+ATOM   2951 C  CB  . THR A 1 372 ? -18.382 -6.601  51.071  1.00 31.26 ? 394  THR A CB  1 
+ATOM   2952 O  OG1 . THR A 1 372 ? -19.421 -7.506  50.772  1.00 33.97 ? 394  THR A OG1 1 
+ATOM   2953 C  CG2 . THR A 1 372 ? -17.858 -6.074  49.737  1.00 31.49 ? 394  THR A CG2 1 
+ATOM   2954 N  N   . ASN A 1 373 ? -17.838 -9.094  53.471  1.00 29.49 ? 395  ASN A N   1 
+ATOM   2955 C  CA  . ASN A 1 373 ? -18.353 -9.647  54.757  1.00 29.95 ? 395  ASN A CA  1 
+ATOM   2956 C  C   . ASN A 1 373 ? -17.292 -9.755  55.831  1.00 30.66 ? 395  ASN A C   1 
+ATOM   2957 O  O   . ASN A 1 373 ? -17.548 -10.275 56.928  1.00 31.43 ? 395  ASN A O   1 
+ATOM   2958 C  CB  . ASN A 1 373 ? -18.996 -11.037 54.494  1.00 31.67 ? 395  ASN A CB  1 
+ATOM   2959 C  CG  . ASN A 1 373 ? -19.465 -11.750 55.770  1.00 33.38 ? 395  ASN A CG  1 
+ATOM   2960 O  OD1 . ASN A 1 373 ? -19.003 -12.882 56.093  1.00 36.58 ? 395  ASN A OD1 1 
+ATOM   2961 N  ND2 . ASN A 1 373 ? -20.428 -11.158 56.452  1.00 35.84 ? 395  ASN A ND2 1 
+ATOM   2962 N  N   . GLN A 1 374 ? -16.117 -9.212  55.536  1.00 31.56 ? 396  GLN A N   1 
+ATOM   2963 C  CA  . GLN A 1 374 ? -15.023 -9.178  56.471  1.00 31.99 ? 396  GLN A CA  1 
+ATOM   2964 C  C   . GLN A 1 374 ? -14.242 -7.866  56.454  1.00 28.60 ? 396  GLN A C   1 
+ATOM   2965 O  O   . GLN A 1 374 ? -13.647 -7.510  55.437  1.00 29.22 ? 396  GLN A O   1 
+ATOM   2966 C  CB  . GLN A 1 374 ? -14.080 -10.322 56.194  1.00 34.43 ? 396  GLN A CB  1 
+ATOM   2967 C  CG  . GLN A 1 374 ? -12.872 -10.342 57.133  1.00 37.87 ? 396  GLN A CG  1 
+ATOM   2968 C  CD  . GLN A 1 374 ? -13.221 -10.464 58.619  1.00 41.41 ? 396  GLN A CD  1 
+ATOM   2969 O  OE1 . GLN A 1 374 ? -13.870 -11.479 59.080  1.00 41.63 ? 396  GLN A OE1 1 
+ATOM   2970 N  NE2 . GLN A 1 374 ? -12.770 -9.456  59.415  1.00 41.65 ? 396  GLN A NE2 1 
+ATOM   2971 N  N   . VAL A 1 375 ? -14.204 -7.166  57.587  1.00 28.84 ? 397  VAL A N   1 
+ATOM   2972 C  CA  . VAL A 1 375 ? -13.479 -5.887  57.637  1.00 28.45 ? 397  VAL A CA  1 
+ATOM   2973 C  C   . VAL A 1 375 ? -12.012 -6.146  57.360  1.00 30.10 ? 397  VAL A C   1 
+ATOM   2974 O  O   . VAL A 1 375 ? -11.491 -7.188  57.754  1.00 31.75 ? 397  VAL A O   1 
+ATOM   2975 C  CB  . VAL A 1 375 ? -13.593 -5.194  58.951  1.00 31.68 ? 397  VAL A CB  1 
+ATOM   2976 C  CG1 . VAL A 1 375 ? -15.049 -4.744  59.203  1.00 29.74 ? 397  VAL A CG1 1 
+ATOM   2977 C  CG2 . VAL A 1 375 ? -13.110 -6.134  60.029  1.00 33.82 ? 397  VAL A CG2 1 
+ATOM   2978 N  N   . GLY A 1 376 ? -11.372 -5.227  56.635  1.00 27.67 ? 398  GLY A N   1 
+ATOM   2979 C  CA  . GLY A 1 376 ? -9.969  -5.347  56.315  1.00 27.22 ? 398  GLY A CA  1 
+ATOM   2980 C  C   . GLY A 1 376 ? -9.634  -4.683  54.990  1.00 27.38 ? 398  GLY A C   1 
+ATOM   2981 O  O   . GLY A 1 376 ? -10.490 -4.083  54.378  1.00 27.23 ? 398  GLY A O   1 
+ATOM   2982 N  N   . ASP A 1 377 ? -8.371  -4.749  54.606  1.00 29.37 ? 399  ASP A N   1 
+ATOM   2983 C  CA  . ASP A 1 377 ? -7.936  -4.274  53.296  1.00 28.08 ? 399  ASP A CA  1 
+ATOM   2984 C  C   . ASP A 1 377 ? -7.835  -5.370  52.243  1.00 28.00 ? 399  ASP A C   1 
+ATOM   2985 O  O   . ASP A 1 377 ? -7.369  -6.496  52.501  1.00 29.43 ? 399  ASP A O   1 
+ATOM   2986 C  CB  . ASP A 1 377 ? -6.583  -3.531  53.362  1.00 30.35 ? 399  ASP A CB  1 
+ATOM   2987 C  CG  . ASP A 1 377 ? -6.641  -2.193  54.127  1.00 32.19 ? 399  ASP A CG  1 
+ATOM   2988 O  OD1 . ASP A 1 377 ? -7.747  -1.644  54.405  1.00 34.26 ? 399  ASP A OD1 1 
+ATOM   2989 O  OD2 . ASP A 1 377 ? -5.516  -1.683  54.448  1.00 32.01 ? 399  ASP A OD2 1 
+ATOM   2990 N  N   . TYR A 1 378 ? -8.223  -5.007  51.029  1.00 25.40 ? 400  TYR A N   1 
+ATOM   2991 C  CA  . TYR A 1 378 ? -8.188  -5.959  49.897  1.00 23.87 ? 400  TYR A CA  1 
+ATOM   2992 C  C   . TYR A 1 378 ? -7.531  -5.231  48.722  1.00 24.54 ? 400  TYR A C   1 
+ATOM   2993 O  O   . TYR A 1 378 ? -7.819  -4.048  48.454  1.00 27.57 ? 400  TYR A O   1 
+ATOM   2994 C  CB  . TYR A 1 378 ? -9.590  -6.425  49.532  1.00 24.20 ? 400  TYR A CB  1 
+ATOM   2995 C  CG  . TYR A 1 378 ? -10.273 -7.090  50.680  1.00 25.67 ? 400  TYR A CG  1 
+ATOM   2996 C  CD1 . TYR A 1 378 ? -10.111 -8.456  50.886  1.00 27.62 ? 400  TYR A CD1 1 
+ATOM   2997 C  CD2 . TYR A 1 378 ? -11.078 -6.368  51.566  1.00 27.99 ? 400  TYR A CD2 1 
+ATOM   2998 C  CE1 . TYR A 1 378 ? -10.682 -9.060  51.962  1.00 30.34 ? 400  TYR A CE1 1 
+ATOM   2999 C  CE2 . TYR A 1 378 ? -11.677 -7.009  52.622  1.00 28.48 ? 400  TYR A CE2 1 
+ATOM   3000 C  CZ  . TYR A 1 378 ? -11.480 -8.341  52.803  1.00 30.02 ? 400  TYR A CZ  1 
+ATOM   3001 O  OH  . TYR A 1 378 ? -12.054 -9.005  53.887  1.00 31.73 ? 400  TYR A OH  1 
+ATOM   3002 N  N   . LEU A 1 379 ? -6.604  -5.891  48.046  1.00 23.17 ? 401  LEU A N   1 
+ATOM   3003 C  CA  . LEU A 1 379 ? -5.892  -5.214  46.981  1.00 23.84 ? 401  LEU A CA  1 
+ATOM   3004 C  C   . LEU A 1 379 ? -6.335  -5.827  45.655  1.00 24.75 ? 401  LEU A C   1 
+ATOM   3005 O  O   . LEU A 1 379 ? -6.196  -7.045  45.387  1.00 28.59 ? 401  LEU A O   1 
+ATOM   3006 C  CB  . LEU A 1 379 ? -4.398  -5.358  47.155  1.00 28.70 ? 401  LEU A CB  1 
+ATOM   3007 C  CG  . LEU A 1 379 ? -3.527  -4.674  46.104  1.00 32.80 ? 401  LEU A CG  1 
+ATOM   3008 C  CD1 . LEU A 1 379 ? -3.745  -3.197  46.100  1.00 32.28 ? 401  LEU A CD1 1 
+ATOM   3009 C  CD2 . LEU A 1 379 ? -2.073  -5.001  46.306  1.00 35.48 ? 401  LEU A CD2 1 
+ATOM   3010 N  N   . LEU A 1 380 ? -6.804  -4.951  44.783  1.00 22.41 ? 402  LEU A N   1 
+ATOM   3011 C  CA  . LEU A 1 380 ? -7.071  -5.347  43.388  1.00 22.71 ? 402  LEU A CA  1 
+ATOM   3012 C  C   . LEU A 1 380 ? -6.000  -4.783  42.470  1.00 20.66 ? 402  LEU A C   1 
+ATOM   3013 O  O   . LEU A 1 380 ? -5.448  -3.712  42.735  1.00 21.85 ? 402  LEU A O   1 
+ATOM   3014 C  CB  . LEU A 1 380 ? -8.411  -4.829  42.962  1.00 24.53 ? 402  LEU A CB  1 
+ATOM   3015 C  CG  . LEU A 1 380 ? -9.587  -5.245  43.824  1.00 26.80 ? 402  LEU A CG  1 
+ATOM   3016 C  CD1 . LEU A 1 380 ? -10.850 -4.585  43.294  1.00 28.27 ? 402  LEU A CD1 1 
+ATOM   3017 C  CD2 . LEU A 1 380 ? -9.747  -6.707  43.917  1.00 27.25 ? 402  LEU A CD2 1 
+ATOM   3018 N  N   . THR A 1 381 ? -5.777  -5.485  41.366  1.00 21.56 ? 403  THR A N   1 
+ATOM   3019 C  CA  . THR A 1 381 ? -4.932  -4.960  40.291  1.00 21.98 ? 403  THR A CA  1 
+ATOM   3020 C  C   . THR A 1 381 ? -5.693  -5.005  38.995  1.00 21.36 ? 403  THR A C   1 
+ATOM   3021 O  O   . THR A 1 381 ? -6.148  -6.031  38.587  1.00 23.29 ? 403  THR A O   1 
+ATOM   3022 C  CB  . THR A 1 381 ? -3.593  -5.663  40.169  1.00 26.28 ? 403  THR A CB  1 
+ATOM   3023 O  OG1 . THR A 1 381 ? -2.935  -5.555  41.430  1.00 28.69 ? 403  THR A OG1 1 
+ATOM   3024 C  CG2 . THR A 1 381 ? -2.676  -5.013  39.059  1.00 28.84 ? 403  THR A CG2 1 
+ATOM   3025 N  N   . TYR A 1 382 ? -5.811  -3.829  38.366  1.00 19.46 ? 404  TYR A N   1 
+ATOM   3026 C  CA  . TYR A 1 382 ? -6.476  -3.720  37.062  1.00 20.25 ? 404  TYR A CA  1 
+ATOM   3027 C  C   . TYR A 1 382 ? -5.420  -3.734  36.000  1.00 21.49 ? 404  TYR A C   1 
+ATOM   3028 O  O   . TYR A 1 382 ? -4.377  -3.086  36.157  1.00 22.94 ? 404  TYR A O   1 
+ATOM   3029 C  CB  . TYR A 1 382 ? -7.215  -2.403  36.974  1.00 21.24 ? 404  TYR A CB  1 
+ATOM   3030 C  CG  . TYR A 1 382 ? -8.411  -2.330  37.902  1.00 19.24 ? 404  TYR A CG  1 
+ATOM   3031 C  CD1 . TYR A 1 382 ? -9.682  -2.629  37.454  1.00 19.54 ? 404  TYR A CD1 1 
+ATOM   3032 C  CD2 . TYR A 1 382 ? -8.249  -2.066  39.229  1.00 20.54 ? 404  TYR A CD2 1 
+ATOM   3033 C  CE1 . TYR A 1 382 ? -10.763 -2.593  38.295  1.00 20.21 ? 404  TYR A CE1 1 
+ATOM   3034 C  CE2 . TYR A 1 382 ? -9.307  -2.038  40.104  1.00 21.36 ? 404  TYR A CE2 1 
+ATOM   3035 C  CZ  . TYR A 1 382 ? -10.573 -2.292  39.650  1.00 21.22 ? 404  TYR A CZ  1 
+ATOM   3036 O  OH  . TYR A 1 382 ? -11.667 -2.265  40.444  1.00 22.06 ? 404  TYR A OH  1 
+ATOM   3037 N  N   . SER A 1 383 ? -5.697  -4.418  34.893  1.00 20.84 ? 405  SER A N   1 
+ATOM   3038 C  CA  A SER A 1 383 ? -4.766  -4.458  33.753  0.55 21.89 ? 405  SER A CA  1 
+ATOM   3039 C  CA  B SER A 1 383 ? -4.775  -4.458  33.750  0.45 20.87 ? 405  SER A CA  1 
+ATOM   3040 C  C   . SER A 1 383 ? -5.504  -4.314  32.427  1.00 21.50 ? 405  SER A C   1 
+ATOM   3041 O  O   . SER A 1 383 ? -6.642  -4.797  32.278  1.00 22.67 ? 405  SER A O   1 
+ATOM   3042 C  CB  A SER A 1 383 ? -3.973  -5.772  33.749  0.55 24.86 ? 405  SER A CB  1 
+ATOM   3043 C  CB  B SER A 1 383 ? -4.039  -5.789  33.739  0.45 21.40 ? 405  SER A CB  1 
+ATOM   3044 O  OG  A SER A 1 383 ? -3.407  -6.068  35.035  0.55 28.25 ? 405  SER A OG  1 
+ATOM   3045 O  OG  B SER A 1 383 ? -3.038  -5.819  32.746  0.45 22.13 ? 405  SER A OG  1 
+ATOM   3046 N  N   . VAL A 1 384 ? -4.822  -3.714  31.458  1.00 20.95 ? 406  VAL A N   1 
+ATOM   3047 C  CA  . VAL A 1 384 ? -5.342  -3.721  30.108  1.00 22.47 ? 406  VAL A CA  1 
+ATOM   3048 C  C   . VAL A 1 384 ? -4.144  -3.745  29.146  1.00 19.82 ? 406  VAL A C   1 
+ATOM   3049 O  O   . VAL A 1 384 ? -3.127  -3.097  29.357  1.00 18.91 ? 406  VAL A O   1 
+ATOM   3050 C  CB  . VAL A 1 384 ? -6.291  -2.535  29.853  1.00 20.87 ? 406  VAL A CB  1 
+ATOM   3051 C  CG1 . VAL A 1 384 ? -5.552  -1.205  29.777  1.00 21.78 ? 406  VAL A CG1 1 
+ATOM   3052 C  CG2 . VAL A 1 384 ? -7.151  -2.780  28.586  1.00 22.55 ? 406  VAL A CG2 1 
+ATOM   3053 N  N   . SER A 1 385 ? -4.323  -4.484  28.041  1.00 23.93 ? 407  SER A N   1 
+ATOM   3054 C  CA  . SER A 1 385 ? -3.306  -4.615  27.049  1.00 23.66 ? 407  SER A CA  1 
+ATOM   3055 C  C   . SER A 1 385 ? -3.852  -4.211  25.663  1.00 22.94 ? 407  SER A C   1 
+ATOM   3056 O  O   . SER A 1 385 ? -4.986  -4.506  25.341  1.00 25.10 ? 407  SER A O   1 
+ATOM   3057 C  CB  . SER A 1 385 ? -2.834  -6.060  26.987  1.00 25.05 ? 407  SER A CB  1 
+ATOM   3058 O  OG  . SER A 1 385 ? -2.253  -6.488  28.179  1.00 27.78 ? 407  SER A OG  1 
+ATOM   3059 N  N   . SER A 1 386 ? -3.012  -3.518  24.909  1.00 24.44 ? 408  SER A N   1 
+ATOM   3060 C  CA  . SER A 1 386 ? -3.305  -3.138  23.538  1.00 24.79 ? 408  SER A CA  1 
+ATOM   3061 C  C   . SER A 1 386 ? -1.982  -2.812  22.864  1.00 24.59 ? 408  SER A C   1 
+ATOM   3062 O  O   . SER A 1 386 ? -1.058  -2.312  23.506  1.00 23.05 ? 408  SER A O   1 
+ATOM   3063 C  CB  . SER A 1 386 ? -4.235  -1.908  23.494  1.00 27.28 ? 408  SER A CB  1 
+ATOM   3064 O  OG  . SER A 1 386 ? -4.567  -1.574  22.178  1.00 31.36 ? 408  SER A OG  1 
+ATOM   3065 N  N   . ASP A 1 387 ? -1.890  -3.087  21.562  1.00 25.47 ? 409  ASP A N   1 
+ATOM   3066 C  CA  . ASP A 1 387 ? -0.742  -2.627  20.782  1.00 25.20 ? 409  ASP A CA  1 
+ATOM   3067 C  C   . ASP A 1 387 ? 0.612   -3.139  21.348  1.00 28.29 ? 409  ASP A C   1 
+ATOM   3068 O  O   . ASP A 1 387 ? 1.623   -2.443  21.288  1.00 28.83 ? 409  ASP A O   1 
+ATOM   3069 C  CB  . ASP A 1 387 ? -0.746  -1.093  20.689  1.00 26.24 ? 409  ASP A CB  1 
+ATOM   3070 C  CG  . ASP A 1 387 ? -1.984  -0.579  20.044  1.00 27.44 ? 409  ASP A CG  1 
+ATOM   3071 O  OD1 . ASP A 1 387 ? -2.102  -0.812  18.816  1.00 31.26 ? 409  ASP A OD1 1 
+ATOM   3072 O  OD2 . ASP A 1 387 ? -2.832  -0.010  20.751  1.00 27.77 ? 409  ASP A OD2 1 
+ATOM   3073 N  N   . ASP A 1 388 ? 0.590   -4.356  21.890  1.00 29.19 ? 410  ASP A N   1 
+ATOM   3074 C  CA  A ASP A 1 388 ? 1.769   -5.014  22.424  0.65 31.58 ? 410  ASP A CA  1 
+ATOM   3075 C  CA  B ASP A 1 388 ? 1.780   -5.018  22.427  0.35 31.35 ? 410  ASP A CA  1 
+ATOM   3076 C  C   . ASP A 1 388 ? 2.334   -4.309  23.660  1.00 30.82 ? 410  ASP A C   1 
+ATOM   3077 O  O   . ASP A 1 388 ? 3.510   -4.482  24.005  1.00 32.56 ? 410  ASP A O   1 
+ATOM   3078 C  CB  A ASP A 1 388 ? 2.835   -5.192  21.322  0.65 37.94 ? 410  ASP A CB  1 
+ATOM   3079 C  CB  B ASP A 1 388 ? 2.878   -5.188  21.351  0.35 35.72 ? 410  ASP A CB  1 
+ATOM   3080 C  CG  A ASP A 1 388 ? 2.439   -6.221  20.270  0.65 43.29 ? 410  ASP A CG  1 
+ATOM   3081 C  CG  B ASP A 1 388 ? 3.913   -6.247  21.736  0.35 39.38 ? 410  ASP A CG  1 
+ATOM   3082 O  OD1 A ASP A 1 388 ? 1.381   -6.896  20.373  0.65 44.29 ? 410  ASP A OD1 1 
+ATOM   3083 O  OD1 B ASP A 1 388 ? 3.527   -7.214  22.431  0.35 40.95 ? 410  ASP A OD1 1 
+ATOM   3084 O  OD2 A ASP A 1 388 ? 3.228   -6.364  19.337  0.65 46.57 ? 410  ASP A OD2 1 
+ATOM   3085 O  OD2 B ASP A 1 388 ? 5.099   -6.117  21.358  0.35 41.03 ? 410  ASP A OD2 1 
+ATOM   3086 N  N   . GLU A 1 389 ? 1.475   -3.537  24.318  1.00 26.51 ? 411  GLU A N   1 
+ATOM   3087 C  CA  . GLU A 1 389 ? 1.816   -2.888  25.579  1.00 24.54 ? 411  GLU A CA  1 
+ATOM   3088 C  C   . GLU A 1 389 ? 0.746   -3.228  26.619  1.00 26.32 ? 411  GLU A C   1 
+ATOM   3089 O  O   . GLU A 1 389 ? -0.391  -3.614  26.283  1.00 27.19 ? 411  GLU A O   1 
+ATOM   3090 C  CB  . GLU A 1 389 ? 1.894   -1.366  25.384  1.00 26.74 ? 411  GLU A CB  1 
+ATOM   3091 C  CG  . GLU A 1 389 ? 2.863   -0.952  24.311  1.00 28.74 ? 411  GLU A CG  1 
+ATOM   3092 C  CD  . GLU A 1 389 ? 4.307   -1.061  24.715  1.00 31.26 ? 411  GLU A CD  1 
+ATOM   3093 O  OE1 . GLU A 1 389 ? 4.659   -1.408  25.853  1.00 32.63 ? 411  GLU A OE1 1 
+ATOM   3094 O  OE2 . GLU A 1 389 ? 5.130   -0.742  23.858  1.00 33.82 ? 411  GLU A OE2 1 
+ATOM   3095 N  N   . THR A 1 390 ? 1.127   -3.082  27.888  1.00 27.04 ? 412  THR A N   1 
+ATOM   3096 C  CA  . THR A 1 390 ? 0.211   -3.305  29.004  1.00 24.58 ? 412  THR A CA  1 
+ATOM   3097 C  C   . THR A 1 390 ? 0.307   -2.195  30.047  1.00 23.36 ? 412  THR A C   1 
+ATOM   3098 O  O   . THR A 1 390 ? 1.393   -1.701  30.311  1.00 25.86 ? 412  THR A O   1 
+ATOM   3099 C  CB  . THR A 1 390 ? 0.521   -4.648  29.708  1.00 27.57 ? 412  THR A CB  1 
+ATOM   3100 O  OG1 . THR A 1 390 ? 0.437   -5.708  28.743  1.00 27.91 ? 412  THR A OG1 1 
+ATOM   3101 C  CG2 . THR A 1 390 ? -0.452  -4.920  30.855  1.00 27.25 ? 412  THR A CG2 1 
+ATOM   3102 N  N   . THR A 1 391 ? -0.831  -1.814  30.631  1.00 20.80 ? 413  THR A N   1 
+ATOM   3103 C  CA  . THR A 1 391 ? -0.838  -0.856  31.725  1.00 20.17 ? 413  THR A CA  1 
+ATOM   3104 C  C   . THR A 1 391 ? -1.555  -1.534  32.870  1.00 21.55 ? 413  THR A C   1 
+ATOM   3105 O  O   . THR A 1 391 ? -2.574  -2.151  32.664  1.00 21.98 ? 413  THR A O   1 
+ATOM   3106 C  CB  . THR A 1 391 ? -1.491  0.443   31.326  1.00 22.54 ? 413  THR A CB  1 
+ATOM   3107 O  OG1 . THR A 1 391 ? -0.701  0.977   30.254  1.00 26.39 ? 413  THR A OG1 1 
+ATOM   3108 C  CG2 . THR A 1 391 ? -1.431  1.426   32.490  1.00 24.02 ? 413  THR A CG2 1 
+ATOM   3109 N  N   . ASN A 1 392 ? -1.028  -1.370  34.080  1.00 21.11 ? 414  ASN A N   1 
+ATOM   3110 C  CA  A ASN A 1 392 ? -1.639  -1.932  35.282  0.53 22.38 ? 414  ASN A CA  1 
+ATOM   3111 C  CA  B ASN A 1 392 ? -1.615  -1.920  35.271  0.47 23.16 ? 414  ASN A CA  1 
+ATOM   3112 C  C   . ASN A 1 392 ? -1.718  -0.835  36.350  1.00 22.53 ? 414  ASN A C   1 
+ATOM   3113 O  O   . ASN A 1 392 ? -0.918  0.140   36.333  1.00 24.10 ? 414  ASN A O   1 
+ATOM   3114 C  CB  A ASN A 1 392 ? -0.838  -3.092  35.921  0.53 24.71 ? 414  ASN A CB  1 
+ATOM   3115 C  CB  B ASN A 1 392 ? -0.696  -3.031  35.734  0.47 26.74 ? 414  ASN A CB  1 
+ATOM   3116 C  CG  A ASN A 1 392 ? -0.367  -4.179  34.954  0.53 26.39 ? 414  ASN A CG  1 
+ATOM   3117 C  CG  B ASN A 1 392 ? 0.664   -2.502  36.188  0.47 30.74 ? 414  ASN A CG  1 
+ATOM   3118 O  OD1 A ASN A 1 392 ? -1.138  -4.958  34.398  0.53 25.96 ? 414  ASN A OD1 1 
+ATOM   3119 O  OD1 B ASN A 1 392 ? 0.744   -1.765  37.165  0.47 34.33 ? 414  ASN A OD1 1 
+ATOM   3120 N  ND2 A ASN A 1 392 ? 0.932   -4.260  34.801  0.53 27.86 ? 414  ASN A ND2 1 
+ATOM   3121 N  ND2 B ASN A 1 392 ? 1.744   -2.906  35.490  0.47 33.58 ? 414  ASN A ND2 1 
+ATOM   3122 N  N   . GLN A 1 393 ? -2.702  -0.952  37.247  1.00 21.20 ? 415  GLN A N   1 
+ATOM   3123 C  CA  . GLN A 1 393 ? -2.841  -0.018  38.312  1.00 20.66 ? 415  GLN A CA  1 
+ATOM   3124 C  C   . GLN A 1 393 ? -3.497  -0.715  39.485  1.00 19.28 ? 415  GLN A C   1 
+ATOM   3125 O  O   . GLN A 1 393 ? -4.484  -1.457  39.318  1.00 21.38 ? 415  GLN A O   1 
+ATOM   3126 C  CB  . GLN A 1 393 ? -3.700  1.168   37.898  1.00 20.37 ? 415  GLN A CB  1 
+ATOM   3127 C  CG  . GLN A 1 393 ? -3.820  2.229   38.976  1.00 21.14 ? 415  GLN A CG  1 
+ATOM   3128 C  CD  . GLN A 1 393 ? -4.602  3.485   38.531  1.00 22.54 ? 415  GLN A CD  1 
+ATOM   3129 O  OE1 . GLN A 1 393 ? -4.853  3.684   37.339  1.00 23.53 ? 415  GLN A OE1 1 
+ATOM   3130 N  NE2 . GLN A 1 393 ? -4.961  4.346   39.496  1.00 23.69 ? 415  GLN A NE2 1 
+ATOM   3131 N  N   . PRO A 1 394 ? -2.964  -0.496  40.701  1.00 22.52 ? 416  PRO A N   1 
+ATOM   3132 C  CA  . PRO A 1 394 ? -3.598  -1.110  41.866  1.00 22.69 ? 416  PRO A CA  1 
+ATOM   3133 C  C   . PRO A 1 394 ? -4.799  -0.312  42.391  1.00 18.82 ? 416  PRO A C   1 
+ATOM   3134 O  O   . PRO A 1 394 ? -4.937  0.891   42.105  1.00 19.30 ? 416  PRO A O   1 
+ATOM   3135 C  CB  . PRO A 1 394 ? -2.474  -1.013  42.907  1.00 27.45 ? 416  PRO A CB  1 
+ATOM   3136 C  CG  . PRO A 1 394 ? -1.868  0.331   42.637  1.00 26.61 ? 416  PRO A CG  1 
+ATOM   3137 C  CD  . PRO A 1 394 ? -1.852  0.400   41.094  1.00 24.97 ? 416  PRO A CD  1 
+ATOM   3138 N  N   . ARG A 1 395 ? -5.603  -0.936  43.226  1.00 18.44 ? 417  ARG A N   1 
+ATOM   3139 C  CA  . ARG A 1 395 ? -6.701  -0.249  43.902  1.00 18.55 ? 417  ARG A CA  1 
+ATOM   3140 C  C   . ARG A 1 395 ? -6.900  -0.943  45.250  1.00 18.04 ? 417  ARG A C   1 
+ATOM   3141 O  O   . ARG A 1 395 ? -7.230  -2.134  45.273  1.00 20.47 ? 417  ARG A O   1 
+ATOM   3142 C  CB  . ARG A 1 395 ? -7.981  -0.417  43.088  1.00 18.52 ? 417  ARG A CB  1 
+ATOM   3143 C  CG  . ARG A 1 395 ? -9.141  0.451   43.550  1.00 18.95 ? 417  ARG A CG  1 
+ATOM   3144 C  CD  . ARG A 1 395 ? -10.414 0.147   42.791  1.00 18.61 ? 417  ARG A CD  1 
+ATOM   3145 N  NE  . ARG A 1 395 ? -11.550 0.942   43.263  1.00 18.92 ? 417  ARG A NE  1 
+ATOM   3146 C  CZ  . ARG A 1 395 ? -12.792 0.787   42.828  1.00 18.76 ? 417  ARG A CZ  1 
+ATOM   3147 N  NH1 . ARG A 1 395 ? -13.078 -0.190  41.937  1.00 19.61 ? 417  ARG A NH1 1 
+ATOM   3148 N  NH2 . ARG A 1 395 ? -13.761 1.541   43.347  1.00 21.18 ? 417  ARG A NH2 1 
+ATOM   3149 N  N   . LYS A 1 396 ? -6.763  -0.222  46.341  1.00 18.81 ? 418  LYS A N   1 
+ATOM   3150 C  CA  . LYS A 1 396 ? -7.056  -0.770  47.651  1.00 19.29 ? 418  LYS A CA  1 
+ATOM   3151 C  C   . LYS A 1 396 ? -8.529  -0.617  47.954  1.00 20.37 ? 418  LYS A C   1 
+ATOM   3152 O  O   . LYS A 1 396 ? -9.087  0.478   47.763  1.00 19.76 ? 418  LYS A O   1 
+ATOM   3153 C  CB  . LYS A 1 396 ? -6.231  -0.008  48.690  1.00 20.33 ? 418  LYS A CB  1 
+ATOM   3154 C  CG  . LYS A 1 396 ? -6.569  -0.481  50.121  1.00 23.54 ? 418  LYS A CG  1 
+ATOM   3155 C  CD  . LYS A 1 396 ? -5.663  0.252   51.098  1.00 27.66 ? 418  LYS A CD  1 
+ATOM   3156 C  CE  . LYS A 1 396 ? -6.007  1.749   51.178  1.00 32.30 ? 418  LYS A CE  1 
+ATOM   3157 N  NZ  . LYS A 1 396 ? -5.331  2.567   52.296  1.00 34.35 ? 418  LYS A NZ  1 
+ATOM   3158 N  N   . ILE A 1 397 ? -9.158  -1.684  48.424  1.00 21.61 ? 419  ILE A N   1 
+ATOM   3159 C  CA  . ILE A 1 397 ? -10.531 -1.628  48.856  1.00 20.85 ? 419  ILE A CA  1 
+ATOM   3160 C  C   . ILE A 1 397 ? -10.523 -1.937  50.369  1.00 19.87 ? 419  ILE A C   1 
+ATOM   3161 O  O   . ILE A 1 397 ? -10.096 -3.007  50.798  1.00 22.10 ? 419  ILE A O   1 
+ATOM   3162 C  CB  . ILE A 1 397 ? -11.426 -2.653  48.132  1.00 23.72 ? 419  ILE A CB  1 
+ATOM   3163 C  CG1 . ILE A 1 397 ? -11.294 -2.563  46.597  1.00 22.39 ? 419  ILE A CG1 1 
+ATOM   3164 C  CG2 . ILE A 1 397 ? -12.838 -2.432  48.560  1.00 24.21 ? 419  ILE A CG2 1 
+ATOM   3165 C  CD1 . ILE A 1 397 ? -11.764 -1.187  46.036  1.00 21.55 ? 419  ILE A CD1 1 
+ATOM   3166 N  N   . THR A 1 398 ? -10.990 -0.979  51.181  1.00 19.57 ? 420  THR A N   1 
+ATOM   3167 C  CA  . THR A 1 398 ? -11.039 -1.145  52.640  1.00 20.98 ? 420  THR A CA  1 
+ATOM   3168 C  C   . THR A 1 398 ? -12.463 -1.356  53.053  1.00 22.92 ? 420  THR A C   1 
+ATOM   3169 O  O   . THR A 1 398 ? -13.303 -0.465  52.877  1.00 21.83 ? 420  THR A O   1 
+ATOM   3170 C  CB  . THR A 1 398 ? -10.485 0.082   53.360  1.00 23.26 ? 420  THR A CB  1 
+ATOM   3171 O  OG1 . THR A 1 398 ? -9.136  0.296   52.886  1.00 25.83 ? 420  THR A OG1 1 
+ATOM   3172 C  CG2 . THR A 1 398 ? -10.585 -0.125  54.877  1.00 25.61 ? 420  THR A CG2 1 
+ATOM   3173 N  N   . VAL A 1 399 ? -12.719 -2.519  53.664  1.00 23.04 ? 421  VAL A N   1 
+ATOM   3174 C  CA  . VAL A 1 399 ? -14.001 -2.777  54.283  1.00 22.69 ? 421  VAL A CA  1 
+ATOM   3175 C  C   . VAL A 1 399 ? -13.997 -2.382  55.751  1.00 22.95 ? 421  VAL A C   1 
+ATOM   3176 O  O   . VAL A 1 399 ? -13.100 -2.755  56.522  1.00 25.62 ? 421  VAL A O   1 
+ATOM   3177 C  CB  . VAL A 1 399 ? -14.377 -4.265  54.114  1.00 22.80 ? 421  VAL A CB  1 
+ATOM   3178 C  CG1 . VAL A 1 399 ? -15.753 -4.610  54.804  1.00 25.73 ? 421  VAL A CG1 1 
+ATOM   3179 C  CG2 . VAL A 1 399 ? -14.413 -4.620  52.609  1.00 24.98 ? 421  VAL A CG2 1 
+ATOM   3180 N  N   . TYR A 1 400 ? -14.955 -1.535  56.115  1.00 22.71 ? 422  TYR A N   1 
+ATOM   3181 C  CA  . TYR A 1 400 ? -15.016 -0.999  57.487  1.00 22.14 ? 422  TYR A CA  1 
+ATOM   3182 C  C   . TYR A 1 400 ? -16.375 -1.174  58.085  1.00 23.61 ? 422  TYR A C   1 
+ATOM   3183 O  O   . TYR A 1 400 ? -17.370 -1.361  57.398  1.00 24.93 ? 422  TYR A O   1 
+ATOM   3184 C  CB  . TYR A 1 400 ? -14.660 0.532   57.473  1.00 21.78 ? 422  TYR A CB  1 
+ATOM   3185 C  CG  . TYR A 1 400 ? -15.696 1.371   56.733  1.00 22.78 ? 422  TYR A CG  1 
+ATOM   3186 C  CD1 . TYR A 1 400 ? -16.724 2.006   57.425  1.00 20.80 ? 422  TYR A CD1 1 
+ATOM   3187 C  CD2 . TYR A 1 400 ? -15.598 1.608   55.344  1.00 22.00 ? 422  TYR A CD2 1 
+ATOM   3188 C  CE1 . TYR A 1 400 ? -17.703 2.719   56.793  1.00 21.42 ? 422  TYR A CE1 1 
+ATOM   3189 C  CE2 . TYR A 1 400 ? -16.557 2.381   54.693  1.00 21.34 ? 422  TYR A CE2 1 
+ATOM   3190 C  CZ  . TYR A 1 400 ? -17.629 2.909   55.398  1.00 21.62 ? 422  TYR A CZ  1 
+ATOM   3191 O  OH  . TYR A 1 400 ? -18.585 3.685   54.766  1.00 22.88 ? 422  TYR A OH  1 
+ATOM   3192 N  N   . GLU A 1 401 ? -16.419 -1.110  59.424  1.00 25.26 ? 423  GLU A N   1 
+ATOM   3193 C  CA  . GLU A 1 401 ? -17.677 -1.148  60.126  1.00 26.12 ? 423  GLU A CA  1 
+ATOM   3194 C  C   . GLU A 1 401 ? -17.858 0.037   61.014  1.00 25.59 ? 423  GLU A C   1 
+ATOM   3195 O  O   . GLU A 1 401 ? -16.905 0.552   61.599  1.00 27.16 ? 423  GLU A O   1 
+ATOM   3196 C  CB  . GLU A 1 401 ? -17.749 -2.431  60.933  1.00 31.99 ? 423  GLU A CB  1 
+ATOM   3197 C  CG  . GLU A 1 401 ? -19.057 -2.583  61.675  1.00 38.73 ? 423  GLU A CG  1 
+ATOM   3198 C  CD  . GLU A 1 401 ? -19.276 -3.948  62.259  1.00 47.20 ? 423  GLU A CD  1 
+ATOM   3199 O  OE1 . GLU A 1 401 ? -20.455 -4.435  62.117  1.00 53.91 ? 423  GLU A OE1 1 
+ATOM   3200 O  OE2 . GLU A 1 401 ? -18.300 -4.486  62.884  1.00 47.05 ? 423  GLU A OE2 1 
+ATOM   3201 N  N   . ILE A 1 402 ? -19.109 0.428   61.162  1.00 23.88 ? 424  ILE A N   1 
+ATOM   3202 C  CA  . ILE A 1 402 ? -19.484 1.546   62.041  1.00 24.70 ? 424  ILE A CA  1 
+ATOM   3203 C  C   . ILE A 1 402 ? -20.234 1.073   63.279  1.00 24.53 ? 424  ILE A C   1 
+ATOM   3204 O  O   . ILE A 1 402 ? -21.090 0.172   63.187  1.00 23.98 ? 424  ILE A O   1 
+ATOM   3205 C  CB  . ILE A 1 402 ? -20.374 2.496   61.231  1.00 24.81 ? 424  ILE A CB  1 
+ATOM   3206 C  CG1 . ILE A 1 402 ? -19.592 3.026   60.017  1.00 24.41 ? 424  ILE A CG1 1 
+ATOM   3207 C  CG2 . ILE A 1 402 ? -20.934 3.568   62.120  1.00 27.76 ? 424  ILE A CG2 1 
+ATOM   3208 C  CD1 . ILE A 1 402 ? -18.527 3.924   60.373  1.00 21.44 ? 424  ILE A CD1 1 
+ATOM   3209 N  N   . LEU A 1 403 ? -19.907 1.649   64.444  1.00 24.09 ? 425  LEU A N   1 
+ATOM   3210 C  CA  . LEU A 1 403 ? -20.586 1.211   65.690  1.00 23.92 ? 425  LEU A CA  1 
+ATOM   3211 C  C   . LEU A 1 403 ? -21.977 1.800   65.686  1.00 21.88 ? 425  LEU A C   1 
+ATOM   3212 O  O   . LEU A 1 403 ? -22.157 2.979   65.334  1.00 22.02 ? 425  LEU A O   1 
+ATOM   3213 C  CB  . LEU A 1 403 ? -19.756 1.752   66.882  1.00 25.50 ? 425  LEU A CB  1 
+ATOM   3214 C  CG  . LEU A 1 403 ? -20.113 1.273   68.296  1.00 27.70 ? 425  LEU A CG  1 
+ATOM   3215 C  CD1 . LEU A 1 403 ? -19.673 -0.168  68.429  1.00 28.00 ? 425  LEU A CD1 1 
+ATOM   3216 C  CD2 . LEU A 1 403 ? -19.458 2.165   69.322  1.00 29.22 ? 425  LEU A CD2 1 
+ATOM   3217 N  N   . PRO A 1 404 ? -22.987 1.027   66.131  1.00 22.35 ? 426  PRO A N   1 
+ATOM   3218 C  CA  . PRO A 1 404 ? -24.291 1.596   66.367  1.00 21.97 ? 426  PRO A CA  1 
+ATOM   3219 C  C   . PRO A 1 404 ? -24.254 2.692   67.447  1.00 23.45 ? 426  PRO A C   1 
+ATOM   3220 O  O   . PRO A 1 404 ? -23.225 2.851   68.147  1.00 22.81 ? 426  PRO A O   1 
+ATOM   3221 C  CB  . PRO A 1 404 ? -25.072 0.424   66.963  1.00 22.85 ? 426  PRO A CB  1 
+ATOM   3222 C  CG  . PRO A 1 404 ? -24.428 -0.798  66.436  1.00 22.33 ? 426  PRO A CG  1 
+ATOM   3223 C  CD  . PRO A 1 404 ? -22.942 -0.391  66.465  1.00 21.88 ? 426  PRO A CD  1 
+ATOM   3224 N  N   . ALA A 1 405 ? -25.384 3.370   67.629  1.00 23.07 ? 427  ALA A N   1 
+ATOM   3225 C  CA  . ALA A 1 405 ? -25.500 4.386   68.650  1.00 24.36 ? 427  ALA A CA  1 
+ATOM   3226 C  C   . ALA A 1 405 ? -26.778 4.312   69.416  1.00 23.16 ? 427  ALA A C   1 
+ATOM   3227 O  O   . ALA A 1 405 ? -27.875 4.072   68.817  1.00 26.18 ? 427  ALA A O   1 
+ATOM   3228 C  CB  . ALA A 1 405 ? -25.457 5.693   67.987  1.00 27.06 ? 427  ALA A CB  1 
+ATOM   3229 N  N   . PHE A 1 406 ? -26.654 4.500   70.734  1.00 23.75 ? 428  PHE A N   1 
+ATOM   3230 C  CA  . PHE A 1 406 ? -27.804 4.555   71.610  1.00 23.48 ? 428  PHE A CA  1 
+ATOM   3231 C  C   . PHE A 1 406 ? -28.330 5.962   71.676  1.00 25.50 ? 428  PHE A C   1 
+ATOM   3232 O  O   . PHE A 1 406 ? -27.559 6.940   71.533  1.00 26.45 ? 428  PHE A O   1 
+ATOM   3233 C  CB  . PHE A 1 406 ? -27.409 4.216   73.046  1.00 24.39 ? 428  PHE A CB  1 
+ATOM   3234 C  CG  . PHE A 1 406 ? -27.142 2.778   73.340  1.00 23.81 ? 428  PHE A CG  1 
+ATOM   3235 C  CD1 . PHE A 1 406 ? -28.174 1.854   73.373  1.00 24.84 ? 428  PHE A CD1 1 
+ATOM   3236 C  CD2 . PHE A 1 406 ? -25.878 2.368   73.729  1.00 24.29 ? 428  PHE A CD2 1 
+ATOM   3237 C  CE1 . PHE A 1 406 ? -27.928 0.537   73.815  1.00 24.15 ? 428  PHE A CE1 1 
+ATOM   3238 C  CE2 . PHE A 1 406 ? -25.626 1.031   74.126  1.00 23.98 ? 428  PHE A CE2 1 
+ATOM   3239 C  CZ  . PHE A 1 406 ? -26.642 0.153   74.184  1.00 23.34 ? 428  PHE A CZ  1 
+ATOM   3240 N  N   . THR A 1 407 ? -29.624 6.106   71.883  1.00 25.47 ? 429  THR A N   1 
+ATOM   3241 C  CA  . THR A 1 407 ? -30.168 7.395   72.308  1.00 27.72 ? 429  THR A CA  1 
+ATOM   3242 C  C   . THR A 1 407 ? -31.086 7.169   73.494  1.00 26.41 ? 429  THR A C   1 
+ATOM   3243 O  O   . THR A 1 407 ? -31.705 6.099   73.644  1.00 26.11 ? 429  THR A O   1 
+ATOM   3244 C  CB  . THR A 1 407 ? -31.025 8.070   71.244  1.00 32.58 ? 429  THR A CB  1 
+ATOM   3245 O  OG1 . THR A 1 407 ? -31.971 7.129   70.755  1.00 37.96 ? 429  THR A OG1 1 
+ATOM   3246 C  CG2 . THR A 1 407 ? -30.194 8.503   70.059  1.00 30.33 ? 429  THR A CG2 1 
+ATOM   3247 N  N   . GLY A 1 408 ? -31.190 8.197   74.310  1.00 27.12 ? 430  GLY A N   1 
+ATOM   3248 C  CA  . GLY A 1 408 ? -32.155 8.167   75.392  1.00 28.48 ? 430  GLY A CA  1 
+ATOM   3249 C  C   . GLY A 1 408 ? -31.640 7.533   76.681  1.00 28.92 ? 430  GLY A C   1 
+ATOM   3250 O  O   . GLY A 1 408 ? -32.423 7.358   77.635  1.00 31.84 ? 430  GLY A O   1 
+ATOM   3251 N  N   . ILE A 1 409 ? -30.355 7.198   76.752  1.00 26.98 ? 431  ILE A N   1 
+ATOM   3252 C  CA  . ILE A 1 409 ? -29.788 6.574   77.981  1.00 29.12 ? 431  ILE A CA  1 
+ATOM   3253 C  C   . ILE A 1 409 ? -29.061 7.676   78.769  1.00 33.78 ? 431  ILE A C   1 
+ATOM   3254 O  O   . ILE A 1 409 ? -27.811 7.817   78.759  1.00 38.47 ? 431  ILE A O   1 
+ATOM   3255 C  CB  . ILE A 1 409 ? -28.820 5.454   77.632  1.00 30.84 ? 431  ILE A CB  1 
+ATOM   3256 C  CG1 . ILE A 1 409 ? -29.574 4.338   76.937  1.00 35.38 ? 431  ILE A CG1 1 
+ATOM   3257 C  CG2 . ILE A 1 409 ? -28.157 4.901   78.888  1.00 33.02 ? 431  ILE A CG2 1 
+ATOM   3258 C  CD1 . ILE A 1 409 ? -28.696 3.244   76.483  1.00 38.81 ? 431  ILE A CD1 1 
+ATOM   3259 N  N   . THR A 1 410 ? -29.816 8.527   79.392  1.00 29.83 ? 432  THR A N   1 
+ATOM   3260 C  CA  . THR A 1 410 ? -29.135 9.554   80.157  1.00 28.89 ? 432  THR A CA  1 
+ATOM   3261 C  C   . THR A 1 410 ? -29.596 9.448   81.586  1.00 25.77 ? 432  THR A C   1 
+ATOM   3262 O  O   . THR A 1 410 ? -30.745 9.015   81.878  1.00 24.47 ? 432  THR A O   1 
+ATOM   3263 C  CB  . THR A 1 410 ? -29.415 10.920  79.655  1.00 35.65 ? 432  THR A CB  1 
+ATOM   3264 O  OG1 . THR A 1 410 ? -30.821 11.162  79.756  1.00 41.96 ? 432  THR A OG1 1 
+ATOM   3265 C  CG2 . THR A 1 410 ? -29.078 11.028  78.221  1.00 36.66 ? 432  THR A CG2 1 
+ATOM   3266 N  N   . ASP A 1 411 ? -28.719 9.849   82.486  1.00 24.50 ? 433  ASP A N   1 
+ATOM   3267 C  CA  . ASP A 1 411 ? -29.082 9.758   83.923  1.00 25.05 ? 433  ASP A CA  1 
+ATOM   3268 C  C   . ASP A 1 411 ? -30.286 10.585  84.205  1.00 22.08 ? 433  ASP A C   1 
+ATOM   3269 O  O   . ASP A 1 411 ? -30.431 11.699  83.607  1.00 22.74 ? 433  ASP A O   1 
+ATOM   3270 C  CB  . ASP A 1 411 ? -27.900 10.228  84.740  1.00 26.36 ? 433  ASP A CB  1 
+ATOM   3271 C  CG  . ASP A 1 411 ? -26.669 9.321   84.610  1.00 27.78 ? 433  ASP A CG  1 
+ATOM   3272 O  OD1 . ASP A 1 411 ? -26.751 8.162   84.110  1.00 25.85 ? 433  ASP A OD1 1 
+ATOM   3273 O  OD2 . ASP A 1 411 ? -25.606 9.772   85.115  1.00 30.44 ? 433  ASP A OD2 1 
+ATOM   3274 N  N   . THR A 1 412 ? -31.148 10.098  85.126  1.00 23.21 ? 434  THR A N   1 
+ATOM   3275 C  CA  . THR A 1 412 ? -32.386 10.800  85.356  1.00 25.91 ? 434  THR A CA  1 
+ATOM   3276 C  C   . THR A 1 412 ? -32.815 10.675  86.813  1.00 24.03 ? 434  THR A C   1 
+ATOM   3277 O  O   . THR A 1 412 ? -32.443 9.739   87.482  1.00 22.69 ? 434  THR A O   1 
+ATOM   3278 C  CB  . THR A 1 412 ? -33.434 10.304  84.412  1.00 31.66 ? 434  THR A CB  1 
+ATOM   3279 O  OG1 . THR A 1 412 ? -34.586 11.126  84.512  1.00 37.31 ? 434  THR A OG1 1 
+ATOM   3280 C  CG2 . THR A 1 412 ? -33.802 8.937   84.714  1.00 30.20 ? 434  THR A CG2 1 
+ATOM   3281 N  N   . THR A 1 413 ? -33.591 11.633  87.261  1.00 25.02 ? 435  THR A N   1 
+ATOM   3282 C  CA  . THR A 1 413 ? -34.105 11.589  88.625  1.00 24.55 ? 435  THR A CA  1 
+ATOM   3283 C  C   . THR A 1 413 ? -35.605 11.523  88.525  1.00 24.60 ? 435  THR A C   1 
+ATOM   3284 O  O   . THR A 1 413 ? -36.201 12.318  87.750  1.00 28.77 ? 435  THR A O   1 
+ATOM   3285 C  CB  . THR A 1 413 ? -33.685 12.885  89.374  1.00 26.32 ? 435  THR A CB  1 
+ATOM   3286 O  OG1 . THR A 1 413 ? -32.263 12.903  89.552  1.00 29.63 ? 435  THR A OG1 1 
+ATOM   3287 C  CG2 . THR A 1 413 ? -34.353 12.966  90.723  1.00 27.23 ? 435  THR A CG2 1 
+ATOM   3288 N  N   . VAL A 1 414 ? -36.240 10.597  89.234  1.00 24.17 ? 436  VAL A N   1 
+ATOM   3289 C  CA  . VAL A 1 414 ? -37.702 10.462  89.217  1.00 25.39 ? 436  VAL A CA  1 
+ATOM   3290 C  C   . VAL A 1 414 ? -38.241 10.498  90.663  1.00 25.41 ? 436  VAL A C   1 
+ATOM   3291 O  O   . VAL A 1 414 ? -37.518 10.231  91.621  1.00 26.28 ? 436  VAL A O   1 
+ATOM   3292 C  CB  . VAL A 1 414 ? -38.119 9.169   88.559  1.00 25.41 ? 436  VAL A CB  1 
+ATOM   3293 C  CG1 . VAL A 1 414 ? -37.528 9.112   87.194  1.00 27.95 ? 436  VAL A CG1 1 
+ATOM   3294 C  CG2 . VAL A 1 414 ? -37.632 7.964   89.370  1.00 22.03 ? 436  VAL A CG2 1 
+ATOM   3295 N  N   . VAL A 1 415 ? -39.527 10.807  90.810  1.00 27.99 ? 437  VAL A N   1 
+ATOM   3296 C  CA  A VAL A 1 415 ? -40.136 10.931  92.118  0.42 27.17 ? 437  VAL A CA  1 
+ATOM   3297 C  CA  B VAL A 1 415 ? -40.135 10.939  92.122  0.58 27.11 ? 437  VAL A CA  1 
+ATOM   3298 C  C   . VAL A 1 415 ? -40.633 9.568   92.603  1.00 26.77 ? 437  VAL A C   1 
+ATOM   3299 O  O   . VAL A 1 415 ? -41.029 8.718   91.847  1.00 24.68 ? 437  VAL A O   1 
+ATOM   3300 C  CB  A VAL A 1 415 ? -41.278 12.000  92.102  0.42 29.09 ? 437  VAL A CB  1 
+ATOM   3301 C  CB  B VAL A 1 415 ? -41.287 12.015  92.109  0.58 29.91 ? 437  VAL A CB  1 
+ATOM   3302 C  CG1 A VAL A 1 415 ? -42.166 11.909  93.331  0.42 30.81 ? 437  VAL A CG1 1 
+ATOM   3303 C  CG1 B VAL A 1 415 ? -42.534 11.463  91.455  0.58 30.74 ? 437  VAL A CG1 1 
+ATOM   3304 C  CG2 A VAL A 1 415 ? -40.671 13.398  91.950  0.42 29.02 ? 437  VAL A CG2 1 
+ATOM   3305 C  CG2 B VAL A 1 415 ? -41.599 12.549  93.489  0.58 31.52 ? 437  VAL A CG2 1 
+ATOM   3306 N  N   . ILE A 1 416 ? -40.586 9.395   93.902  1.00 26.73 ? 438  ILE A N   1 
+ATOM   3307 C  CA  . ILE A 1 416 ? -41.097 8.215   94.546  1.00 26.69 ? 438  ILE A CA  1 
+ATOM   3308 C  C   . ILE A 1 416 ? -42.508 7.855   94.039  1.00 25.72 ? 438  ILE A C   1 
+ATOM   3309 O  O   . ILE A 1 416 ? -43.388 8.730   93.867  1.00 25.49 ? 438  ILE A O   1 
+ATOM   3310 C  CB  . ILE A 1 416 ? -41.107 8.464   96.060  1.00 28.67 ? 438  ILE A CB  1 
+ATOM   3311 C  CG1 . ILE A 1 416 ? -41.326 7.161   96.711  1.00 34.40 ? 438  ILE A CG1 1 
+ATOM   3312 C  CG2 . ILE A 1 416 ? -42.161 9.454   96.464  1.00 30.82 ? 438  ILE A CG2 1 
+ATOM   3313 C  CD1 . ILE A 1 416 ? -40.036 6.527   96.900  1.00 37.75 ? 438  ILE A CD1 1 
+ATOM   3314 N  N   . ASP A 1 417 ? -42.700 6.562   93.797  1.00 25.38 ? 439  ASP A N   1 
+ATOM   3315 C  CA  . ASP A 1 417 ? -43.966 5.949   93.401  1.00 25.65 ? 439  ASP A CA  1 
+ATOM   3316 C  C   . ASP A 1 417 ? -44.368 6.298   91.978  1.00 26.83 ? 439  ASP A C   1 
+ATOM   3317 O  O   . ASP A 1 417 ? -45.441 5.932   91.532  1.00 30.08 ? 439  ASP A O   1 
+ATOM   3318 C  CB  . ASP A 1 417 ? -45.064 6.234   94.416  1.00 27.16 ? 439  ASP A CB  1 
+ATOM   3319 C  CG  . ASP A 1 417 ? -44.781 5.585   95.734  1.00 29.13 ? 439  ASP A CG  1 
+ATOM   3320 O  OD1 . ASP A 1 417 ? -44.161 4.491   95.733  1.00 27.43 ? 439  ASP A OD1 1 
+ATOM   3321 O  OD2 . ASP A 1 417 ? -45.157 6.174   96.763  1.00 31.64 ? 439  ASP A OD2 1 
+ATOM   3322 N  N   . SER A 1 418 ? -43.471 6.946   91.244  1.00 25.88 ? 440  SER A N   1 
+ATOM   3323 C  CA  . SER A 1 418 ? -43.756 7.169   89.829  1.00 27.81 ? 440  SER A CA  1 
+ATOM   3324 C  C   . SER A 1 418 ? -43.547 5.871   89.029  1.00 25.41 ? 440  SER A C   1 
+ATOM   3325 O  O   . SER A 1 418 ? -42.898 4.927   89.457  1.00 25.46 ? 440  SER A O   1 
+ATOM   3326 C  CB  . SER A 1 418 ? -42.860 8.270   89.300  1.00 28.75 ? 440  SER A CB  1 
+ATOM   3327 O  OG  . SER A 1 418 ? -41.561 7.793   89.303  1.00 28.25 ? 440  SER A OG  1 
+ATOM   3328 N  N   . GLU A 1 419 ? -44.180 5.798   87.877  1.00 27.82 ? 441  GLU A N   1 
+ATOM   3329 C  CA  . GLU A 1 419 ? -43.976 4.674   86.999  1.00 30.19 ? 441  GLU A CA  1 
+ATOM   3330 C  C   . GLU A 1 419 ? -42.707 4.902   86.223  1.00 29.84 ? 441  GLU A C   1 
+ATOM   3331 O  O   . GLU A 1 419 ? -42.485 5.991   85.704  1.00 31.02 ? 441  GLU A O   1 
+ATOM   3332 C  CB  . GLU A 1 419 ? -45.150 4.594   86.017  1.00 38.52 ? 441  GLU A CB  1 
+ATOM   3333 C  CG  . GLU A 1 419 ? -46.298 3.790   86.573  1.00 47.06 ? 441  GLU A CG  1 
+ATOM   3334 C  CD  . GLU A 1 419 ? -46.128 2.311   86.235  1.00 56.42 ? 441  GLU A CD  1 
+ATOM   3335 O  OE1 . GLU A 1 419 ? -45.253 1.995   85.367  1.00 60.27 ? 441  GLU A OE1 1 
+ATOM   3336 O  OE2 . GLU A 1 419 ? -46.855 1.483   86.844  1.00 59.97 ? 441  GLU A OE2 1 
+ATOM   3337 N  N   . PHE A 1 420 ? -41.853 3.898   86.164  1.00 26.91 ? 442  PHE A N   1 
+ATOM   3338 C  CA  . PHE A 1 420 ? -40.618 4.037   85.410  1.00 24.38 ? 442  PHE A CA  1 
+ATOM   3339 C  C   . PHE A 1 420 ? -40.465 2.863   84.446  1.00 26.46 ? 442  PHE A C   1 
+ATOM   3340 O  O   . PHE A 1 420 ? -40.498 1.701   84.857  1.00 28.25 ? 442  PHE A O   1 
+ATOM   3341 C  CB  . PHE A 1 420 ? -39.344 4.193   86.311  1.00 25.19 ? 442  PHE A CB  1 
+ATOM   3342 C  CG  . PHE A 1 420 ? -38.062 4.355   85.535  1.00 25.29 ? 442  PHE A CG  1 
+ATOM   3343 C  CD1 . PHE A 1 420 ? -37.687 5.581   85.072  1.00 27.90 ? 442  PHE A CD1 1 
+ATOM   3344 C  CD2 . PHE A 1 420 ? -37.259 3.270   85.224  1.00 23.31 ? 442  PHE A CD2 1 
+ATOM   3345 C  CE1 . PHE A 1 420 ? -36.548 5.725   84.249  1.00 27.06 ? 442  PHE A CE1 1 
+ATOM   3346 C  CE2 . PHE A 1 420 ? -36.112 3.425   84.459  1.00 23.81 ? 442  PHE A CE2 1 
+ATOM   3347 C  CZ  . PHE A 1 420 ? -35.758 4.655   83.982  1.00 24.96 ? 442  PHE A CZ  1 
+ATOM   3348 N  N   . ASP A 1 421 ? -40.304 3.183   83.174  1.00 25.54 ? 443  ASP A N   1 
+ATOM   3349 C  CA  . ASP A 1 421 ? -40.094 2.185   82.136  1.00 27.03 ? 443  ASP A CA  1 
+ATOM   3350 C  C   . ASP A 1 421 ? -38.683 2.383   81.596  1.00 24.03 ? 443  ASP A C   1 
+ATOM   3351 O  O   . ASP A 1 421 ? -38.386 3.415   80.965  1.00 25.35 ? 443  ASP A O   1 
+ATOM   3352 C  CB  . ASP A 1 421 ? -41.143 2.379   81.030  1.00 31.70 ? 443  ASP A CB  1 
+ATOM   3353 C  CG  . ASP A 1 421 ? -40.886 1.510   79.795  1.00 35.04 ? 443  ASP A CG  1 
+ATOM   3354 O  OD1 . ASP A 1 421 ? -39.869 0.757   79.755  1.00 31.29 ? 443  ASP A OD1 1 
+ATOM   3355 O  OD2 . ASP A 1 421 ? -41.732 1.562   78.869  1.00 39.27 ? 443  ASP A OD2 1 
+ATOM   3356 N  N   . PRO A 1 422 ? -37.783 1.419   81.842  1.00 25.11 ? 444  PRO A N   1 
+ATOM   3357 C  CA  . PRO A 1 422 ? -36.390 1.544   81.402  1.00 22.32 ? 444  PRO A CA  1 
+ATOM   3358 C  C   . PRO A 1 422 ? -36.229 1.707   79.894  1.00 23.40 ? 444  PRO A C   1 
+ATOM   3359 O  O   . PRO A 1 422 ? -35.160 2.166   79.461  1.00 22.07 ? 444  PRO A O   1 
+ATOM   3360 C  CB  . PRO A 1 422 ? -35.756 0.231   81.846  1.00 25.07 ? 444  PRO A CB  1 
+ATOM   3361 C  CG  . PRO A 1 422 ? -36.607 -0.260  82.903  1.00 29.25 ? 444  PRO A CG  1 
+ATOM   3362 C  CD  . PRO A 1 422 ? -38.003 0.128   82.498  1.00 27.95 ? 444  PRO A CD  1 
+ATOM   3363 N  N   . MET A 1 423 ? -37.256 1.373   79.122  1.00 25.24 ? 445  MET A N   1 
+ATOM   3364 C  CA  . MET A 1 423 ? -37.109 1.524   77.666  1.00 25.18 ? 445  MET A CA  1 
+ATOM   3365 C  C   . MET A 1 423 ? -37.766 2.767   77.097  1.00 28.61 ? 445  MET A C   1 
+ATOM   3366 O  O   . MET A 1 423 ? -37.642 3.024   75.892  1.00 28.64 ? 445  MET A O   1 
+ATOM   3367 C  CB  . MET A 1 423 ? -37.573 0.280   76.925  1.00 27.37 ? 445  MET A CB  1 
+ATOM   3368 C  CG  . MET A 1 423 ? -36.606 -0.893  77.129  1.00 25.59 ? 445  MET A CG  1 
+ATOM   3369 S  SD  . MET A 1 423 ? -34.921 -0.663  76.507  1.00 27.47 ? 445  MET A SD  1 
+ATOM   3370 C  CE  . MET A 1 423 ? -35.212 -0.475  74.737  1.00 28.94 ? 445  MET A CE  1 
+ATOM   3371 N  N   . GLN A 1 424 ? -38.449 3.534   77.932  1.00 30.95 ? 446  GLN A N   1 
+ATOM   3372 C  CA  A GLN A 1 424 ? -39.085 4.742   77.459  0.60 32.67 ? 446  GLN A CA  1 
+ATOM   3373 C  CA  B GLN A 1 424 ? -39.098 4.745   77.452  0.40 32.41 ? 446  GLN A CA  1 
+ATOM   3374 C  C   . GLN A 1 424 ? -38.058 5.704   76.950  1.00 32.09 ? 446  GLN A C   1 
+ATOM   3375 O  O   . GLN A 1 424 ? -37.104 6.031   77.669  1.00 29.24 ? 446  GLN A O   1 
+ATOM   3376 C  CB  A GLN A 1 424 ? -39.879 5.421   78.550  0.60 36.13 ? 446  GLN A CB  1 
+ATOM   3377 C  CB  B GLN A 1 424 ? -39.936 5.424   78.528  0.40 34.89 ? 446  GLN A CB  1 
+ATOM   3378 C  CG  A GLN A 1 424 ? -40.495 6.722   78.070  0.60 40.17 ? 446  GLN A CG  1 
+ATOM   3379 C  CG  B GLN A 1 424 ? -40.469 6.815   78.116  0.40 37.91 ? 446  GLN A CG  1 
+ATOM   3380 C  CD  A GLN A 1 424 ? -41.529 6.470   77.028  0.60 43.44 ? 446  GLN A CD  1 
+ATOM   3381 C  CD  B GLN A 1 424 ? -39.711 7.973   78.781  0.40 40.60 ? 446  GLN A CD  1 
+ATOM   3382 O  OE1 A GLN A 1 424 ? -41.957 5.335   76.851  0.60 46.15 ? 446  GLN A OE1 1 
+ATOM   3383 O  OE1 B GLN A 1 424 ? -40.095 8.469   79.847  0.40 42.22 ? 446  GLN A OE1 1 
+ATOM   3384 N  NE2 A GLN A 1 424 ? -41.925 7.505   76.309  0.60 44.64 ? 446  GLN A NE2 1 
+ATOM   3385 N  NE2 B GLN A 1 424 ? -38.639 8.407   78.147  0.40 41.36 ? 446  GLN A NE2 1 
+ATOM   3386 N  N   . GLY A 1 425 ? -38.255 6.139   75.692  1.00 33.40 ? 447  GLY A N   1 
+ATOM   3387 C  CA  . GLY A 1 425 ? -37.351 7.092   75.087  1.00 31.57 ? 447  GLY A CA  1 
+ATOM   3388 C  C   . GLY A 1 425 ? -35.991 6.543   74.696  1.00 28.72 ? 447  GLY A C   1 
+ATOM   3389 O  O   . GLY A 1 425 ? -35.152 7.301   74.209  1.00 30.22 ? 447  GLY A O   1 
+ATOM   3390 N  N   . VAL A 1 426 ? -35.819 5.230   74.813  1.00 26.21 ? 448  VAL A N   1 
+ATOM   3391 C  CA  . VAL A 1 426 ? -34.562 4.590   74.515  1.00 24.66 ? 448  VAL A CA  1 
+ATOM   3392 C  C   . VAL A 1 426 ? -34.592 3.909   73.144  1.00 24.94 ? 448  VAL A C   1 
+ATOM   3393 O  O   . VAL A 1 426 ? -35.523 3.214   72.818  1.00 26.42 ? 448  VAL A O   1 
+ATOM   3394 C  CB  . VAL A 1 426 ? -34.227 3.534   75.556  1.00 24.64 ? 448  VAL A CB  1 
+ATOM   3395 C  CG1 . VAL A 1 426 ? -32.972 2.783   75.150  1.00 23.19 ? 448  VAL A CG1 1 
+ATOM   3396 C  CG2 . VAL A 1 426 ? -34.044 4.212   76.911  1.00 25.69 ? 448  VAL A CG2 1 
+ATOM   3397 N  N   . SER A 1 427 ? -33.576 4.147   72.335  1.00 23.49 ? 449  SER A N   1 
+ATOM   3398 C  CA  . SER A 1 427 ? -33.500 3.483   71.028  1.00 24.16 ? 449  SER A CA  1 
+ATOM   3399 C  C   . SER A 1 427 ? -32.025 3.282   70.609  1.00 23.88 ? 449  SER A C   1 
+ATOM   3400 O  O   . SER A 1 427 ? -31.102 3.747   71.289  1.00 24.25 ? 449  SER A O   1 
+ATOM   3401 C  CB  . SER A 1 427 ? -34.314 4.277   70.050  1.00 27.00 ? 449  SER A CB  1 
+ATOM   3402 O  OG  . SER A 1 427 ? -33.594 5.431   69.736  1.00 32.47 ? 449  SER A OG  1 
+ATOM   3403 N  N   . ALA A 1 428 ? -31.811 2.534   69.523  1.00 23.72 ? 450  ALA A N   1 
+ATOM   3404 C  CA  . ALA A 1 428 ? -30.488 2.397   68.947  1.00 22.50 ? 450  ALA A CA  1 
+ATOM   3405 C  C   . ALA A 1 428 ? -30.671 2.285   67.436  1.00 21.19 ? 450  ALA A C   1 
+ATOM   3406 O  O   . ALA A 1 428 ? -31.689 1.796   66.944  1.00 24.18 ? 450  ALA A O   1 
+ATOM   3407 C  CB  . ALA A 1 428 ? -29.783 1.209   69.433  1.00 23.21 ? 450  ALA A CB  1 
+ATOM   3408 N  N   . SER A 1 429 ? -29.643 2.771   66.774  1.00 22.90 ? 451  SER A N   1 
+ATOM   3409 C  CA  . SER A 1 429 ? -29.656 2.781   65.311  1.00 22.50 ? 451  SER A CA  1 
+ATOM   3410 C  C   . SER A 1 429 ? -28.273 2.411   64.766  1.00 24.35 ? 451  SER A C   1 
+ATOM   3411 O  O   . SER A 1 429 ? -27.244 2.521   65.422  1.00 23.56 ? 451  SER A O   1 
+ATOM   3412 C  CB  . SER A 1 429 ? -30.074 4.131   64.732  1.00 26.43 ? 451  SER A CB  1 
+ATOM   3413 O  OG  . SER A 1 429 ? -29.018 5.062   64.918  1.00 27.73 ? 451  SER A OG  1 
+ATOM   3414 N  N   . HIS A 1 430 ? -28.274 2.001   63.500  1.00 24.16 ? 452  HIS A N   1 
+ATOM   3415 C  CA  . HIS A 1 430 ? -27.015 1.713   62.816  1.00 23.28 ? 452  HIS A CA  1 
+ATOM   3416 C  C   . HIS A 1 430 ? -27.296 2.080   61.371  1.00 22.73 ? 452  HIS A C   1 
+ATOM   3417 O  O   . HIS A 1 430 ? -28.404 1.891   60.870  1.00 23.64 ? 452  HIS A O   1 
+ATOM   3418 C  CB  . HIS A 1 430 ? -26.622 0.236   62.963  1.00 23.73 ? 452  HIS A CB  1 
+ATOM   3419 C  CG  . HIS A 1 430 ? -25.360 -0.145  62.231  1.00 22.15 ? 452  HIS A CG  1 
+ATOM   3420 N  ND1 . HIS A 1 430 ? -25.339 -0.554  60.914  1.00 22.89 ? 452  HIS A ND1 1 
+ATOM   3421 C  CD2 . HIS A 1 430 ? -24.069 -0.150  62.632  1.00 23.62 ? 452  HIS A CD2 1 
+ATOM   3422 C  CE1 . HIS A 1 430 ? -24.096 -0.813  60.552  1.00 24.75 ? 452  HIS A CE1 1 
+ATOM   3423 N  NE2 . HIS A 1 430 ? -23.303 -0.567  61.573  1.00 24.09 ? 452  HIS A NE2 1 
+ATOM   3424 N  N   . PRO A 1 431 ? -26.283 2.560   60.657  1.00 24.71 ? 453  PRO A N   1 
+ATOM   3425 C  CA  . PRO A 1 431 ? -26.614 3.057   59.308  1.00 26.13 ? 453  PRO A CA  1 
+ATOM   3426 C  C   . PRO A 1 431 ? -27.097 2.025   58.314  1.00 26.37 ? 453  PRO A C   1 
+ATOM   3427 O  O   . PRO A 1 431 ? -27.862 2.415   57.363  1.00 27.65 ? 453  PRO A O   1 
+ATOM   3428 C  CB  . PRO A 1 431 ? -25.272 3.610   58.818  1.00 26.94 ? 453  PRO A CB  1 
+ATOM   3429 C  CG  . PRO A 1 431 ? -24.419 3.845   59.936  1.00 30.00 ? 453  PRO A CG  1 
+ATOM   3430 C  CD  . PRO A 1 431 ? -24.901 2.857   61.042  1.00 25.75 ? 453  PRO A CD  1 
+ATOM   3431 N  N   . THR A 1 432 ? -26.661 0.774   58.460  1.00 24.67 ? 454  THR A N   1 
+ATOM   3432 C  CA  . THR A 1 432 ? -27.113 -0.269  57.522  1.00 26.32 ? 454  THR A CA  1 
+ATOM   3433 C  C   . THR A 1 432 ? -28.072 -1.253  58.143  1.00 26.16 ? 454  THR A C   1 
+ATOM   3434 O  O   . THR A 1 432 ? -28.923 -1.825  57.459  1.00 27.85 ? 454  THR A O   1 
+ATOM   3435 C  CB  . THR A 1 432 ? -25.941 -1.036  56.858  1.00 27.57 ? 454  THR A CB  1 
+ATOM   3436 O  OG1 . THR A 1 432 ? -25.253 -1.795  57.831  1.00 29.23 ? 454  THR A OG1 1 
+ATOM   3437 C  CG2 . THR A 1 432 ? -24.972 -0.132  56.224  1.00 28.60 ? 454  THR A CG2 1 
+ATOM   3438 N  N   . GLN A 1 433 ? -28.018 -1.417  59.476  1.00 25.23 ? 455  GLN A N   1 
+ATOM   3439 C  CA  A GLN A 1 433 ? -28.889 -2.395  60.097  0.41 25.57 ? 455  GLN A CA  1 
+ATOM   3440 C  CA  B GLN A 1 433 ? -28.931 -2.365  60.118  0.59 26.46 ? 455  GLN A CA  1 
+ATOM   3441 C  C   . GLN A 1 433 ? -30.222 -1.686  60.514  1.00 28.41 ? 455  GLN A C   1 
+ATOM   3442 O  O   . GLN A 1 433 ? -31.243 -2.373  60.818  1.00 32.07 ? 455  GLN A O   1 
+ATOM   3443 C  CB  A GLN A 1 433 ? -28.118 -3.154  61.224  0.41 23.50 ? 455  GLN A CB  1 
+ATOM   3444 C  CB  B GLN A 1 433 ? -28.330 -2.984  61.374  0.59 27.44 ? 455  GLN A CB  1 
+ATOM   3445 C  CG  A GLN A 1 433 ? -26.717 -3.735  60.767  0.41 23.98 ? 455  GLN A CG  1 
+ATOM   3446 C  CG  B GLN A 1 433 ? -27.298 -4.011  61.162  0.59 28.69 ? 455  GLN A CG  1 
+ATOM   3447 C  CD  A GLN A 1 433 ? -25.840 -4.346  61.879  0.41 22.72 ? 455  GLN A CD  1 
+ATOM   3448 C  CD  B GLN A 1 433 ? -27.158 -4.907  62.358  0.59 29.78 ? 455  GLN A CD  1 
+ATOM   3449 O  OE1 A GLN A 1 433 ? -26.354 -4.986  62.784  0.41 22.14 ? 455  GLN A OE1 1 
+ATOM   3450 O  OE1 B GLN A 1 433 ? -26.227 -4.737  63.145  0.59 30.29 ? 455  GLN A OE1 1 
+ATOM   3451 N  NE2 A GLN A 1 433 ? -24.511 -4.132  61.813  0.41 23.31 ? 455  GLN A NE2 1 
+ATOM   3452 N  NE2 B GLN A 1 433 ? -28.075 -5.880  62.503  0.59 29.58 ? 455  GLN A NE2 1 
+ATOM   3453 N  N   . GLY A 1 434 ? -30.237 -0.345  60.566  1.00 26.64 ? 456  GLY A N   1 
+ATOM   3454 C  CA  . GLY A 1 434 ? -31.484 0.365   60.800  1.00 25.15 ? 456  GLY A CA  1 
+ATOM   3455 C  C   . GLY A 1 434 ? -31.828 0.473   62.285  1.00 25.43 ? 456  GLY A C   1 
+ATOM   3456 O  O   . GLY A 1 434 ? -30.954 0.701   63.147  1.00 25.19 ? 456  GLY A O   1 
+ATOM   3457 N  N   . ASP A 1 435 ? -33.105 0.299   62.580  1.00 25.10 ? 457  ASP A N   1 
+ATOM   3458 C  CA  . ASP A 1 435 ? -33.592 0.437   63.980  1.00 24.88 ? 457  ASP A CA  1 
+ATOM   3459 C  C   . ASP A 1 435 ? -33.210 -0.830  64.747  1.00 22.14 ? 457  ASP A C   1 
+ATOM   3460 O  O   . ASP A 1 435 ? -33.726 -1.965  64.441  1.00 26.03 ? 457  ASP A O   1 
+ATOM   3461 C  CB  . ASP A 1 435 ? -35.122 0.617   63.974  1.00 24.78 ? 457  ASP A CB  1 
+ATOM   3462 C  CG  . ASP A 1 435 ? -35.720 0.916   65.339  1.00 27.43 ? 457  ASP A CG  1 
+ATOM   3463 O  OD1 . ASP A 1 435 ? -35.042 0.753   66.352  1.00 27.24 ? 457  ASP A OD1 1 
+ATOM   3464 O  OD2 . ASP A 1 435 ? -36.908 1.341   65.379  1.00 29.72 ? 457  ASP A OD2 1 
+ATOM   3465 N  N   . LEU A 1 436 ? -32.396 -0.684  65.788  1.00 22.30 ? 458  LEU A N   1 
+ATOM   3466 C  CA  . LEU A 1 436 ? -31.934 -1.787  66.618  1.00 21.42 ? 458  LEU A CA  1 
+ATOM   3467 C  C   . LEU A 1 436 ? -32.524 -1.756  68.033  1.00 22.81 ? 458  LEU A C   1 
+ATOM   3468 O  O   . LEU A 1 436 ? -32.018 -2.487  68.915  1.00 23.79 ? 458  LEU A O   1 
+ATOM   3469 C  CB  . LEU A 1 436 ? -30.415 -1.747  66.698  1.00 19.37 ? 458  LEU A CB  1 
+ATOM   3470 C  CG  . LEU A 1 436 ? -29.670 -2.180  65.394  1.00 21.16 ? 458  LEU A CG  1 
+ATOM   3471 C  CD1 . LEU A 1 436 ? -28.178 -1.907  65.566  1.00 22.46 ? 458  LEU A CD1 1 
+ATOM   3472 C  CD2 . LEU A 1 436 ? -30.040 -3.650  65.046  1.00 23.75 ? 458  LEU A CD2 1 
+ATOM   3473 N  N   . THR A 1 437 ? -33.589 -0.991  68.218  1.00 22.69 ? 459  THR A N   1 
+ATOM   3474 C  CA  . THR A 1 437 ? -34.182 -0.859  69.543  1.00 22.82 ? 459  THR A CA  1 
+ATOM   3475 C  C   . THR A 1 437 ? -34.572 -2.223  70.136  1.00 22.06 ? 459  THR A C   1 
+ATOM   3476 O  O   . THR A 1 437 ? -34.482 -2.409  71.349  1.00 23.39 ? 459  THR A O   1 
+ATOM   3477 C  CB  . THR A 1 437 ? -35.382 0.047   69.481  1.00 23.10 ? 459  THR A CB  1 
+ATOM   3478 O  OG1 . THR A 1 437 ? -34.957 1.324   68.996  1.00 24.52 ? 459  THR A OG1 1 
+ATOM   3479 C  CG2 . THR A 1 437 ? -36.009 0.247   70.861  1.00 23.51 ? 459  THR A CG2 1 
+ATOM   3480 N  N   . ALA A 1 438 ? -35.071 -3.138  69.302  1.00 23.49 ? 460  ALA A N   1 
+ATOM   3481 C  CA  . ALA A 1 438 ? -35.548 -4.443  69.816  1.00 23.36 ? 460  ALA A CA  1 
+ATOM   3482 C  C   . ALA A 1 438 ? -34.400 -5.328  70.225  1.00 22.28 ? 460  ALA A C   1 
+ATOM   3483 O  O   . ALA A 1 438 ? -34.649 -6.418  70.824  1.00 24.49 ? 460  ALA A O   1 
+ATOM   3484 C  CB  . ALA A 1 438 ? -36.390 -5.149  68.760  1.00 25.76 ? 460  ALA A CB  1 
+ATOM   3485 N  N   . ASN A 1 439 ? -33.162 -4.890  69.941  1.00 22.38 ? 461  ASN A N   1 
+ATOM   3486 C  CA  . ASN A 1 439 ? -31.954 -5.666  70.298  1.00 21.32 ? 461  ASN A CA  1 
+ATOM   3487 C  C   . ASN A 1 439 ? -31.225 -5.204  71.576  1.00 20.83 ? 461  ASN A C   1 
+ATOM   3488 O  O   . ASN A 1 439 ? -30.114 -5.649  71.852  1.00 20.47 ? 461  ASN A O   1 
+ATOM   3489 C  CB  . ASN A 1 439 ? -30.947 -5.666  69.138  1.00 20.53 ? 461  ASN A CB  1 
+ATOM   3490 C  CG  . ASN A 1 439 ? -31.399 -6.548  67.964  1.00 22.63 ? 461  ASN A CG  1 
+ATOM   3491 O  OD1 . ASN A 1 439 ? -32.594 -6.898  67.834  1.00 24.28 ? 461  ASN A OD1 1 
+ATOM   3492 N  ND2 . ASN A 1 439 ? -30.444 -6.944  67.163  1.00 23.30 ? 461  ASN A ND2 1 
+ATOM   3493 N  N   . ILE A 1 440 ? -31.903 -4.316  72.303  1.00 19.44 ? 462  ILE A N   1 
+ATOM   3494 C  CA  . ILE A 1 440 ? -31.430 -3.770  73.577  1.00 18.82 ? 462  ILE A CA  1 
+ATOM   3495 C  C   . ILE A 1 440 ? -32.011 -4.580  74.768  1.00 21.03 ? 462  ILE A C   1 
+ATOM   3496 O  O   . ILE A 1 440 ? -33.210 -4.846  74.830  1.00 23.16 ? 462  ILE A O   1 
+ATOM   3497 C  CB  . ILE A 1 440 ? -31.800 -2.306  73.768  1.00 18.42 ? 462  ILE A CB  1 
+ATOM   3498 C  CG1 . ILE A 1 440 ? -31.211 -1.432  72.629  1.00 20.17 ? 462  ILE A CG1 1 
+ATOM   3499 C  CG2 . ILE A 1 440 ? -31.321 -1.845  75.141  1.00 20.89 ? 462  ILE A CG2 1 
+ATOM   3500 C  CD1 . ILE A 1 440 ? -31.849 -0.071  72.620  1.00 20.65 ? 462  ILE A CD1 1 
+ATOM   3501 N  N   . THR A 1 441 ? -31.118 -4.983  75.652  1.00 19.51 ? 463  THR A N   1 
+ATOM   3502 C  CA  . THR A 1 441 ? -31.549 -5.620  76.920  1.00 21.00 ? 463  THR A CA  1 
+ATOM   3503 C  C   . THR A 1 441 ? -31.136 -4.734  78.057  1.00 20.46 ? 463  THR A C   1 
+ATOM   3504 O  O   . THR A 1 441 ? -30.177 -3.942  77.925  1.00 19.37 ? 463  THR A O   1 
+ATOM   3505 C  CB  . THR A 1 441 ? -30.978 -6.987  77.107  1.00 22.46 ? 463  THR A CB  1 
+ATOM   3506 O  OG1 . THR A 1 441 ? -29.570 -6.924  77.358  1.00 24.14 ? 463  THR A OG1 1 
+ATOM   3507 C  CG2 . THR A 1 441 ? -31.247 -7.861  75.931  1.00 25.95 ? 463  THR A CG2 1 
+ATOM   3508 N  N   . VAL A 1 442 ? -31.849 -4.885  79.187  1.00 20.55 ? 464  VAL A N   1 
+ATOM   3509 C  CA  . VAL A 1 442 ? -31.612 -4.059  80.360  1.00 20.97 ? 464  VAL A CA  1 
+ATOM   3510 C  C   . VAL A 1 442 ? -31.277 -4.932  81.561  1.00 22.84 ? 464  VAL A C   1 
+ATOM   3511 O  O   . VAL A 1 442 ? -32.039 -5.850  81.862  1.00 23.83 ? 464  VAL A O   1 
+ATOM   3512 C  CB  . VAL A 1 442 ? -32.853 -3.185  80.701  1.00 22.60 ? 464  VAL A CB  1 
+ATOM   3513 C  CG1 . VAL A 1 442 ? -32.507 -2.267  81.905  1.00 24.90 ? 464  VAL A CG1 1 
+ATOM   3514 C  CG2 . VAL A 1 442 ? -33.267 -2.347  79.470  1.00 24.66 ? 464  VAL A CG2 1 
+ATOM   3515 N  N   . THR A 1 443 ? -30.104 -4.702  82.140  1.00 20.63 ? 465  THR A N   1 
+ATOM   3516 C  CA  . THR A 1 443 ? -29.655 -5.384  83.398  1.00 20.78 ? 465  THR A CA  1 
+ATOM   3517 C  C   . THR A 1 443 ? -29.869 -4.406  84.561  1.00 20.83 ? 465  THR A C   1 
+ATOM   3518 O  O   . THR A 1 443 ? -29.456 -3.258  84.514  1.00 22.32 ? 465  THR A O   1 
+ATOM   3519 C  CB  . THR A 1 443 ? -28.167 -5.739  83.273  1.00 24.49 ? 465  THR A CB  1 
+ATOM   3520 O  OG1 . THR A 1 443 ? -28.021 -6.749  82.267  1.00 27.00 ? 465  THR A OG1 1 
+ATOM   3521 C  CG2 . THR A 1 443 ? -27.555 -6.224  84.636  1.00 24.69 ? 465  THR A CG2 1 
+ATOM   3522 N  N   . GLY A 1 444 ? -30.480 -4.911  85.636  1.00 22.03 ? 466  GLY A N   1 
+ATOM   3523 C  CA  . GLY A 1 444 ? -30.854 -4.081  86.774  1.00 21.02 ? 466  GLY A CA  1 
+ATOM   3524 C  C   . GLY A 1 444 ? -32.287 -3.616  86.737  1.00 20.28 ? 466  GLY A C   1 
+ATOM   3525 O  O   . GLY A 1 444 ? -32.915 -3.675  85.704  1.00 24.35 ? 466  GLY A O   1 
+ATOM   3526 N  N   . GLU A 1 445 ? -32.773 -3.149  87.892  1.00 22.49 ? 467  GLU A N   1 
+ATOM   3527 C  CA  . GLU A 1 445 ? -34.131 -2.672  88.065  1.00 22.94 ? 467  GLU A CA  1 
+ATOM   3528 C  C   . GLU A 1 445 ? -34.120 -1.367  88.849  1.00 19.77 ? 467  GLU A C   1 
+ATOM   3529 O  O   . GLU A 1 445 ? -33.184 -1.108  89.670  1.00 19.40 ? 467  GLU A O   1 
+ATOM   3530 C  CB  . GLU A 1 445 ? -34.957 -3.728  88.831  1.00 30.29 ? 467  GLU A CB  1 
+ATOM   3531 C  CG  . GLU A 1 445 ? -34.832 -5.064  88.169  1.00 40.84 ? 467  GLU A CG  1 
+ATOM   3532 C  CD  . GLU A 1 445 ? -36.080 -5.408  87.418  1.00 51.61 ? 467  GLU A CD  1 
+ATOM   3533 O  OE1 . GLU A 1 445 ? -37.105 -4.687  87.568  1.00 55.99 ? 467  GLU A OE1 1 
+ATOM   3534 O  OE2 . GLU A 1 445 ? -36.041 -6.402  86.686  1.00 56.34 ? 467  GLU A OE2 1 
+ATOM   3535 N  N   . VAL A 1 446 ? -35.143 -0.563  88.625  1.00 21.19 ? 468  VAL A N   1 
+ATOM   3536 C  CA  . VAL A 1 446 ? -35.397 0.619   89.450  1.00 19.62 ? 468  VAL A CA  1 
+ATOM   3537 C  C   . VAL A 1 446 ? -36.604 0.321   90.332  1.00 19.48 ? 468  VAL A C   1 
+ATOM   3538 O  O   . VAL A 1 446 ? -37.621 -0.172  89.838  1.00 22.16 ? 468  VAL A O   1 
+ATOM   3539 C  CB  . VAL A 1 446 ? -35.703 1.830   88.559  1.00 19.15 ? 468  VAL A CB  1 
+ATOM   3540 C  CG1 . VAL A 1 446 ? -36.053 3.057   89.382  1.00 18.02 ? 468  VAL A CG1 1 
+ATOM   3541 C  CG2 . VAL A 1 446 ? -34.492 2.111   87.628  1.00 20.67 ? 468  VAL A CG2 1 
+ATOM   3542 N  N   . ASP A 1 447 ? -36.501 0.567   91.650  1.00 17.55 ? 469  ASP A N   1 
+ATOM   3543 C  CA  . ASP A 1 447 ? -37.630 0.401   92.540  1.00 17.10 ? 469  ASP A CA  1 
+ATOM   3544 C  C   . ASP A 1 447 ? -38.081 1.810   92.960  1.00 19.24 ? 469  ASP A C   1 
+ATOM   3545 O  O   . ASP A 1 447 ? -37.452 2.409   93.857  1.00 19.11 ? 469  ASP A O   1 
+ATOM   3546 C  CB  . ASP A 1 447 ? -37.252 -0.447  93.764  1.00 16.72 ? 469  ASP A CB  1 
+ATOM   3547 C  CG  . ASP A 1 447 ? -38.443 -0.759  94.618  1.00 17.95 ? 469  ASP A CG  1 
+ATOM   3548 O  OD1 . ASP A 1 447 ? -39.434 0.009   94.600  1.00 19.11 ? 469  ASP A OD1 1 
+ATOM   3549 O  OD2 . ASP A 1 447 ? -38.320 -1.739  95.366  1.00 17.53 ? 469  ASP A OD2 1 
+ATOM   3550 N  N   . THR A 1 448 ? -39.118 2.353   92.314  1.00 18.28 ? 470  THR A N   1 
+ATOM   3551 C  CA  . THR A 1 448 ? -39.493 3.719   92.616  1.00 19.10 ? 470  THR A CA  1 
+ATOM   3552 C  C   . THR A 1 448 ? -40.226 3.838   93.967  1.00 18.34 ? 470  THR A C   1 
+ATOM   3553 O  O   . THR A 1 448 ? -40.530 4.955   94.366  1.00 19.94 ? 470  THR A O   1 
+ATOM   3554 C  CB  . THR A 1 448 ? -40.314 4.381   91.544  1.00 20.87 ? 470  THR A CB  1 
+ATOM   3555 O  OG1 . THR A 1 448 ? -41.568 3.705   91.498  1.00 22.86 ? 470  THR A OG1 1 
+ATOM   3556 C  CG2 . THR A 1 448 ? -39.613 4.339   90.166  1.00 22.73 ? 470  THR A CG2 1 
+ATOM   3557 N  N   . ASN A 1 449 ? -40.521 2.725   94.663  1.00 19.40 ? 471  ASN A N   1 
+ATOM   3558 C  CA  . ASN A 1 449 ? -41.089 2.813   96.015  1.00 16.87 ? 471  ASN A CA  1 
+ATOM   3559 C  C   . ASN A 1 449 ? -40.016 3.096   97.087  1.00 17.82 ? 471  ASN A C   1 
+ATOM   3560 O  O   . ASN A 1 449 ? -40.349 3.381   98.265  1.00 18.92 ? 471  ASN A O   1 
+ATOM   3561 C  CB  . ASN A 1 449 ? -41.891 1.550   96.369  1.00 17.87 ? 471  ASN A CB  1 
+ATOM   3562 C  CG  . ASN A 1 449 ? -42.713 1.661   97.668  1.00 22.30 ? 471  ASN A CG  1 
+ATOM   3563 O  OD1 . ASN A 1 449 ? -42.606 0.806   98.542  1.00 23.84 ? 471  ASN A OD1 1 
+ATOM   3564 N  ND2 . ASN A 1 449 ? -43.514 2.699   97.797  1.00 25.56 ? 471  ASN A ND2 1 
+ATOM   3565 N  N   . VAL A 1 450 ? -38.730 2.949   96.698  1.00 17.26 ? 472  VAL A N   1 
+ATOM   3566 C  CA  . VAL A 1 450 ? -37.600 3.010   97.653  1.00 16.35 ? 472  VAL A CA  1 
+ATOM   3567 C  C   . VAL A 1 450 ? -36.586 4.075   97.204  1.00 16.64 ? 472  VAL A C   1 
+ATOM   3568 O  O   . VAL A 1 450 ? -35.958 3.923   96.173  1.00 17.48 ? 472  VAL A O   1 
+ATOM   3569 C  CB  . VAL A 1 450 ? -36.965 1.628   97.836  1.00 16.54 ? 472  VAL A CB  1 
+ATOM   3570 C  CG1 . VAL A 1 450 ? -35.781 1.677   98.814  1.00 17.23 ? 472  VAL A CG1 1 
+ATOM   3571 C  CG2 . VAL A 1 450 ? -38.034 0.600   98.269  1.00 15.79 ? 472  VAL A CG2 1 
+ATOM   3572 N  N   . VAL A 1 451 ? -36.396 5.110   98.019  1.00 17.40 ? 473  VAL A N   1 
+ATOM   3573 C  CA  . VAL A 1 451 ? -35.474 6.209   97.693  1.00 16.50 ? 473  VAL A CA  1 
+ATOM   3574 C  C   . VAL A 1 451 ? -34.098 5.626   97.533  1.00 17.32 ? 473  VAL A C   1 
+ATOM   3575 O  O   . VAL A 1 451 ? -33.732 4.752   98.299  1.00 15.92 ? 473  VAL A O   1 
+ATOM   3576 C  CB  . VAL A 1 451 ? -35.509 7.253   98.817  1.00 20.79 ? 473  VAL A CB  1 
+ATOM   3577 C  CG1 . VAL A 1 451 ? -34.354 8.216   98.700  1.00 23.90 ? 473  VAL A CG1 1 
+ATOM   3578 C  CG2 . VAL A 1 451 ? -36.858 7.973   98.766  1.00 19.40 ? 473  VAL A CG2 1 
+ATOM   3579 N  N   . GLY A 1 452 ? -33.368 6.085   96.519  1.00 17.72 ? 474  GLY A N   1 
+ATOM   3580 C  CA  . GLY A 1 452 ? -32.004 5.696   96.339  1.00 18.58 ? 474  GLY A CA  1 
+ATOM   3581 C  C   . GLY A 1 452 ? -31.601 5.787   94.890  1.00 17.73 ? 474  GLY A C   1 
+ATOM   3582 O  O   . GLY A 1 452 ? -32.316 6.381   94.062  1.00 18.28 ? 474  GLY A O   1 
+ATOM   3583 N  N   . VAL A 1 453 ? -30.444 5.206   94.615  1.00 18.34 ? 475  VAL A N   1 
+ATOM   3584 C  CA  . VAL A 1 453 ? -29.792 5.304   93.315  1.00 18.54 ? 475  VAL A CA  1 
+ATOM   3585 C  C   . VAL A 1 453 ? -29.691 3.921   92.690  1.00 18.70 ? 475  VAL A C   1 
+ATOM   3586 O  O   . VAL A 1 453 ? -29.195 2.993   93.320  1.00 20.76 ? 475  VAL A O   1 
+ATOM   3587 C  CB  . VAL A 1 453 ? -28.377 5.870   93.464  1.00 20.75 ? 475  VAL A CB  1 
+ATOM   3588 C  CG1 . VAL A 1 453 ? -27.663 5.867   92.090  1.00 26.02 ? 475  VAL A CG1 1 
+ATOM   3589 C  CG2 . VAL A 1 453 ? -28.408 7.302   94.012  1.00 20.88 ? 475  VAL A CG2 1 
+ATOM   3590 N  N   . TYR A 1 454 ? -30.239 3.763   91.493  1.00 15.85 ? 476  TYR A N   1 
+ATOM   3591 C  CA  . TYR A 1 454 ? -30.350 2.471   90.811  1.00 16.02 ? 476  TYR A CA  1 
+ATOM   3592 C  C   . TYR A 1 454 ? -29.531 2.544   89.540  1.00 17.58 ? 476  TYR A C   1 
+ATOM   3593 O  O   . TYR A 1 454 ? -29.726 3.459   88.743  1.00 20.10 ? 476  TYR A O   1 
+ATOM   3594 C  CB  . TYR A 1 454 ? -31.801 2.193   90.487  1.00 15.24 ? 476  TYR A CB  1 
+ATOM   3595 C  CG  . TYR A 1 454 ? -32.609 2.056   91.754  1.00 15.42 ? 476  TYR A CG  1 
+ATOM   3596 C  CD1 . TYR A 1 454 ? -32.709 0.819   92.377  1.00 16.67 ? 476  TYR A CD1 1 
+ATOM   3597 C  CD2 . TYR A 1 454 ? -33.233 3.123   92.319  1.00 17.05 ? 476  TYR A CD2 1 
+ATOM   3598 C  CE1 . TYR A 1 454 ? -33.439 0.675   93.580  1.00 17.04 ? 476  TYR A CE1 1 
+ATOM   3599 C  CE2 . TYR A 1 454 ? -33.945 2.997   93.523  1.00 14.92 ? 476  TYR A CE2 1 
+ATOM   3600 C  CZ  . TYR A 1 454 ? -34.036 1.746   94.127  1.00 15.01 ? 476  TYR A CZ  1 
+ATOM   3601 O  OH  . TYR A 1 454 ? -34.722 1.611   95.325  1.00 15.94 ? 476  TYR A OH  1 
+ATOM   3602 N  N   . GLU A 1 455 ? -28.675 1.554   89.330  1.00 18.45 ? 477  GLU A N   1 
+ATOM   3603 C  CA  . GLU A 1 455 ? -27.877 1.491   88.110  1.00 20.90 ? 477  GLU A CA  1 
+ATOM   3604 C  C   . GLU A 1 455 ? -28.534 0.518   87.156  1.00 19.19 ? 477  GLU A C   1 
+ATOM   3605 O  O   . GLU A 1 455 ? -28.893 -0.593  87.531  1.00 19.99 ? 477  GLU A O   1 
+ATOM   3606 C  CB  . GLU A 1 455 ? -26.473 0.993   88.393  1.00 23.58 ? 477  GLU A CB  1 
+ATOM   3607 C  CG  . GLU A 1 455 ? -25.533 1.010   87.153  1.00 30.78 ? 477  GLU A CG  1 
+ATOM   3608 C  CD  . GLU A 1 455 ? -24.135 0.416   87.457  1.00 43.69 ? 477  GLU A CD  1 
+ATOM   3609 O  OE1 . GLU A 1 455 ? -24.040 -0.664  88.096  1.00 49.02 ? 477  GLU A OE1 1 
+ATOM   3610 O  OE2 . GLU A 1 455 ? -23.122 1.038   87.082  1.00 48.49 ? 477  GLU A OE2 1 
+ATOM   3611 N  N   . LEU A 1 456 ? -28.611 0.949   85.886  1.00 18.62 ? 478  LEU A N   1 
+ATOM   3612 C  CA  . LEU A 1 456 ? -29.116 0.093   84.805  1.00 18.31 ? 478  LEU A CA  1 
+ATOM   3613 C  C   . LEU A 1 456 ? -28.007 -0.060  83.775  1.00 19.86 ? 478  LEU A C   1 
+ATOM   3614 O  O   . LEU A 1 456 ? -27.347 0.916   83.401  1.00 23.34 ? 478  LEU A O   1 
+ATOM   3615 C  CB  . LEU A 1 456 ? -30.316 0.733   84.108  1.00 21.89 ? 478  LEU A CB  1 
+ATOM   3616 C  CG  . LEU A 1 456 ? -31.546 0.883   84.981  1.00 21.11 ? 478  LEU A CG  1 
+ATOM   3617 C  CD1 . LEU A 1 456 ? -32.651 1.579   84.236  1.00 23.21 ? 478  LEU A CD1 1 
+ATOM   3618 C  CD2 . LEU A 1 456 ? -32.035 -0.431  85.611  1.00 21.85 ? 478  LEU A CD2 1 
+ATOM   3619 N  N   . THR A 1 457 ? -27.778 -1.265  83.322  1.00 20.09 ? 479  THR A N   1 
+ATOM   3620 C  CA  . THR A 1 457 ? -26.797 -1.496  82.246  1.00 20.96 ? 479  THR A CA  1 
+ATOM   3621 C  C   . THR A 1 457 ? -27.587 -1.884  80.996  1.00 20.96 ? 479  THR A C   1 
+ATOM   3622 O  O   . THR A 1 457 ? -28.305 -2.871  80.990  1.00 20.84 ? 479  THR A O   1 
+ATOM   3623 C  CB  . THR A 1 457 ? -25.783 -2.590  82.604  1.00 27.70 ? 479  THR A CB  1 
+ATOM   3624 O  OG1 . THR A 1 457 ? -25.096 -2.158  83.793  1.00 32.19 ? 479  THR A OG1 1 
+ATOM   3625 C  CG2 . THR A 1 457 ? -24.810 -2.821  81.502  1.00 28.74 ? 479  THR A CG2 1 
+ATOM   3626 N  N   . TYR A 1 458 ? -27.454 -1.035  79.981  1.00 19.43 ? 480  TYR A N   1 
+ATOM   3627 C  CA  . TYR A 1 458 ? -28.088 -1.344  78.695  1.00 19.44 ? 480  TYR A CA  1 
+ATOM   3628 C  C   . TYR A 1 458 ? -27.073 -2.050  77.858  1.00 17.86 ? 480  TYR A C   1 
+ATOM   3629 O  O   . TYR A 1 458 ? -25.949 -1.565  77.723  1.00 19.83 ? 480  TYR A O   1 
+ATOM   3630 C  CB  . TYR A 1 458 ? -28.491 -0.077  78.009  1.00 20.13 ? 480  TYR A CB  1 
+ATOM   3631 C  CG  . TYR A 1 458 ? -29.647 0.609   78.712  1.00 19.39 ? 480  TYR A CG  1 
+ATOM   3632 C  CD1 . TYR A 1 458 ? -30.937 0.487   78.254  1.00 19.62 ? 480  TYR A CD1 1 
+ATOM   3633 C  CD2 . TYR A 1 458 ? -29.444 1.357   79.868  1.00 19.65 ? 480  TYR A CD2 1 
+ATOM   3634 C  CE1 . TYR A 1 458 ? -32.003 1.056   78.891  1.00 18.73 ? 480  TYR A CE1 1 
+ATOM   3635 C  CE2 . TYR A 1 458 ? -30.511 1.947   80.509  1.00 18.69 ? 480  TYR A CE2 1 
+ATOM   3636 C  CZ  . TYR A 1 458 ? -31.781 1.834   80.010  1.00 18.24 ? 480  TYR A CZ  1 
+ATOM   3637 O  OH  . TYR A 1 458 ? -32.826 2.481   80.655  1.00 19.90 ? 480  TYR A OH  1 
+ATOM   3638 N  N   . GLN A 1 459 ? -27.488 -3.137  77.216  1.00 18.64 ? 481  GLN A N   1 
+ATOM   3639 C  CA  . GLN A 1 459 ? -26.648 -3.870  76.273  1.00 20.07 ? 481  GLN A CA  1 
+ATOM   3640 C  C   . GLN A 1 459 ? -27.356 -3.916  74.931  1.00 19.10 ? 481  GLN A C   1 
+ATOM   3641 O  O   . GLN A 1 459 ? -28.546 -4.159  74.857  1.00 20.90 ? 481  GLN A O   1 
+ATOM   3642 C  CB  . GLN A 1 459 ? -26.503 -5.297  76.726  1.00 23.97 ? 481  GLN A CB  1 
+ATOM   3643 C  CG  . GLN A 1 459 ? -25.874 -5.361  78.078  1.00 32.41 ? 481  GLN A CG  1 
+ATOM   3644 C  CD  . GLN A 1 459 ? -24.527 -5.722  77.838  1.00 41.14 ? 481  GLN A CD  1 
+ATOM   3645 O  OE1 . GLN A 1 459 ? -23.811 -4.940  77.191  1.00 44.52 ? 481  GLN A OE1 1 
+ATOM   3646 N  NE2 . GLN A 1 459 ? -24.206 -6.996  78.068  1.00 42.87 ? 481  GLN A NE2 1 
+ATOM   3647 N  N   . LEU A 1 460 ? -26.588 -3.637  73.904  1.00 19.82 ? 482  LEU A N   1 
+ATOM   3648 C  CA  . LEU A 1 460 ? -27.081 -3.755  72.528  1.00 20.32 ? 482  LEU A CA  1 
+ATOM   3649 C  C   . LEU A 1 460 ? -26.324 -4.857  71.811  1.00 18.59 ? 482  LEU A C   1 
+ATOM   3650 O  O   . LEU A 1 460 ? -25.082 -4.874  71.854  1.00 21.00 ? 482  LEU A O   1 
+ATOM   3651 C  CB  . LEU A 1 460 ? -26.893 -2.422  71.825  1.00 19.56 ? 482  LEU A CB  1 
+ATOM   3652 C  CG  . LEU A 1 460 ? -27.183 -2.608  70.332  1.00 20.25 ? 482  LEU A CG  1 
+ATOM   3653 C  CD1 . LEU A 1 460 ? -28.623 -2.916  69.966  1.00 22.61 ? 482  LEU A CD1 1 
+ATOM   3654 C  CD2 . LEU A 1 460 ? -26.709 -1.285  69.636  1.00 21.89 ? 482  LEU A CD2 1 
+ATOM   3655 N  N   . PHE A 1 461 ? -27.060 -5.788  71.210  1.00 20.65 ? 483  PHE A N   1 
+ATOM   3656 C  CA  . PHE A 1 461 ? -26.442 -6.875  70.445  1.00 20.67 ? 483  PHE A CA  1 
+ATOM   3657 C  C   . PHE A 1 461 ? -26.789 -6.684  68.998  1.00 23.19 ? 483  PHE A C   1 
+ATOM   3658 O  O   . PHE A 1 461 ? -27.911 -6.291  68.663  1.00 22.82 ? 483  PHE A O   1 
+ATOM   3659 C  CB  . PHE A 1 461 ? -26.987 -8.217  70.950  1.00 21.22 ? 483  PHE A CB  1 
+ATOM   3660 C  CG  . PHE A 1 461 ? -26.735 -8.410  72.407  1.00 21.94 ? 483  PHE A CG  1 
+ATOM   3661 C  CD1 . PHE A 1 461 ? -25.539 -8.894  72.825  1.00 25.38 ? 483  PHE A CD1 1 
+ATOM   3662 C  CD2 . PHE A 1 461 ? -27.688 -8.061  73.384  1.00 23.23 ? 483  PHE A CD2 1 
+ATOM   3663 C  CE1 . PHE A 1 461 ? -25.282 -9.022  74.201  1.00 24.47 ? 483  PHE A CE1 1 
+ATOM   3664 C  CE2 . PHE A 1 461 ? -27.431 -8.176  74.733  1.00 23.16 ? 483  PHE A CE2 1 
+ATOM   3665 C  CZ  . PHE A 1 461 ? -26.227 -8.662  75.144  1.00 23.12 ? 483  PHE A CZ  1 
+ATOM   3666 N  N   . TYR A 1 462 ? -25.794 -6.887  68.144  1.00 21.06 ? 484  TYR A N   1 
+ATOM   3667 C  CA  . TYR A 1 462 ? -26.000 -6.540  66.743  1.00 22.99 ? 484  TYR A CA  1 
+ATOM   3668 C  C   . TYR A 1 462 ? -24.995 -7.258  65.873  1.00 24.00 ? 484  TYR A C   1 
+ATOM   3669 O  O   . TYR A 1 462 ? -24.182 -8.082  66.326  1.00 23.97 ? 484  TYR A O   1 
+ATOM   3670 C  CB  . TYR A 1 462 ? -25.841 -5.012  66.567  1.00 24.46 ? 484  TYR A CB  1 
+ATOM   3671 C  CG  . TYR A 1 462 ? -24.422 -4.504  66.802  1.00 25.65 ? 484  TYR A CG  1 
+ATOM   3672 C  CD1 . TYR A 1 462 ? -23.576 -4.253  65.736  1.00 27.86 ? 484  TYR A CD1 1 
+ATOM   3673 C  CD2 . TYR A 1 462 ? -23.925 -4.284  68.111  1.00 26.99 ? 484  TYR A CD2 1 
+ATOM   3674 C  CE1 . TYR A 1 462 ? -22.270 -3.821  65.943  1.00 27.50 ? 484  TYR A CE1 1 
+ATOM   3675 C  CE2 . TYR A 1 462 ? -22.617 -3.846  68.340  1.00 28.54 ? 484  TYR A CE2 1 
+ATOM   3676 C  CZ  . TYR A 1 462 ? -21.798 -3.627  67.208  1.00 29.26 ? 484  TYR A CZ  1 
+ATOM   3677 O  OH  . TYR A 1 462 ? -20.501 -3.219  67.329  1.00 32.71 ? 484  TYR A OH  1 
+ATOM   3678 N  N   . GLY A 1 463 ? -25.038 -6.919  64.569  1.00 25.79 ? 485  GLY A N   1 
+ATOM   3679 C  CA  . GLY A 1 463 ? -24.156 -7.579  63.659  1.00 27.08 ? 485  GLY A CA  1 
+ATOM   3680 C  C   . GLY A 1 463 ? -24.667 -8.974  63.365  1.00 28.71 ? 485  GLY A C   1 
+ATOM   3681 O  O   . GLY A 1 463 ? -25.831 -9.394  63.713  1.00 26.63 ? 485  GLY A O   1 
+ATOM   3682 N  N   . GLN A 1 464 ? -23.793 -9.711  62.666  1.00 26.92 ? 486  GLN A N   1 
+ATOM   3683 C  CA  . GLN A 1 464 ? -24.131 -11.045 62.232  1.00 28.41 ? 486  GLN A CA  1 
+ATOM   3684 C  C   . GLN A 1 464 ? -24.396 -11.922 63.456  1.00 27.91 ? 486  GLN A C   1 
+ATOM   3685 O  O   . GLN A 1 464 ? -23.554 -12.074 64.351  1.00 28.95 ? 486  GLN A O   1 
+ATOM   3686 C  CB  . GLN A 1 464 ? -22.976 -11.606 61.422  1.00 32.35 ? 486  GLN A CB  1 
+ATOM   3687 C  CG  . GLN A 1 464 ? -23.331 -12.770 60.586  1.00 38.43 ? 486  GLN A CG  1 
+ATOM   3688 C  CD  . GLN A 1 464 ? -22.350 -12.948 59.444  1.00 41.79 ? 486  GLN A CD  1 
+ATOM   3689 O  OE1 . GLN A 1 464 ? -21.854 -11.970 58.834  1.00 42.83 ? 486  GLN A OE1 1 
+ATOM   3690 N  NE2 . GLN A 1 464 ? -22.060 -14.204 59.127  1.00 44.96 ? 486  GLN A NE2 1 
+ATOM   3691 N  N   . ASP A 1 465 ? -25.575 -12.533 63.454  1.00 26.30 ? 487  ASP A N   1 
+ATOM   3692 C  CA  . ASP A 1 465 ? -26.027 -13.421 64.520  1.00 24.36 ? 487  ASP A CA  1 
+ATOM   3693 C  C   . ASP A 1 465 ? -26.025 -12.729 65.899  1.00 23.41 ? 487  ASP A C   1 
+ATOM   3694 O  O   . ASP A 1 465 ? -26.036 -13.415 66.918  1.00 22.91 ? 487  ASP A O   1 
+ATOM   3695 C  CB  . ASP A 1 465 ? -25.197 -14.707 64.619  1.00 25.90 ? 487  ASP A CB  1 
+ATOM   3696 C  CG  . ASP A 1 465 ? -25.126 -15.454 63.298  1.00 27.09 ? 487  ASP A CG  1 
+ATOM   3697 O  OD1 . ASP A 1 465 ? -26.203 -15.871 62.799  1.00 28.12 ? 487  ASP A OD1 1 
+ATOM   3698 O  OD2 . ASP A 1 465 ? -24.003 -15.637 62.727  1.00 29.56 ? 487  ASP A OD2 1 
+ATOM   3699 N  N   . ASN A 1 466 ? -26.109 -11.402 65.895  1.00 23.66 ? 488  ASN A N   1 
+ATOM   3700 C  CA  . ASN A 1 466 ? -26.131 -10.646 67.145  1.00 22.38 ? 488  ASN A CA  1 
+ATOM   3701 C  C   . ASN A 1 466 ? -24.965 -10.980 68.050  1.00 23.49 ? 488  ASN A C   1 
+ATOM   3702 O  O   . ASN A 1 466 ? -25.079 -10.892 69.298  1.00 23.39 ? 488  ASN A O   1 
+ATOM   3703 C  CB  . ASN A 1 466 ? -27.501 -10.811 67.800  1.00 22.77 ? 488  ASN A CB  1 
+ATOM   3704 C  CG  . ASN A 1 466 ? -28.586 -10.001 67.053  1.00 24.66 ? 488  ASN A CG  1 
+ATOM   3705 O  OD1 . ASN A 1 466 ? -28.303 -8.979  66.429  1.00 24.42 ? 488  ASN A OD1 1 
+ATOM   3706 N  ND2 . ASN A 1 466 ? -29.772 -10.519 67.007  1.00 24.49 ? 488  ASN A ND2 1 
+ATOM   3707 N  N   . GLN A 1 467 ? -23.806 -11.270 67.441  1.00 25.18 ? 489  GLN A N   1 
+ATOM   3708 C  CA  . GLN A 1 467 ? -22.593 -11.591 68.240  1.00 29.05 ? 489  GLN A CA  1 
+ATOM   3709 C  C   . GLN A 1 467 ? -21.663 -10.405 68.523  1.00 30.37 ? 489  GLN A C   1 
+ATOM   3710 O  O   . GLN A 1 467 ? -20.641 -10.540 69.194  1.00 32.44 ? 489  GLN A O   1 
+ATOM   3711 C  CB  . GLN A 1 467 ? -21.836 -12.740 67.607  1.00 31.69 ? 489  GLN A CB  1 
+ATOM   3712 C  CG  . GLN A 1 467 ? -22.637 -14.061 67.641  1.00 33.02 ? 489  GLN A CG  1 
+ATOM   3713 C  CD  . GLN A 1 467 ? -23.177 -14.435 69.071  1.00 36.31 ? 489  GLN A CD  1 
+ATOM   3714 O  OE1 . GLN A 1 467 ? -22.417 -14.527 70.052  1.00 39.14 ? 489  GLN A OE1 1 
+ATOM   3715 N  NE2 . GLN A 1 467 ? -24.501 -14.642 69.178  1.00 37.92 ? 489  GLN A NE2 1 
+ATOM   3716 N  N   . GLN A 1 468 ? -22.034 -9.233  68.073  1.00 28.23 ? 490  GLN A N   1 
+ATOM   3717 C  CA  A GLN A 1 468 ? -21.355 -8.013  68.510  0.44 27.65 ? 490  GLN A CA  1 
+ATOM   3718 C  CA  B GLN A 1 468 ? -21.352 -8.018  68.524  0.56 26.42 ? 490  GLN A CA  1 
+ATOM   3719 C  C   . GLN A 1 468 ? -22.181 -7.332  69.600  1.00 26.24 ? 490  GLN A C   1 
+ATOM   3720 O  O   . GLN A 1 468 ? -23.419 -7.432  69.607  1.00 24.91 ? 490  GLN A O   1 
+ATOM   3721 C  CB  A GLN A 1 468 ? -21.149 -7.067  67.328  0.44 29.42 ? 490  GLN A CB  1 
+ATOM   3722 C  CB  B GLN A 1 468 ? -21.103 -7.071  67.351  0.56 26.93 ? 490  GLN A CB  1 
+ATOM   3723 C  CG  A GLN A 1 468 ? -20.375 -7.695  66.161  0.44 31.89 ? 490  GLN A CG  1 
+ATOM   3724 C  CG  B GLN A 1 468 ? -20.203 -7.672  66.259  0.56 29.29 ? 490  GLN A CG  1 
+ATOM   3725 C  CD  A GLN A 1 468 ? -18.892 -7.422  66.213  0.44 34.18 ? 490  GLN A CD  1 
+ATOM   3726 C  CD  B GLN A 1 468 ? -19.953 -6.705  65.131  0.56 31.86 ? 490  GLN A CD  1 
+ATOM   3727 O  OE1 A GLN A 1 468 ? -18.182 -7.935  67.067  0.44 35.80 ? 490  GLN A OE1 1 
+ATOM   3728 O  OE1 B GLN A 1 468 ? -20.475 -6.861  64.025  0.56 33.70 ? 490  GLN A OE1 1 
+ATOM   3729 N  NE2 A GLN A 1 468 ? -18.413 -6.606  65.286  0.44 35.80 ? 490  GLN A NE2 1 
+ATOM   3730 N  NE2 B GLN A 1 468 ? -19.145 -5.688  65.410  0.56 34.60 ? 490  GLN A NE2 1 
+ATOM   3731 N  N   . ASN A 1 469 ? -21.501 -6.628  70.508  1.00 25.41 ? 491  ASN A N   1 
+ATOM   3732 C  CA  A ASN A 1 469 ? -22.177 -6.039  71.620  0.49 25.67 ? 491  ASN A CA  1 
+ATOM   3733 C  CA  B ASN A 1 469 ? -22.134 -6.073  71.680  0.51 25.43 ? 491  ASN A CA  1 
+ATOM   3734 C  C   . ASN A 1 469 ? -21.554 -4.697  72.013  1.00 23.85 ? 491  ASN A C   1 
+ATOM   3735 O  O   . ASN A 1 469 ? -20.397 -4.445  71.751  1.00 26.55 ? 491  ASN A O   1 
+ATOM   3736 C  CB  A ASN A 1 469 ? -22.136 -7.034  72.784  0.49 28.84 ? 491  ASN A CB  1 
+ATOM   3737 C  CB  B ASN A 1 469 ? -21.936 -7.074  72.851  0.51 27.96 ? 491  ASN A CB  1 
+ATOM   3738 C  CG  A ASN A 1 469 ? -20.979 -6.778  73.736  0.49 31.61 ? 491  ASN A CG  1 
+ATOM   3739 C  CG  B ASN A 1 469 ? -22.223 -6.459  74.257  0.51 29.22 ? 491  ASN A CG  1 
+ATOM   3740 O  OD1 A ASN A 1 469 ? -20.908 -5.724  74.379  0.49 35.07 ? 491  ASN A OD1 1 
+ATOM   3741 O  OD1 B ASN A 1 469 ? -21.311 -6.232  75.084  0.51 33.49 ? 491  ASN A OD1 1 
+ATOM   3742 N  ND2 A ASN A 1 469 ? -20.093 -7.747  73.866  0.49 31.77 ? 491  ASN A ND2 1 
+ATOM   3743 N  ND2 B ASN A 1 469 ? -23.493 -6.208  74.530  0.51 26.80 ? 491  ASN A ND2 1 
+ATOM   3744 N  N   . MET A 1 470 ? -22.368 -3.826  72.587  1.00 23.39 ? 492  MET A N   1 
+ATOM   3745 C  CA  . MET A 1 470 ? -21.877 -2.601  73.197  1.00 22.20 ? 492  MET A CA  1 
+ATOM   3746 C  C   . MET A 1 470 ? -22.775 -2.300  74.391  1.00 21.93 ? 492  MET A C   1 
+ATOM   3747 O  O   . MET A 1 470 ? -23.954 -2.694  74.446  1.00 22.75 ? 492  MET A O   1 
+ATOM   3748 C  CB  . MET A 1 470 ? -21.904 -1.461  72.236  1.00 23.85 ? 492  MET A CB  1 
+ATOM   3749 C  CG  . MET A 1 470 ? -23.225 -1.144  71.608  1.00 25.86 ? 492  MET A CG  1 
+ATOM   3750 S  SD  . MET A 1 470 ? -23.081 0.156   70.309  1.00 28.73 ? 492  MET A SD  1 
+ATOM   3751 C  CE  . MET A 1 470 ? -22.806 1.609   71.232  1.00 29.36 ? 492  MET A CE  1 
+ATOM   3752 N  N   . THR A 1 471 ? -22.183 -1.632  75.370  1.00 21.40 ? 493  THR A N   1 
+ATOM   3753 C  CA  . THR A 1 471 ? -22.826 -1.413  76.645  1.00 21.22 ? 493  THR A CA  1 
+ATOM   3754 C  C   . THR A 1 471 ? -22.832 0.060   77.018  1.00 22.27 ? 493  THR A C   1 
+ATOM   3755 O  O   . THR A 1 471 ? -21.879 0.843   76.689  1.00 24.40 ? 493  THR A O   1 
+ATOM   3756 C  CB  . THR A 1 471 ? -22.010 -2.159  77.742  1.00 26.83 ? 493  THR A CB  1 
+ATOM   3757 O  OG1 . THR A 1 471 ? -21.819 -3.519  77.325  1.00 30.03 ? 493  THR A OG1 1 
+ATOM   3758 C  CG2 . THR A 1 471 ? -22.717 -2.190  79.053  1.00 25.48 ? 493  THR A CG2 1 
+ATOM   3759 N  N   . ASP A 1 472 ? -23.871 0.443   77.738  1.00 20.83 ? 494  ASP A N   1 
+ATOM   3760 C  CA  . ASP A 1 472 ? -23.892 1.804   78.298  1.00 24.02 ? 494  ASP A CA  1 
+ATOM   3761 C  C   . ASP A 1 472 ? -24.631 1.705   79.668  1.00 24.67 ? 494  ASP A C   1 
+ATOM   3762 O  O   . ASP A 1 472 ? -25.590 0.939   79.805  1.00 26.73 ? 494  ASP A O   1 
+ATOM   3763 C  CB  . ASP A 1 472 ? -24.600 2.760   77.362  1.00 30.36 ? 494  ASP A CB  1 
+ATOM   3764 C  CG  . ASP A 1 472 ? -24.228 4.202   77.565  1.00 40.26 ? 494  ASP A CG  1 
+ATOM   3765 O  OD1 . ASP A 1 472 ? -23.574 4.569   78.569  1.00 39.11 ? 494  ASP A OD1 1 
+ATOM   3766 O  OD2 . ASP A 1 472 ? -24.624 4.976   76.650  1.00 47.12 ? 494  ASP A OD2 1 
+ATOM   3767 N  N   . LYS A 1 473 ? -24.213 2.537   80.601  1.00 21.14 ? 495  LYS A N   1 
+ATOM   3768 C  CA  . LYS A 1 473 ? -24.804 2.549   81.945  1.00 22.37 ? 495  LYS A CA  1 
+ATOM   3769 C  C   . LYS A 1 473 ? -25.652 3.813   82.165  1.00 23.46 ? 495  LYS A C   1 
+ATOM   3770 O  O   . LYS A 1 473 ? -25.412 4.876   81.536  1.00 25.00 ? 495  LYS A O   1 
+ATOM   3771 C  CB  . LYS A 1 473 ? -23.695 2.433   82.993  1.00 28.70 ? 495  LYS A CB  1 
+ATOM   3772 C  CG  . LYS A 1 473 ? -23.126 0.998   83.038  1.00 34.95 ? 495  LYS A CG  1 
+ATOM   3773 C  CD  . LYS A 1 473 ? -22.099 0.786   84.114  1.00 41.82 ? 495  LYS A CD  1 
+ATOM   3774 C  CE  . LYS A 1 473 ? -21.632 -0.709  84.255  1.00 46.45 ? 495  LYS A CE  1 
+ATOM   3775 N  NZ  . LYS A 1 473 ? -21.365 -1.300  82.939  1.00 49.19 ? 495  LYS A NZ  1 
+ATOM   3776 N  N   . ARG A 1 474 ? -26.700 3.671   82.960  1.00 20.21 ? 496  ARG A N   1 
+ATOM   3777 C  CA  . ARG A 1 474 ? -27.581 4.788   83.300  1.00 20.50 ? 496  ARG A CA  1 
+ATOM   3778 C  C   . ARG A 1 474 ? -27.845 4.750   84.796  1.00 20.58 ? 496  ARG A C   1 
+ATOM   3779 O  O   . ARG A 1 474 ? -28.024 3.670   85.347  1.00 20.01 ? 496  ARG A O   1 
+ATOM   3780 C  CB  . ARG A 1 474 ? -28.917 4.586   82.588  1.00 22.68 ? 496  ARG A CB  1 
+ATOM   3781 C  CG  . ARG A 1 474 ? -29.840 5.721   82.611  1.00 24.32 ? 496  ARG A CG  1 
+ATOM   3782 C  CD  . ARG A 1 474 ? -31.140 5.374   81.902  1.00 22.35 ? 496  ARG A CD  1 
+ATOM   3783 N  NE  . ARG A 1 474 ? -31.996 6.510   81.751  1.00 22.13 ? 496  ARG A NE  1 
+ATOM   3784 C  CZ  . ARG A 1 474 ? -33.217 6.451   81.237  1.00 22.73 ? 496  ARG A CZ  1 
+ATOM   3785 N  NH1 . ARG A 1 474 ? -33.718 5.282   80.843  1.00 20.87 ? 496  ARG A NH1 1 
+ATOM   3786 N  NH2 . ARG A 1 474 ? -33.905 7.572   81.042  1.00 26.00 ? 496  ARG A NH2 1 
+ATOM   3787 N  N   . ILE A 1 475 ? -27.846 5.924   85.406  1.00 19.77 ? 497  ILE A N   1 
+ATOM   3788 C  CA  . ILE A 1 475 ? -28.156 6.056   86.831  1.00 20.64 ? 497  ILE A CA  1 
+ATOM   3789 C  C   . ILE A 1 475 ? -29.512 6.653   86.984  1.00 19.84 ? 497  ILE A C   1 
+ATOM   3790 O  O   . ILE A 1 475 ? -29.787 7.752   86.431  1.00 21.25 ? 497  ILE A O   1 
+ATOM   3791 C  CB  . ILE A 1 475 ? -27.103 6.939   87.546  1.00 23.15 ? 497  ILE A CB  1 
+ATOM   3792 C  CG1 . ILE A 1 475 ? -25.733 6.325   87.272  1.00 27.76 ? 497  ILE A CG1 1 
+ATOM   3793 C  CG2 . ILE A 1 475 ? -27.343 6.938   89.033  1.00 23.71 ? 497  ILE A CG2 1 
+ATOM   3794 C  CD1 . ILE A 1 475 ? -25.533 5.105   88.104  1.00 33.92 ? 497  ILE A CD1 1 
+ATOM   3795 N  N   . VAL A 1 476 ? -30.391 5.935   87.669  1.00 17.30 ? 498  VAL A N   1 
+ATOM   3796 C  CA  . VAL A 1 476 ? -31.723 6.455   87.928  1.00 19.99 ? 498  VAL A CA  1 
+ATOM   3797 C  C   . VAL A 1 476 ? -31.885 6.702   89.426  1.00 20.70 ? 498  VAL A C   1 
+ATOM   3798 O  O   . VAL A 1 476 ? -31.766 5.774   90.227  1.00 18.46 ? 498  VAL A O   1 
+ATOM   3799 C  CB  . VAL A 1 476 ? -32.807 5.535   87.406  1.00 20.53 ? 498  VAL A CB  1 
+ATOM   3800 C  CG1 . VAL A 1 476 ? -34.204 6.072   87.738  1.00 21.17 ? 498  VAL A CG1 1 
+ATOM   3801 C  CG2 . VAL A 1 476 ? -32.617 5.248   85.891  1.00 21.18 ? 498  VAL A CG2 1 
+ATOM   3802 N  N   . THR A 1 477 ? -32.125 7.957   89.792  1.00 20.53 ? 499  THR A N   1 
+ATOM   3803 C  CA  . THR A 1 477 ? -32.207 8.334   91.210  1.00 20.69 ? 499  THR A CA  1 
+ATOM   3804 C  C   . THR A 1 477 ? -33.657 8.567   91.557  1.00 20.39 ? 499  THR A C   1 
+ATOM   3805 O  O   . THR A 1 477 ? -34.352 9.303   90.860  1.00 23.63 ? 499  THR A O   1 
+ATOM   3806 C  CB  . THR A 1 477 ? -31.420 9.635   91.469  1.00 20.37 ? 499  THR A CB  1 
+ATOM   3807 O  OG1 . THR A 1 477 ? -30.055 9.467   91.106  1.00 20.65 ? 499  THR A OG1 1 
+ATOM   3808 C  CG2 . THR A 1 477 ? -31.456 10.022  92.940  1.00 22.58 ? 499  THR A CG2 1 
+ATOM   3809 N  N   . VAL A 1 478 ? -34.128 7.889   92.610  1.00 19.02 ? 500  VAL A N   1 
+ATOM   3810 C  CA  . VAL A 1 478 ? -35.503 8.017   93.107  1.00 19.69 ? 500  VAL A CA  1 
+ATOM   3811 C  C   . VAL A 1 478 ? -35.458 8.927   94.317  1.00 21.51 ? 500  VAL A C   1 
+ATOM   3812 O  O   . VAL A 1 478 ? -34.734 8.629   95.284  1.00 18.82 ? 500  VAL A O   1 
+ATOM   3813 C  CB  . VAL A 1 478 ? -36.053 6.653   93.467  1.00 19.21 ? 500  VAL A CB  1 
+ATOM   3814 C  CG1 . VAL A 1 478 ? -37.440 6.761   94.105  1.00 20.25 ? 500  VAL A CG1 1 
+ATOM   3815 C  CG2 . VAL A 1 478 ? -36.135 5.777   92.232  1.00 18.24 ? 500  VAL A CG2 1 
+ATOM   3816 N  N   . VAL A 1 479 ? -36.219 10.010  94.281  1.00 23.55 ? 501  VAL A N   1 
+ATOM   3817 C  CA  . VAL A 1 479 ? -36.200 10.988  95.389  1.00 24.69 ? 501  VAL A CA  1 
+ATOM   3818 C  C   . VAL A 1 479 ? -37.584 11.184  95.982  1.00 25.23 ? 501  VAL A C   1 
+ATOM   3819 O  O   . VAL A 1 479 ? -38.612 11.033  95.298  1.00 26.83 ? 501  VAL A O   1 
+ATOM   3820 C  CB  . VAL A 1 479 ? -35.673 12.322  94.935  1.00 29.11 ? 501  VAL A CB  1 
+ATOM   3821 C  CG1 . VAL A 1 479 ? -34.278 12.154  94.394  1.00 31.12 ? 501  VAL A CG1 1 
+ATOM   3822 C  CG2 . VAL A 1 479 ? -36.603 12.918  93.859  1.00 27.35 ? 501  VAL A CG2 1 
+ATOM   3823 N  N   . THR A 1 480 ? -37.632 11.519  97.274  1.00 26.82 ? 502  THR A N   1 
+ATOM   3824 C  CA  . THR A 1 480 ? -38.906 11.605  97.884  1.00 33.92 ? 502  THR A CA  1 
+ATOM   3825 C  C   . THR A 1 480 ? -39.505 12.926  97.461  1.00 38.50 ? 502  THR A C   1 
+ATOM   3826 O  O   . THR A 1 480 ? -38.786 13.826  97.034  1.00 36.82 ? 502  THR A O   1 
+ATOM   3827 C  CB  . THR A 1 480 ? -38.821 11.520  99.439  1.00 39.18 ? 502  THR A CB  1 
+ATOM   3828 O  OG1 . THR A 1 480 ? -40.147 11.620  99.945  1.00 43.05 ? 502  THR A OG1 1 
+ATOM   3829 C  CG2 . THR A 1 480 ? -37.973 12.631  99.994  1.00 39.43 ? 502  THR A CG2 1 
+ATOM   3830 N  N   . ASP A 1 481 ? -40.826 13.014  97.549  1.00 44.95 ? 503  ASP A N   1 
+ATOM   3831 C  CA  . ASP A 1 481 ? -41.550 14.288  97.451  1.00 50.57 ? 503  ASP A CA  1 
+ATOM   3832 C  C   . ASP A 1 481 ? -41.702 14.926  98.845  1.00 52.02 ? 503  ASP A C   1 
+ATOM   3833 O  O   . ASP A 1 481 ? -42.123 16.083  98.969  1.00 53.89 ? 503  ASP A O   1 
+ATOM   3834 C  CB  . ASP A 1 481 ? -42.922 14.068  96.785  1.00 54.72 ? 503  ASP A CB  1 
+ATOM   3835 C  CG  . ASP A 1 481 ? -43.743 12.916  97.443  1.00 58.74 ? 503  ASP A CG  1 
+ATOM   3836 O  OD1 . ASP A 1 481 ? -43.361 12.373  98.506  1.00 59.84 ? 503  ASP A OD1 1 
+ATOM   3837 O  OD2 . ASP A 1 481 ? -44.796 12.551  96.887  1.00 61.09 ? 503  ASP A OD2 1 
+ATOM   3838 N  N   . ALA A 1 482 ? -41.336 14.181  99.900  1.00 51.85 ? 504  ALA A N   1 
+ATOM   3839 C  CA  . ALA A 1 482 ? -41.532 14.635  101.284 1.00 52.83 ? 504  ALA A CA  1 
+ATOM   3840 C  C   . ALA A 1 482 ? -40.813 15.947  101.540 1.00 53.21 ? 504  ALA A C   1 
+ATOM   3841 O  O   . ALA A 1 482 ? -39.665 16.153  101.109 1.00 52.08 ? 504  ALA A O   1 
+ATOM   3842 C  CB  . ALA A 1 482 ? -41.056 13.579  102.273 1.00 53.42 ? 504  ALA A CB  1 
+ATOM   3843 N  N   . VAL A 1 483 ? -41.492 16.821  102.278 1.00 54.15 ? 505  VAL A N   1 
+ATOM   3844 C  CA  . VAL A 1 483 ? -40.911 18.083  102.665 1.00 54.97 ? 505  VAL A CA  1 
+ATOM   3845 C  C   . VAL A 1 483 ? -40.077 17.855  103.895 1.00 54.44 ? 505  VAL A C   1 
+ATOM   3846 O  O   . VAL A 1 483 ? -40.522 17.220  104.870 1.00 56.57 ? 505  VAL A O   1 
+ATOM   3847 C  CB  . VAL A 1 483 ? -41.965 19.156  103.003 1.00 57.49 ? 505  VAL A CB  1 
+ATOM   3848 C  CG1 . VAL A 1 483 ? -42.689 19.585  101.757 1.00 57.94 ? 505  VAL A CG1 1 
+ATOM   3849 C  CG2 . VAL A 1 483 ? -42.937 18.661  104.130 1.00 59.49 ? 505  VAL A CG2 1 
+ATOM   3850 N  N   . SER A 1 484 ? -38.860 18.379  103.829 1.00 52.07 ? 506  SER A N   1 
+ATOM   3851 C  CA  . SER A 1 484 ? -37.869 18.228  104.875 1.00 50.51 ? 506  SER A CA  1 
+ATOM   3852 C  C   . SER A 1 484 ? -37.505 19.586  105.457 1.00 46.01 ? 506  SER A C   1 
+ATOM   3853 O  O   . SER A 1 484 ? -37.786 20.619  104.847 1.00 43.58 ? 506  SER A O   1 
+ATOM   3854 C  CB  . SER A 1 484 ? -36.609 17.538  104.307 1.00 53.50 ? 506  SER A CB  1 
+ATOM   3855 O  OG  . SER A 1 484 ? -35.877 16.918  105.373 1.00 56.15 ? 506  SER A OG  1 
+ATOM   3856 N  N   . ASP A 1 485 ? -36.887 19.577  106.638 1.00 44.31 ? 507  ASP A N   1 
+ATOM   3857 C  CA  . ASP A 1 485 ? -36.325 20.801  107.191 1.00 44.16 ? 507  ASP A CA  1 
+ATOM   3858 C  C   . ASP A 1 485 ? -35.234 21.293  106.248 1.00 41.07 ? 507  ASP A C   1 
+ATOM   3859 O  O   . ASP A 1 485 ? -34.590 20.508  105.543 1.00 40.86 ? 507  ASP A O   1 
+ATOM   3860 C  CB  . ASP A 1 485 ? -35.794 20.574  108.604 1.00 47.02 ? 507  ASP A CB  1 
+ATOM   3861 C  CG  . ASP A 1 485 ? -36.891 20.113  109.568 1.00 50.56 ? 507  ASP A CG  1 
+ATOM   3862 O  OD1 . ASP A 1 485 ? -37.701 20.976  109.982 1.00 51.81 ? 507  ASP A OD1 1 
+ATOM   3863 O  OD2 . ASP A 1 485 ? -36.945 18.904  109.904 1.00 51.36 ? 507  ASP A OD2 1 
+ATOM   3864 N  N   . ASP A 1 486 ? -35.080 22.605  106.177 1.00 38.66 ? 508  ASP A N   1 
+ATOM   3865 C  CA  . ASP A 1 486 ? -34.184 23.176  105.221 1.00 38.79 ? 508  ASP A CA  1 
+ATOM   3866 C  C   . ASP A 1 486 ? -32.709 22.748  105.549 1.00 34.36 ? 508  ASP A C   1 
+ATOM   3867 O  O   . ASP A 1 486 ? -32.359 22.471  106.710 1.00 32.40 ? 508  ASP A O   1 
+ATOM   3868 C  CB  . ASP A 1 486 ? -34.460 24.694  105.115 1.00 44.78 ? 508  ASP A CB  1 
+ATOM   3869 C  CG  . ASP A 1 486 ? -35.609 25.026  104.107 1.00 49.68 ? 508  ASP A CG  1 
+ATOM   3870 O  OD1 . ASP A 1 486 ? -35.679 24.371  103.011 1.00 55.77 ? 508  ASP A OD1 1 
+ATOM   3871 O  OD2 . ASP A 1 486 ? -36.402 25.974  104.377 1.00 47.37 ? 508  ASP A OD2 1 
+ATOM   3872 N  N   . ASP A 1 487 ? -31.897 22.570  104.494 1.00 32.86 ? 509  ASP A N   1 
+ATOM   3873 C  CA  . ASP A 1 487 ? -30.516 22.127  104.668 1.00 32.51 ? 509  ASP A CA  1 
+ATOM   3874 C  C   . ASP A 1 487 ? -29.772 23.106  105.569 1.00 29.95 ? 509  ASP A C   1 
+ATOM   3875 O  O   . ASP A 1 487 ? -29.938 24.328  105.478 1.00 29.96 ? 509  ASP A O   1 
+ATOM   3876 C  CB  . ASP A 1 487 ? -29.780 21.995  103.340 1.00 35.77 ? 509  ASP A CB  1 
+ATOM   3877 C  CG  . ASP A 1 487 ? -30.398 20.989  102.441 1.00 41.18 ? 509  ASP A CG  1 
+ATOM   3878 O  OD1 . ASP A 1 487 ? -31.012 20.022  102.907 1.00 42.50 ? 509  ASP A OD1 1 
+ATOM   3879 O  OD2 . ASP A 1 487 ? -30.273 21.168  101.222 1.00 47.02 ? 509  ASP A OD2 1 
+ATOM   3880 N  N   . TRP A 1 488 ? -28.928 22.571  106.439 1.00 28.60 ? 510  TRP A N   1 
+ATOM   3881 C  CA  . TRP A 1 488 ? -27.978 23.399  107.197 1.00 28.43 ? 510  TRP A CA  1 
+ATOM   3882 C  C   . TRP A 1 488 ? -27.050 24.170  106.271 1.00 28.74 ? 510  TRP A C   1 
+ATOM   3883 O  O   . TRP A 1 488 ? -26.595 23.631  105.225 1.00 31.23 ? 510  TRP A O   1 
+ATOM   3884 C  CB  . TRP A 1 488 ? -27.142 22.500  108.107 1.00 28.79 ? 510  TRP A CB  1 
+ATOM   3885 C  CG  . TRP A 1 488 ? -26.030 23.202  108.844 1.00 28.51 ? 510  TRP A CG  1 
+ATOM   3886 C  CD1 . TRP A 1 488 ? -26.137 23.922  110.007 1.00 28.91 ? 510  TRP A CD1 1 
+ATOM   3887 C  CD2 . TRP A 1 488 ? -24.626 23.272  108.470 1.00 28.65 ? 510  TRP A CD2 1 
+ATOM   3888 N  NE1 . TRP A 1 488 ? -24.911 24.402  110.371 1.00 28.72 ? 510  TRP A NE1 1 
+ATOM   3889 C  CE2 . TRP A 1 488 ? -23.967 24.008  109.470 1.00 28.35 ? 510  TRP A CE2 1 
+ATOM   3890 C  CE3 . TRP A 1 488 ? -23.863 22.751  107.400 1.00 28.66 ? 510  TRP A CE3 1 
+ATOM   3891 C  CZ2 . TRP A 1 488 ? -22.600 24.270  109.438 1.00 27.86 ? 510  TRP A CZ2 1 
+ATOM   3892 C  CZ3 . TRP A 1 488 ? -22.477 22.995  107.390 1.00 27.90 ? 510  TRP A CZ3 1 
+ATOM   3893 C  CH2 . TRP A 1 488 ? -21.872 23.720  108.438 1.00 29.54 ? 510  TRP A CH2 1 
+ATOM   3894 N  N   . GLN A 1 489 ? -26.793 25.438  106.616 1.00 30.35 ? 511  GLN A N   1 
+ATOM   3895 C  CA  . GLN A 1 489 ? -25.796 26.252  105.872 1.00 33.18 ? 511  GLN A CA  1 
+ATOM   3896 C  C   . GLN A 1 489 ? -24.788 26.822  106.821 1.00 33.30 ? 511  GLN A C   1 
+ATOM   3897 O  O   . GLN A 1 489 ? -25.156 27.345  107.881 1.00 33.73 ? 511  GLN A O   1 
+ATOM   3898 C  CB  . GLN A 1 489 ? -26.401 27.413  105.081 1.00 38.76 ? 511  GLN A CB  1 
+ATOM   3899 C  CG  . GLN A 1 489 ? -27.797 27.258  104.685 1.00 44.42 ? 511  GLN A CG  1 
+ATOM   3900 C  CD  . GLN A 1 489 ? -27.908 27.030  103.286 1.00 50.89 ? 511  GLN A CD  1 
+ATOM   3901 O  OE1 . GLN A 1 489 ? -28.178 27.967  102.519 1.00 53.76 ? 511  GLN A OE1 1 
+ATOM   3902 N  NE2 . GLN A 1 489 ? -27.640 25.792  102.866 1.00 53.33 ? 511  GLN A NE2 1 
+ATOM   3903 N  N   . VAL A 1 490 ? -23.522 26.764  106.415 1.00 32.38 ? 512  VAL A N   1 
+ATOM   3904 C  CA  . VAL A 1 490 ? -22.419 27.125  107.296 1.00 34.06 ? 512  VAL A CA  1 
+ATOM   3905 C  C   . VAL A 1 490 ? -22.444 28.595  107.657 1.00 36.28 ? 512  VAL A C   1 
+ATOM   3906 O  O   . VAL A 1 490 ? -21.906 28.999  108.680 1.00 35.71 ? 512  VAL A O   1 
+ATOM   3907 C  CB  . VAL A 1 490 ? -21.073 26.715  106.640 1.00 33.71 ? 512  VAL A CB  1 
+ATOM   3908 C  CG1 . VAL A 1 490 ? -20.791 27.570  105.286 1.00 33.35 ? 512  VAL A CG1 1 
+ATOM   3909 C  CG2 . VAL A 1 490 ? -19.894 26.804  107.600 1.00 33.05 ? 512  VAL A CG2 1 
+ATOM   3910 N  N   . GLY A 1 491 ? -23.063 29.408  106.809 1.00 36.30 ? 513  GLY A N   1 
+ATOM   3911 C  CA  . GLY A 1 491 ? -23.042 30.861  107.035 1.00 37.47 ? 513  GLY A CA  1 
+ATOM   3912 C  C   . GLY A 1 491 ? -24.311 31.371  107.686 1.00 38.30 ? 513  GLY A C   1 
+ATOM   3913 O  O   . GLY A 1 491 ? -24.451 32.591  107.920 1.00 39.78 ? 513  GLY A O   1 
+ATOM   3914 N  N   . SER A 1 492 ? -25.248 30.474  107.979 1.00 42.97 ? 514  SER A N   1 
+ATOM   3915 C  CA  . SER A 1 492 ? -26.524 30.908  108.543 1.00 43.71 ? 514  SER A CA  1 
+ATOM   3916 C  C   . SER A 1 492 ? -26.457 30.900  110.045 1.00 42.60 ? 514  SER A C   1 
+ATOM   3917 O  O   . SER A 1 492 ? -25.588 30.257  110.653 1.00 42.94 ? 514  SER A O   1 
+ATOM   3918 C  CB  . SER A 1 492 ? -27.695 30.042  108.044 1.00 44.66 ? 514  SER A CB  1 
+ATOM   3919 O  OG  . SER A 1 492 ? -27.871 30.167  106.627 1.00 47.04 ? 514  SER A OG  1 
+ATOM   3920 N  N   . THR A 1 493 ? -27.344 31.693  110.623 1.00 45.05 ? 515  THR A N   1 
+ATOM   3921 C  CA  . THR A 1 493 ? -27.443 31.795  112.061 1.00 43.11 ? 515  THR A CA  1 
+ATOM   3922 C  C   . THR A 1 493 ? -28.731 31.103  112.500 1.00 45.32 ? 515  THR A C   1 
+ATOM   3923 O  O   . THR A 1 493 ? -29.819 31.376  111.944 1.00 45.97 ? 515  THR A O   1 
+ATOM   3924 C  CB  . THR A 1 493 ? -27.472 33.275  112.554 1.00 43.75 ? 515  THR A CB  1 
+ATOM   3925 O  OG1 . THR A 1 493 ? -26.299 33.960  112.107 1.00 42.88 ? 515  THR A OG1 1 
+ATOM   3926 C  CG2 . THR A 1 493 ? -27.538 33.302  114.081 1.00 42.91 ? 515  THR A CG2 1 
+ATOM   3927 N  N   . TYR A 1 494 ? -28.585 30.186  113.461 1.00 42.10 ? 516  TYR A N   1 
+ATOM   3928 C  CA  . TYR A 1 494 ? -29.700 29.409  114.025 1.00 42.39 ? 516  TYR A CA  1 
+ATOM   3929 C  C   . TYR A 1 494 ? -29.819 29.686  115.504 1.00 44.89 ? 516  TYR A C   1 
+ATOM   3930 O  O   . TYR A 1 494 ? -28.831 29.973  116.172 1.00 44.59 ? 516  TYR A O   1 
+ATOM   3931 C  CB  . TYR A 1 494 ? -29.469 27.886  113.802 1.00 41.70 ? 516  TYR A CB  1 
+ATOM   3932 C  CG  . TYR A 1 494 ? -29.306 27.552  112.354 1.00 39.27 ? 516  TYR A CG  1 
+ATOM   3933 C  CD1 . TYR A 1 494 ? -30.416 27.369  111.551 1.00 36.23 ? 516  TYR A CD1 1 
+ATOM   3934 C  CD2 . TYR A 1 494 ? -28.031 27.469  111.760 1.00 37.56 ? 516  TYR A CD2 1 
+ATOM   3935 C  CE1 . TYR A 1 494 ? -30.273 27.086  110.178 1.00 38.84 ? 516  TYR A CE1 1 
+ATOM   3936 C  CE2 . TYR A 1 494 ? -27.883 27.184  110.403 1.00 36.89 ? 516  TYR A CE2 1 
+ATOM   3937 C  CZ  . TYR A 1 494 ? -29.003 26.997  109.629 1.00 38.84 ? 516  TYR A CZ  1 
+ATOM   3938 O  OH  . TYR A 1 494 ? -28.876 26.708  108.287 1.00 38.45 ? 516  TYR A OH  1 
+ATOM   3939 N  N   . VAL A 1 495 ? -31.042 29.564  116.004 1.00 47.77 ? 517  VAL A N   1 
+ATOM   3940 C  CA  . VAL A 1 495 ? -31.293 29.672  117.428 1.00 48.48 ? 517  VAL A CA  1 
+ATOM   3941 C  C   . VAL A 1 495 ? -32.059 28.488  117.970 1.00 48.25 ? 517  VAL A C   1 
+ATOM   3942 O  O   . VAL A 1 495 ? -32.494 27.610  117.220 1.00 49.07 ? 517  VAL A O   1 
+ATOM   3943 C  CB  . VAL A 1 495 ? -32.156 30.903  117.751 1.00 51.50 ? 517  VAL A CB  1 
+ATOM   3944 C  CG1 . VAL A 1 495 ? -31.491 32.138  117.247 1.00 52.38 ? 517  VAL A CG1 1 
+ATOM   3945 C  CG2 . VAL A 1 495 ? -33.572 30.743  117.133 1.00 53.04 ? 517  VAL A CG2 1 
+ATOM   3946 N  N   . LYS A 1 496 ? -32.259 28.477  119.285 1.00 50.18 ? 518  LYS A N   1 
+ATOM   3947 C  CA  . LYS A 1 496 ? -32.881 27.336  119.912 1.00 51.82 ? 518  LYS A CA  1 
+ATOM   3948 C  C   . LYS A 1 496 ? -34.171 26.904  119.221 1.00 51.82 ? 518  LYS A C   1 
+ATOM   3949 O  O   . LYS A 1 496 ? -35.063 27.723  118.924 1.00 51.19 ? 518  LYS A O   1 
+ATOM   3950 C  CB  . LYS A 1 496 ? -33.171 27.620  121.370 1.00 54.97 ? 518  LYS A CB  1 
+ATOM   3951 C  CG  . LYS A 1 496 ? -33.898 26.497  122.072 1.00 57.36 ? 518  LYS A CG  1 
+ATOM   3952 C  CD  . LYS A 1 496 ? -34.393 26.958  123.499 1.00 60.90 ? 518  LYS A CD  1 
+ATOM   3953 C  CE  . LYS A 1 496 ? -35.570 27.983  123.434 1.00 63.90 ? 518  LYS A CE  1 
+ATOM   3954 N  NZ  . LYS A 1 496 ? -35.372 29.278  124.221 1.00 65.49 ? 518  LYS A NZ  1 
+ATOM   3955 N  N   . ASP A 1 497 ? -34.213 25.593  118.962 1.00 51.08 ? 519  ASP A N   1 
+ATOM   3956 C  CA  . ASP A 1 497 ? -35.345 24.872  118.365 1.00 51.59 ? 519  ASP A CA  1 
+ATOM   3957 C  C   . ASP A 1 497 ? -35.488 24.985  116.866 1.00 47.11 ? 519  ASP A C   1 
+ATOM   3958 O  O   . ASP A 1 497 ? -36.404 24.394  116.271 1.00 49.51 ? 519  ASP A O   1 
+ATOM   3959 C  CB  . ASP A 1 497 ? -36.630 25.267  119.062 1.00 55.58 ? 519  ASP A CB  1 
+ATOM   3960 C  CG  . ASP A 1 497 ? -36.586 24.905  120.525 1.00 60.78 ? 519  ASP A CG  1 
+ATOM   3961 O  OD1 . ASP A 1 497 ? -35.970 23.862  120.840 1.00 62.33 ? 519  ASP A OD1 1 
+ATOM   3962 O  OD2 . ASP A 1 497 ? -37.127 25.642  121.381 1.00 64.11 ? 519  ASP A OD2 1 
+ATOM   3963 N  N   . ASP A 1 498 ? -34.614 25.749  116.242 1.00 41.81 ? 520  ASP A N   1 
+ATOM   3964 C  CA  . ASP A 1 498 ? -34.566 25.721  114.772 1.00 43.05 ? 520  ASP A CA  1 
+ATOM   3965 C  C   . ASP A 1 498 ? -34.155 24.328  114.310 1.00 43.32 ? 520  ASP A C   1 
+ATOM   3966 O  O   . ASP A 1 498 ? -33.322 23.677  114.959 1.00 43.68 ? 520  ASP A O   1 
+ATOM   3967 C  CB  . ASP A 1 498 ? -33.554 26.741  114.278 1.00 44.46 ? 520  ASP A CB  1 
+ATOM   3968 C  CG  . ASP A 1 498 ? -34.132 28.128  114.143 1.00 47.31 ? 520  ASP A CG  1 
+ATOM   3969 O  OD1 . ASP A 1 498 ? -35.412 28.284  114.069 1.00 47.36 ? 520  ASP A OD1 1 
+ATOM   3970 O  OD2 . ASP A 1 498 ? -33.274 29.053  114.139 1.00 45.80 ? 520  ASP A OD2 1 
+ATOM   3971 N  N   . LYS A 1 499 ? -34.733 23.849  113.206 1.00 42.22 ? 521  LYS A N   1 
+ATOM   3972 C  CA  . LYS A 1 499 ? -34.400 22.513  112.743 1.00 40.61 ? 521  LYS A CA  1 
+ATOM   3973 C  C   . LYS A 1 499 ? -33.777 22.584  111.375 1.00 37.20 ? 521  LYS A C   1 
+ATOM   3974 O  O   . LYS A 1 499 ? -34.162 23.437  110.564 1.00 38.18 ? 521  LYS A O   1 
+ATOM   3975 C  CB  . LYS A 1 499 ? -35.651 21.666  112.716 1.00 44.81 ? 521  LYS A CB  1 
+ATOM   3976 C  CG  . LYS A 1 499 ? -36.141 21.373  114.134 1.00 48.80 ? 521  LYS A CG  1 
+ATOM   3977 C  CD  . LYS A 1 499 ? -37.319 20.375  114.180 1.00 54.26 ? 521  LYS A CD  1 
+ATOM   3978 C  CE  . LYS A 1 499 ? -36.985 19.005  113.540 1.00 58.11 ? 521  LYS A CE  1 
+ATOM   3979 N  NZ  . LYS A 1 499 ? -37.560 17.842  114.380 1.00 61.18 ? 521  LYS A NZ  1 
+ATOM   3980 N  N   . VAL A 1 500 ? -32.792 21.703  111.122 1.00 34.17 ? 522  VAL A N   1 
+ATOM   3981 C  CA  . VAL A 1 500 ? -32.103 21.659  109.842 1.00 32.38 ? 522  VAL A CA  1 
+ATOM   3982 C  C   . VAL A 1 500 ? -31.874 20.208  109.473 1.00 31.16 ? 522  VAL A C   1 
+ATOM   3983 O  O   . VAL A 1 500 ? -31.786 19.328  110.336 1.00 31.33 ? 522  VAL A O   1 
+ATOM   3984 C  CB  . VAL A 1 500 ? -30.702 22.350  109.852 1.00 31.89 ? 522  VAL A CB  1 
+ATOM   3985 C  CG1 . VAL A 1 500 ? -30.816 23.836  110.143 1.00 33.74 ? 522  VAL A CG1 1 
+ATOM   3986 C  CG2 . VAL A 1 500 ? -29.753 21.637  110.852 1.00 32.36 ? 522  VAL A CG2 1 
+ATOM   3987 N  N   . THR A 1 501 ? -31.744 19.974  108.169 1.00 27.94 ? 523  THR A N   1 
+ATOM   3988 C  CA  . THR A 1 501 ? -31.343 18.672  107.666 1.00 27.82 ? 523  THR A CA  1 
+ATOM   3989 C  C   . THR A 1 501 ? -29.867 18.743  107.333 1.00 25.89 ? 523  THR A C   1 
+ATOM   3990 O  O   . THR A 1 501 ? -29.400 19.764  106.835 1.00 26.58 ? 523  THR A O   1 
+ATOM   3991 C  CB  . THR A 1 501 ? -32.112 18.261  106.439 1.00 30.25 ? 523  THR A CB  1 
+ATOM   3992 O  OG1 . THR A 1 501 ? -31.952 19.261  105.457 1.00 36.63 ? 523  THR A OG1 1 
+ATOM   3993 C  CG2 . THR A 1 501 ? -33.522 18.112  106.724 1.00 27.77 ? 523  THR A CG2 1 
+ATOM   3994 N  N   . HIS A 1 502 ? -29.105 17.707  107.664 1.00 24.63 ? 524  HIS A N   1 
+ATOM   3995 C  CA  . HIS A 1 502 ? -27.669 17.684  107.305 1.00 22.58 ? 524  HIS A CA  1 
+ATOM   3996 C  C   . HIS A 1 502 ? -27.155 16.258  107.418 1.00 20.70 ? 524  HIS A C   1 
+ATOM   3997 O  O   . HIS A 1 502 ? -27.421 15.554  108.406 1.00 21.02 ? 524  HIS A O   1 
+ATOM   3998 C  CB  . HIS A 1 502 ? -26.839 18.586  108.213 1.00 24.62 ? 524  HIS A CB  1 
+ATOM   3999 C  CG  . HIS A 1 502 ? -25.422 18.720  107.773 1.00 24.16 ? 524  HIS A CG  1 
+ATOM   4000 N  ND1 . HIS A 1 502 ? -25.068 19.355  106.600 1.00 25.65 ? 524  HIS A ND1 1 
+ATOM   4001 C  CD2 . HIS A 1 502 ? -24.278 18.190  108.274 1.00 26.78 ? 524  HIS A CD2 1 
+ATOM   4002 C  CE1 . HIS A 1 502 ? -23.758 19.251  106.428 1.00 24.96 ? 524  HIS A CE1 1 
+ATOM   4003 N  NE2 . HIS A 1 502 ? -23.263 18.531  107.421 1.00 25.87 ? 524  HIS A NE2 1 
+ATOM   4004 N  N   . ASN A 1 503 ? -26.485 15.805  106.370 1.00 21.05 ? 525  ASN A N   1 
+ATOM   4005 C  CA  . ASN A 1 503 ? -25.899 14.499  106.363 1.00 20.12 ? 525  ASN A CA  1 
+ATOM   4006 C  C   . ASN A 1 503 ? -26.936 13.446  106.706 1.00 18.43 ? 525  ASN A C   1 
+ATOM   4007 O  O   . ASN A 1 503 ? -26.657 12.478  107.462 1.00 18.60 ? 525  ASN A O   1 
+ATOM   4008 C  CB  . ASN A 1 503 ? -24.612 14.400  107.183 1.00 20.22 ? 525  ASN A CB  1 
+ATOM   4009 C  CG  . ASN A 1 503 ? -23.381 14.920  106.445 1.00 23.21 ? 525  ASN A CG  1 
+ATOM   4010 O  OD1 . ASN A 1 503 ? -23.371 15.044  105.184 1.00 25.49 ? 525  ASN A OD1 1 
+ATOM   4011 N  ND2 . ASN A 1 503 ? -22.332 15.256  107.219 1.00 22.94 ? 525  ASN A ND2 1 
+ATOM   4012 N  N   . GLY A 1 504 ? -28.101 13.597  106.073 1.00 19.25 ? 526  GLY A N   1 
+ATOM   4013 C  CA  . GLY A 1 504 ? -29.093 12.560  106.181 1.00 20.65 ? 526  GLY A CA  1 
+ATOM   4014 C  C   . GLY A 1 504 ? -29.975 12.579  107.414 1.00 21.42 ? 526  GLY A C   1 
+ATOM   4015 O  O   . GLY A 1 504 ? -30.911 11.777  107.512 1.00 25.47 ? 526  GLY A O   1 
+ATOM   4016 N  N   . ALA A 1 505 ? -29.723 13.492  108.360 1.00 21.81 ? 527  ALA A N   1 
+ATOM   4017 C  CA  . ALA A 1 505 ? -30.495 13.543  109.616 1.00 21.82 ? 527  ALA A CA  1 
+ATOM   4018 C  C   . ALA A 1 505 ? -31.084 14.924  109.809 1.00 23.47 ? 527  ALA A C   1 
+ATOM   4019 O  O   . ALA A 1 505 ? -30.640 15.875  109.178 1.00 24.66 ? 527  ALA A O   1 
+ATOM   4020 C  CB  . ALA A 1 505 ? -29.581 13.184  110.789 1.00 19.46 ? 527  ALA A CB  1 
+ATOM   4021 N  N   . THR A 1 506 ? -32.090 15.000  110.685 1.00 25.68 ? 528  THR A N   1 
+ATOM   4022 C  CA  . THR A 1 506 ? -32.716 16.230  111.110 1.00 28.86 ? 528  THR A CA  1 
+ATOM   4023 C  C   . THR A 1 506 ? -32.195 16.534  112.510 1.00 28.32 ? 528  THR A C   1 
+ATOM   4024 O  O   . THR A 1 506 ? -32.291 15.701  113.412 1.00 30.08 ? 528  THR A O   1 
+ATOM   4025 C  CB  . THR A 1 506 ? -34.236 16.093  111.076 1.00 32.19 ? 528  THR A CB  1 
+ATOM   4026 O  OG1 . THR A 1 506 ? -34.615 15.836  109.725 1.00 35.79 ? 528  THR A OG1 1 
+ATOM   4027 C  CG2 . THR A 1 506 ? -34.900 17.344  111.542 1.00 35.12 ? 528  THR A CG2 1 
+ATOM   4028 N  N   . TRP A 1 507 ? -31.612 17.703  112.629 1.00 27.05 ? 529  TRP A N   1 
+ATOM   4029 C  CA  . TRP A 1 507 ? -30.962 18.184  113.834 1.00 27.83 ? 529  TRP A CA  1 
+ATOM   4030 C  C   . TRP A 1 507 ? -31.671 19.413  114.425 1.00 30.61 ? 529  TRP A C   1 
+ATOM   4031 O  O   . TRP A 1 507 ? -32.196 20.255  113.696 1.00 31.59 ? 529  TRP A O   1 
+ATOM   4032 C  CB  . TRP A 1 507 ? -29.508 18.548  113.544 1.00 25.59 ? 529  TRP A CB  1 
+ATOM   4033 C  CG  . TRP A 1 507 ? -28.728 17.497  112.811 1.00 25.07 ? 529  TRP A CG  1 
+ATOM   4034 C  CD1 . TRP A 1 507 ? -28.684 17.315  111.452 1.00 25.02 ? 529  TRP A CD1 1 
+ATOM   4035 C  CD2 . TRP A 1 507 ? -27.827 16.543  113.378 1.00 24.66 ? 529  TRP A CD2 1 
+ATOM   4036 N  NE1 . TRP A 1 507 ? -27.831 16.258  111.138 1.00 24.13 ? 529  TRP A NE1 1 
+ATOM   4037 C  CE2 . TRP A 1 507 ? -27.294 15.775  112.310 1.00 22.64 ? 529  TRP A CE2 1 
+ATOM   4038 C  CE3 . TRP A 1 507 ? -27.442 16.225  114.692 1.00 24.86 ? 529  TRP A CE3 1 
+ATOM   4039 C  CZ2 . TRP A 1 507 ? -26.395 14.749  112.514 1.00 24.17 ? 529  TRP A CZ2 1 
+ATOM   4040 C  CZ3 . TRP A 1 507 ? -26.552 15.171  114.892 1.00 25.04 ? 529  TRP A CZ3 1 
+ATOM   4041 C  CH2 . TRP A 1 507 ? -26.036 14.443  113.813 1.00 25.08 ? 529  TRP A CH2 1 
+ATOM   4042 N  N   . THR A 1 508 ? -31.640 19.497  115.747 1.00 34.00 ? 530  THR A N   1 
+ATOM   4043 C  CA  . THR A 1 508 ? -32.259 20.624  116.446 1.00 35.23 ? 530  THR A CA  1 
+ATOM   4044 C  C   . THR A 1 508 ? -31.198 21.414  117.236 1.00 37.53 ? 530  THR A C   1 
+ATOM   4045 O  O   . THR A 1 508 ? -30.388 20.836  117.947 1.00 38.98 ? 530  THR A O   1 
+ATOM   4046 C  CB  . THR A 1 508 ? -33.413 20.135  117.347 1.00 37.20 ? 530  THR A CB  1 
+ATOM   4047 O  OG1 . THR A 1 508 ? -34.355 19.399  116.578 1.00 39.15 ? 530  THR A OG1 1 
+ATOM   4048 C  CG2 . THR A 1 508 ? -34.157 21.339  117.993 1.00 39.26 ? 530  THR A CG2 1 
+ATOM   4049 N  N   . ALA A 1 509 ? -31.163 22.733  117.013 1.00 39.72 ? 531  ALA A N   1 
+ATOM   4050 C  CA  . ALA A 1 509 ? -30.285 23.663  117.709 1.00 40.39 ? 531  ALA A CA  1 
+ATOM   4051 C  C   . ALA A 1 509 ? -30.666 23.823  119.180 1.00 41.92 ? 531  ALA A C   1 
+ATOM   4052 O  O   . ALA A 1 509 ? -31.822 24.040  119.490 1.00 42.99 ? 531  ALA A O   1 
+ATOM   4053 C  CB  . ALA A 1 509 ? -30.387 25.020  117.083 1.00 38.32 ? 531  ALA A CB  1 
+ATOM   4054 N  N   . GLN A 1 510 ? -29.671 23.754  120.038 1.00 42.14 ? 532  GLN A N   1 
+ATOM   4055 C  CA  . GLN A 1 510 ? -29.907 23.842  121.495 1.00 43.18 ? 532  GLN A CA  1 
+ATOM   4056 C  C   . GLN A 1 510 ? -29.577 25.214  121.985 1.00 45.12 ? 532  GLN A C   1 
+ATOM   4057 O  O   . GLN A 1 510 ? -29.850 25.531  123.171 1.00 47.73 ? 532  GLN A O   1 
+ATOM   4058 C  CB  . GLN A 1 510 ? -29.053 22.835  122.237 1.00 45.43 ? 532  GLN A CB  1 
+ATOM   4059 C  CG  . GLN A 1 510 ? -29.296 21.388  121.795 1.00 45.67 ? 532  GLN A CG  1 
+ATOM   4060 C  CD  . GLN A 1 510 ? -30.753 20.933  121.921 1.00 47.15 ? 532  GLN A CD  1 
+ATOM   4061 O  OE1 . GLN A 1 510 ? -31.318 20.923  123.008 1.00 48.14 ? 532  GLN A OE1 1 
+ATOM   4062 N  NE2 . GLN A 1 510 ? -31.359 20.558  120.801 1.00 47.35 ? 532  GLN A NE2 1 
+ATOM   4063 N  N   . TRP A 1 511 ? -29.007 26.043  121.113 1.00 46.62 ? 533  TRP A N   1 
+ATOM   4064 C  CA  . TRP A 1 511 ? -28.754 27.460  121.417 1.00 47.94 ? 533  TRP A CA  1 
+ATOM   4065 C  C   . TRP A 1 511 ? -28.291 28.171  120.147 1.00 47.31 ? 533  TRP A C   1 
+ATOM   4066 O  O   . TRP A 1 511 ? -28.382 27.628  119.021 1.00 46.69 ? 533  TRP A O   1 
+ATOM   4067 C  CB  . TRP A 1 511 ? -27.732 27.624  122.554 1.00 48.98 ? 533  TRP A CB  1 
+ATOM   4068 C  CG  . TRP A 1 511 ? -26.419 26.876  122.421 1.00 50.63 ? 533  TRP A CG  1 
+ATOM   4069 C  CD1 . TRP A 1 511 ? -25.318 27.255  121.692 1.00 50.69 ? 533  TRP A CD1 1 
+ATOM   4070 C  CD2 . TRP A 1 511 ? -26.053 25.650  123.090 1.00 51.05 ? 533  TRP A CD2 1 
+ATOM   4071 N  NE1 . TRP A 1 511 ? -24.303 26.326  121.847 1.00 51.36 ? 533  TRP A NE1 1 
+ATOM   4072 C  CE2 . TRP A 1 511 ? -24.722 25.336  122.697 1.00 51.24 ? 533  TRP A CE2 1 
+ATOM   4073 C  CE3 . TRP A 1 511 ? -26.724 24.783  123.974 1.00 50.29 ? 533  TRP A CE3 1 
+ATOM   4074 C  CZ2 . TRP A 1 511 ? -24.057 24.170  123.127 1.00 52.17 ? 533  TRP A CZ2 1 
+ATOM   4075 C  CZ3 . TRP A 1 511 ? -26.063 23.637  124.410 1.00 51.72 ? 533  TRP A CZ3 1 
+ATOM   4076 C  CH2 . TRP A 1 511 ? -24.740 23.336  123.982 1.00 51.85 ? 533  TRP A CH2 1 
+ATOM   4077 N  N   . TRP A 1 512 ? -27.767 29.374  120.314 1.00 47.18 ? 534  TRP A N   1 
+ATOM   4078 C  CA  . TRP A 1 512 ? -27.298 30.189  119.208 1.00 47.87 ? 534  TRP A CA  1 
+ATOM   4079 C  C   . TRP A 1 512 ? -26.072 29.601  118.523 1.00 46.84 ? 534  TRP A C   1 
+ATOM   4080 O  O   . TRP A 1 512 ? -25.053 29.307  119.190 1.00 47.62 ? 534  TRP A O   1 
+ATOM   4081 C  CB  . TRP A 1 512 ? -26.955 31.601  119.779 1.00 52.24 ? 534  TRP A CB  1 
+ATOM   4082 C  CG  . TRP A 1 512 ? -26.621 32.583  118.718 1.00 57.51 ? 534  TRP A CG  1 
+ATOM   4083 C  CD1 . TRP A 1 512 ? -27.468 33.516  118.181 1.00 58.92 ? 534  TRP A CD1 1 
+ATOM   4084 C  CD2 . TRP A 1 512 ? -25.360 32.736  118.025 1.00 60.16 ? 534  TRP A CD2 1 
+ATOM   4085 N  NE1 . TRP A 1 512 ? -26.819 34.234  117.204 1.00 60.19 ? 534  TRP A NE1 1 
+ATOM   4086 C  CE2 . TRP A 1 512 ? -25.527 33.782  117.084 1.00 60.62 ? 534  TRP A CE2 1 
+ATOM   4087 C  CE3 . TRP A 1 512 ? -24.118 32.085  118.098 1.00 61.50 ? 534  TRP A CE3 1 
+ATOM   4088 C  CZ2 . TRP A 1 512 ? -24.492 34.199  116.219 1.00 61.01 ? 534  TRP A CZ2 1 
+ATOM   4089 C  CZ3 . TRP A 1 512 ? -23.096 32.503  117.252 1.00 61.81 ? 534  TRP A CZ3 1 
+ATOM   4090 C  CH2 . TRP A 1 512 ? -23.290 33.551  116.324 1.00 61.69 ? 534  TRP A CH2 1 
+ATOM   4091 N  N   . THR A 1 513 ? -26.140 29.470  117.183 1.00 42.97 ? 535  THR A N   1 
+ATOM   4092 C  CA  . THR A 1 513 ? -25.031 28.923  116.485 1.00 42.28 ? 535  THR A CA  1 
+ATOM   4093 C  C   . THR A 1 513 ? -24.908 29.432  115.043 1.00 42.25 ? 535  THR A C   1 
+ATOM   4094 O  O   . THR A 1 513 ? -25.925 29.676  114.334 1.00 41.39 ? 535  THR A O   1 
+ATOM   4095 C  CB  . THR A 1 513 ? -25.178 27.365  116.452 1.00 41.65 ? 535  THR A CB  1 
+ATOM   4096 O  OG1 . THR A 1 513 ? -24.128 26.789  115.682 1.00 41.07 ? 535  THR A OG1 1 
+ATOM   4097 C  CG2 . THR A 1 513 ? -26.545 26.970  115.887 1.00 41.08 ? 535  THR A CG2 1 
+ATOM   4098 N  N   . LYS A 1 514 ? -23.646 29.587  114.650 1.00 39.88 ? 536  LYS A N   1 
+ATOM   4099 C  CA  . LYS A 1 514 ? -23.274 29.974  113.299 1.00 39.42 ? 536  LYS A CA  1 
+ATOM   4100 C  C   . LYS A 1 514 ? -21.975 29.260  112.957 1.00 40.12 ? 536  LYS A C   1 
+ATOM   4101 O  O   . LYS A 1 514 ? -21.005 29.337  113.705 1.00 41.00 ? 536  LYS A O   1 
+ATOM   4102 C  CB  . LYS A 1 514 ? -23.085 31.509  113.190 1.00 38.42 ? 536  LYS A CB  1 
+ATOM   4103 C  CG  . LYS A 1 514 ? -22.656 31.923  111.820 1.00 40.06 ? 536  LYS A CG  1 
+ATOM   4104 C  CD  . LYS A 1 514 ? -22.435 33.426  111.733 1.00 41.51 ? 536  LYS A CD  1 
+ATOM   4105 C  CE  . LYS A 1 514 ? -22.701 33.927  110.331 1.00 45.32 ? 536  LYS A CE  1 
+ATOM   4106 N  NZ  . LYS A 1 514 ? -23.932 34.825  110.302 1.00 47.72 ? 536  LYS A NZ  1 
+ATOM   4107 N  N   . GLY A 1 515 ? -21.961 28.495  111.866 1.00 38.75 ? 537  GLY A N   1 
+ATOM   4108 C  CA  . GLY A 1 515 ? -20.730 27.870  111.426 1.00 38.39 ? 537  GLY A CA  1 
+ATOM   4109 C  C   . GLY A 1 515 ? -20.364 26.522  112.049 1.00 36.45 ? 537  GLY A C   1 
+ATOM   4110 O  O   . GLY A 1 515 ? -19.220 26.057  111.859 1.00 36.43 ? 537  GLY A O   1 
+ATOM   4111 N  N   . GLU A 1 516 ? -21.298 25.887  112.782 1.00 36.11 ? 538  GLU A N   1 
+ATOM   4112 C  CA  . GLU A 1 516 ? -20.988 24.593  113.415 1.00 35.42 ? 538  GLU A CA  1 
+ATOM   4113 C  C   . GLU A 1 516 ? -21.725 23.503  112.726 1.00 34.32 ? 538  GLU A C   1 
+ATOM   4114 O  O   . GLU A 1 516 ? -22.956 23.536  112.650 1.00 34.29 ? 538  GLU A O   1 
+ATOM   4115 C  CB  . GLU A 1 516 ? -21.358 24.577  114.922 1.00 36.46 ? 538  GLU A CB  1 
+ATOM   4116 C  CG  . GLU A 1 516 ? -20.674 25.712  115.665 1.00 40.95 ? 538  GLU A CG  1 
+ATOM   4117 C  CD  . GLU A 1 516 ? -21.058 25.684  117.095 1.00 44.36 ? 538  GLU A CD  1 
+ATOM   4118 O  OE1 . GLU A 1 516 ? -20.521 24.793  117.800 1.00 45.27 ? 538  GLU A OE1 1 
+ATOM   4119 O  OE2 . GLU A 1 516 ? -21.956 26.469  117.479 1.00 44.81 ? 538  GLU A OE2 1 
+ATOM   4120 N  N   . GLU A 1 517 ? -20.976 22.511  112.258 1.00 32.25 ? 539  GLU A N   1 
+ATOM   4121 C  CA  . GLU A 1 517 ? -21.566 21.455  111.446 1.00 27.11 ? 539  GLU A CA  1 
+ATOM   4122 C  C   . GLU A 1 517 ? -22.345 20.413  112.284 1.00 27.02 ? 539  GLU A C   1 
+ATOM   4123 O  O   . GLU A 1 517 ? -21.783 19.802  113.182 1.00 29.00 ? 539  GLU A O   1 
+ATOM   4124 C  CB  . GLU A 1 517 ? -20.486 20.773  110.617 1.00 27.75 ? 539  GLU A CB  1 
+ATOM   4125 C  CG  . GLU A 1 517 ? -21.095 19.797  109.640 1.00 28.13 ? 539  GLU A CG  1 
+ATOM   4126 C  CD  . GLU A 1 517 ? -20.086 19.012  108.782 1.00 27.01 ? 539  GLU A CD  1 
+ATOM   4127 O  OE1 . GLU A 1 517 ? -18.857 19.242  108.890 1.00 29.29 ? 539  GLU A OE1 1 
+ATOM   4128 O  OE2 . GLU A 1 517 ? -20.550 18.201  107.951 1.00 27.61 ? 539  GLU A OE2 1 
+ATOM   4129 N  N   . PRO A 1 518 ? -23.613 20.168  111.912 1.00 26.53 ? 540  PRO A N   1 
+ATOM   4130 C  CA  . PRO A 1 518 ? -24.313 19.094  112.635 1.00 27.12 ? 540  PRO A CA  1 
+ATOM   4131 C  C   . PRO A 1 518 ? -23.602 17.751  112.513 1.00 25.37 ? 540  PRO A C   1 
+ATOM   4132 O  O   . PRO A 1 518 ? -23.120 17.409  111.412 1.00 25.38 ? 540  PRO A O   1 
+ATOM   4133 C  CB  . PRO A 1 518 ? -25.704 19.075  112.010 1.00 26.76 ? 540  PRO A CB  1 
+ATOM   4134 C  CG  . PRO A 1 518 ? -25.900 20.482  111.593 1.00 27.92 ? 540  PRO A CG  1 
+ATOM   4135 C  CD  . PRO A 1 518 ? -24.542 20.906  111.050 1.00 26.72 ? 540  PRO A CD  1 
+ATOM   4136 N  N   . GLY A 1 519 ? -23.574 16.999  113.615 1.00 24.98 ? 541  GLY A N   1 
+ATOM   4137 C  CA  . GLY A 1 519 ? -22.860 15.737  113.603 1.00 25.21 ? 541  GLY A CA  1 
+ATOM   4138 C  C   . GLY A 1 519 ? -21.412 15.840  114.099 1.00 25.87 ? 541  GLY A C   1 
+ATOM   4139 O  O   . GLY A 1 519 ? -20.770 14.810  114.461 1.00 25.95 ? 541  GLY A O   1 
+ATOM   4140 N  N   . THR A 1 520 ? -20.897 17.072  114.214 1.00 25.72 ? 542  THR A N   1 
+ATOM   4141 C  CA  . THR A 1 520 ? -19.496 17.201  114.612 1.00 26.87 ? 542  THR A CA  1 
+ATOM   4142 C  C   . THR A 1 520 ? -19.367 17.790  116.021 1.00 29.65 ? 542  THR A C   1 
+ATOM   4143 O  O   . THR A 1 520 ? -18.262 18.079  116.481 1.00 30.86 ? 542  THR A O   1 
+ATOM   4144 C  CB  . THR A 1 520 ? -18.691 18.103  113.615 1.00 25.87 ? 542  THR A CB  1 
+ATOM   4145 O  OG1 . THR A 1 520 ? -19.086 19.468  113.787 1.00 26.55 ? 542  THR A OG1 1 
+ATOM   4146 C  CG2 . THR A 1 520 ? -18.954 17.697  112.186 1.00 26.00 ? 542  THR A CG2 1 
+ATOM   4147 N  N   . THR A 1 521 ? -20.477 18.011  116.695 1.00 30.32 ? 543  THR A N   1 
+ATOM   4148 C  CA  . THR A 1 521 ? -20.387 18.678  117.990 1.00 32.17 ? 543  THR A CA  1 
+ATOM   4149 C  C   . THR A 1 521 ? -20.587 17.763  119.160 1.00 32.66 ? 543  THR A C   1 
+ATOM   4150 O  O   . THR A 1 521 ? -20.880 18.216  120.277 1.00 34.60 ? 543  THR A O   1 
+ATOM   4151 C  CB  . THR A 1 521 ? -21.349 19.831  118.061 1.00 31.19 ? 543  THR A CB  1 
+ATOM   4152 O  OG1 . THR A 1 521 ? -22.682 19.336  118.133 1.00 31.60 ? 543  THR A OG1 1 
+ATOM   4153 C  CG2 . THR A 1 521 ? -21.169 20.710  116.820 1.00 32.11 ? 543  THR A CG2 1 
+ATOM   4154 N  N   . GLY A 1 522 ? -20.405 16.469  118.963 1.00 33.24 ? 544  GLY A N   1 
+ATOM   4155 C  CA  . GLY A 1 522 ? -20.289 15.590  120.105 1.00 32.70 ? 544  GLY A CA  1 
+ATOM   4156 C  C   . GLY A 1 522 ? -21.592 15.211  120.728 1.00 34.93 ? 544  GLY A C   1 
+ATOM   4157 O  O   . GLY A 1 522 ? -22.662 15.399  120.163 1.00 34.79 ? 544  GLY A O   1 
+ATOM   4158 N  N   . GLU A 1 523 ? -21.477 14.650  121.924 1.00 35.31 ? 545  GLU A N   1 
+ATOM   4159 C  CA  . GLU A 1 523 ? -22.625 14.123  122.621 1.00 39.32 ? 545  GLU A CA  1 
+ATOM   4160 C  C   . GLU A 1 523 ? -23.398 15.301  123.245 1.00 42.83 ? 545  GLU A C   1 
+ATOM   4161 O  O   . GLU A 1 523 ? -24.631 15.274  123.278 1.00 44.87 ? 545  GLU A O   1 
+ATOM   4162 C  CB  . GLU A 1 523 ? -22.181 13.155  123.721 1.00 38.68 ? 545  GLU A CB  1 
+ATOM   4163 C  CG  . GLU A 1 523 ? -23.293 12.646  124.640 1.00 39.79 ? 545  GLU A CG  1 
+ATOM   4164 C  CD  . GLU A 1 523 ? -24.233 11.602  124.027 1.00 40.43 ? 545  GLU A CD  1 
+ATOM   4165 O  OE1 . GLU A 1 523 ? -23.891 10.971  122.977 1.00 41.65 ? 545  GLU A OE1 1 
+ATOM   4166 O  OE2 . GLU A 1 523 ? -25.305 11.402  124.651 1.00 40.40 ? 545  GLU A OE2 1 
+ATOM   4167 N  N   . TRP A 1 524 ? -22.695 16.351  123.682 1.00 42.26 ? 546  TRP A N   1 
+ATOM   4168 C  CA  . TRP A 1 524 ? -23.321 17.402  124.417 1.00 44.82 ? 546  TRP A CA  1 
+ATOM   4169 C  C   . TRP A 1 524 ? -23.126 18.798  123.831 1.00 42.40 ? 546  TRP A C   1 
+ATOM   4170 O  O   . TRP A 1 524 ? -22.992 19.775  124.570 1.00 44.09 ? 546  TRP A O   1 
+ATOM   4171 C  CB  . TRP A 1 524 ? -22.747 17.348  125.852 1.00 49.00 ? 546  TRP A CB  1 
+ATOM   4172 C  CG  . TRP A 1 524 ? -23.125 16.088  126.626 1.00 53.85 ? 546  TRP A CG  1 
+ATOM   4173 C  CD1 . TRP A 1 524 ? -24.374 15.774  127.115 1.00 55.23 ? 546  TRP A CD1 1 
+ATOM   4174 C  CD2 . TRP A 1 524 ? -22.246 14.993  127.033 1.00 55.96 ? 546  TRP A CD2 1 
+ATOM   4175 N  NE1 . TRP A 1 524 ? -24.328 14.562  127.811 1.00 57.15 ? 546  TRP A NE1 1 
+ATOM   4176 C  CE2 . TRP A 1 524 ? -23.043 14.064  127.779 1.00 57.60 ? 546  TRP A CE2 1 
+ATOM   4177 C  CE3 . TRP A 1 524 ? -20.874 14.702  126.832 1.00 55.66 ? 546  TRP A CE3 1 
+ATOM   4178 C  CZ2 . TRP A 1 524 ? -22.498 12.850  128.342 1.00 57.90 ? 546  TRP A CZ2 1 
+ATOM   4179 C  CZ3 . TRP A 1 524 ? -20.330 13.476  127.386 1.00 56.37 ? 546  TRP A CZ3 1 
+ATOM   4180 C  CH2 . TRP A 1 524 ? -21.152 12.578  128.123 1.00 57.07 ? 546  TRP A CH2 1 
+ATOM   4181 N  N   . GLY A 1 525 ? -23.078 18.908  122.513 1.00 40.99 ? 547  GLY A N   1 
+ATOM   4182 C  CA  . GLY A 1 525 ? -22.987 20.187  121.837 1.00 37.77 ? 547  GLY A CA  1 
+ATOM   4183 C  C   . GLY A 1 525 ? -24.258 20.857  121.312 1.00 36.95 ? 547  GLY A C   1 
+ATOM   4184 O  O   . GLY A 1 525 ? -25.370 20.518  121.705 1.00 39.30 ? 547  GLY A O   1 
+ATOM   4185 N  N   . VAL A 1 526 ? -24.095 21.824  120.390 1.00 37.68 ? 548  VAL A N   1 
+ATOM   4186 C  CA  . VAL A 1 526 ? -25.233 22.652  119.966 1.00 35.67 ? 548  VAL A CA  1 
+ATOM   4187 C  C   . VAL A 1 526 ? -26.265 21.931  119.070 1.00 36.47 ? 548  VAL A C   1 
+ATOM   4188 O  O   . VAL A 1 526 ? -27.461 22.245  119.085 1.00 36.78 ? 548  VAL A O   1 
+ATOM   4189 C  CB  . VAL A 1 526 ? -24.760 23.968  119.353 1.00 37.60 ? 548  VAL A CB  1 
+ATOM   4190 C  CG1 . VAL A 1 526 ? -24.272 23.733  117.900 1.00 35.88 ? 548  VAL A CG1 1 
+ATOM   4191 C  CG2 . VAL A 1 526 ? -25.875 24.958  119.345 1.00 38.15 ? 548  VAL A CG2 1 
+ATOM   4192 N  N   . TRP A 1 527 ? -25.809 20.930  118.298 1.00 35.19 ? 549  TRP A N   1 
+ATOM   4193 C  CA  . TRP A 1 527 ? -26.724 20.192  117.431 1.00 33.48 ? 549  TRP A CA  1 
+ATOM   4194 C  C   . TRP A 1 527 ? -27.045 18.837  118.014 1.00 34.21 ? 549  TRP A C   1 
+ATOM   4195 O  O   . TRP A 1 527 ? -26.144 18.079  118.307 1.00 36.39 ? 549  TRP A O   1 
+ATOM   4196 C  CB  . TRP A 1 527 ? -26.125 20.004  116.048 1.00 32.94 ? 549  TRP A CB  1 
+ATOM   4197 C  CG  . TRP A 1 527 ? -26.015 21.278  115.277 1.00 33.14 ? 549  TRP A CG  1 
+ATOM   4198 C  CD1 . TRP A 1 527 ? -24.886 21.909  114.923 1.00 33.15 ? 549  TRP A CD1 1 
+ATOM   4199 C  CD2 . TRP A 1 527 ? -27.103 22.074  114.795 1.00 33.09 ? 549  TRP A CD2 1 
+ATOM   4200 N  NE1 . TRP A 1 527 ? -25.181 23.054  114.197 1.00 35.17 ? 549  TRP A NE1 1 
+ATOM   4201 C  CE2 . TRP A 1 527 ? -26.541 23.191  114.129 1.00 34.18 ? 549  TRP A CE2 1 
+ATOM   4202 C  CE3 . TRP A 1 527 ? -28.499 21.955  114.866 1.00 34.41 ? 549  TRP A CE3 1 
+ATOM   4203 C  CZ2 . TRP A 1 527 ? -27.316 24.168  113.505 1.00 33.92 ? 549  TRP A CZ2 1 
+ATOM   4204 C  CZ3 . TRP A 1 527 ? -29.280 22.938  114.250 1.00 33.72 ? 549  TRP A CZ3 1 
+ATOM   4205 C  CH2 . TRP A 1 527 ? -28.665 24.042  113.566 1.00 33.67 ? 549  TRP A CH2 1 
+ATOM   4206 N  N   . ARG A 1 528 ? -28.330 18.528  118.181 1.00 36.40 ? 550  ARG A N   1 
+ATOM   4207 C  CA  . ARG A 1 528 ? -28.712 17.201  118.619 1.00 36.86 ? 550  ARG A CA  1 
+ATOM   4208 C  C   . ARG A 1 528 ? -29.819 16.580  117.760 1.00 35.75 ? 550  ARG A C   1 
+ATOM   4209 O  O   . ARG A 1 528 ? -29.997 15.352  117.773 1.00 35.75 ? 550  ARG A O   1 
+ATOM   4210 C  CB  . ARG A 1 528 ? -29.209 17.249  120.085 1.00 41.18 ? 550  ARG A CB  1 
+ATOM   4211 C  CG  . ARG A 1 528 ? -28.415 18.192  120.978 1.00 45.01 ? 550  ARG A CG  1 
+ATOM   4212 C  CD  . ARG A 1 528 ? -27.258 17.561  121.730 1.00 48.56 ? 550  ARG A CD  1 
+ATOM   4213 N  NE  . ARG A 1 528 ? -26.657 18.559  122.638 1.00 51.63 ? 550  ARG A NE  1 
+ATOM   4214 C  CZ  . ARG A 1 528 ? -27.035 18.787  123.891 1.00 54.03 ? 550  ARG A CZ  1 
+ATOM   4215 N  NH1 . ARG A 1 528 ? -26.436 19.740  124.640 1.00 54.65 ? 550  ARG A NH1 1 
+ATOM   4216 N  NH2 . ARG A 1 528 ? -28.018 18.066  124.418 1.00 54.23 ? 550  ARG A NH2 1 
+ATOM   4217 O  OXT . ARG A 1 528 ? -30.552 17.272  117.042 1.00 34.06 ? 550  ARG A OXT 1 
+HETATM 4218 C  C1  A NAG B 2 .   ? 2.224   32.599  39.082  0.50 19.50 ? 1    NAG B C1  1 
+HETATM 4219 C  C2  A NAG B 2 .   ? 1.211   32.176  38.084  0.50 18.40 ? 1    NAG B C2  1 
+HETATM 4220 C  C3  A NAG B 2 .   ? 1.537   32.746  36.735  0.50 18.65 ? 1    NAG B C3  1 
+HETATM 4221 C  C4  A NAG B 2 .   ? 1.724   34.243  36.796  0.50 17.69 ? 1    NAG B C4  1 
+HETATM 4222 C  C5  A NAG B 2 .   ? 2.617   34.549  37.965  0.50 19.30 ? 1    NAG B C5  1 
+HETATM 4223 C  C6  A NAG B 2 .   ? 2.724   36.043  38.163  0.50 22.47 ? 1    NAG B C6  1 
+HETATM 4224 C  C7  A NAG B 2 .   ? -0.028  30.050  38.435  0.50 19.81 ? 1    NAG B C7  1 
+HETATM 4225 C  C8  A NAG B 2 .   ? -0.046  28.554  38.310  0.50 20.88 ? 1    NAG B C8  1 
+HETATM 4226 N  N2  A NAG B 2 .   ? 1.115   30.763  38.030  0.50 17.95 ? 1    NAG B N2  1 
+HETATM 4227 O  O1  A NAG B 2 .   ? 1.857   32.057  40.265  0.50 23.72 ? 1    NAG B O1  1 
+HETATM 4228 O  O3  A NAG B 2 .   ? 0.500   32.359  35.958  0.50 17.15 ? 1    NAG B O3  1 
+HETATM 4229 O  O4  A NAG B 2 .   ? 2.292   34.789  35.656  0.50 16.62 ? 1    NAG B O4  1 
+HETATM 4230 O  O5  A NAG B 2 .   ? 2.229   33.961  39.133  0.50 19.31 ? 1    NAG B O5  1 
+HETATM 4231 O  O6  A NAG B 2 .   ? 1.451   36.474  38.428  0.50 22.11 ? 1    NAG B O6  1 
+HETATM 4232 O  O7  A NAG B 2 .   ? -0.970  30.599  38.844  0.50 22.72 ? 1    NAG B O7  1 
+HETATM 4233 C  C1  B NDG B 2 .   ? 2.097   32.649  39.175  0.50 18.36 ? 1    NDG B C1  1 
+HETATM 4234 C  C2  B NDG B 2 .   ? 1.181   32.176  38.091  0.50 18.19 ? 1    NDG B C2  1 
+HETATM 4235 C  C3  B NDG B 2 .   ? 1.527   32.748  36.740  0.50 18.33 ? 1    NDG B C3  1 
+HETATM 4236 C  C4  B NDG B 2 .   ? 1.698   34.243  36.785  0.50 17.65 ? 1    NDG B C4  1 
+HETATM 4237 C  C5  B NDG B 2 .   ? 2.536   34.590  37.969  0.50 19.52 ? 1    NDG B C5  1 
+HETATM 4238 C  C6  B NDG B 2 .   ? 2.457   36.091  38.166  0.50 25.00 ? 1    NDG B C6  1 
+HETATM 4239 C  C7  B NDG B 2 .   ? -0.028  30.046  38.435  0.50 19.67 ? 1    NDG B C7  1 
+HETATM 4240 C  C8  B NDG B 2 .   ? -0.045  28.550  38.312  0.50 20.75 ? 1    NDG B C8  1 
+HETATM 4241 O  O5  B NDG B 2 .   ? 2.200   33.990  39.144  0.50 19.00 ? 1    NDG B O5  1 
+HETATM 4242 O  O3  B NDG B 2 .   ? 0.527   32.353  35.916  0.50 15.54 ? 1    NDG B O3  1 
+HETATM 4243 O  O4  B NDG B 2 .   ? 2.292   34.788  35.657  0.50 16.90 ? 1    NDG B O4  1 
+HETATM 4244 O  O6  B NDG B 2 .   ? 3.522   36.365  38.992  0.50 27.07 ? 1    NDG B O6  1 
+HETATM 4245 O  O7  B NDG B 2 .   ? -0.970  30.596  38.843  0.50 22.60 ? 1    NDG B O7  1 
+HETATM 4246 N  N2  B NDG B 2 .   ? 1.112   30.763  38.033  0.50 17.75 ? 1    NDG B N2  1 
+HETATM 4247 O  O1  B NDG B 2 .   ? 3.323   32.122  39.113  0.50 19.03 ? 1    NDG B O1  1 
+HETATM 4248 C  C1  . NAG B 2 .   ? 1.588   34.574  34.393  1.00 16.43 ? 2    NAG B C1  1 
+HETATM 4249 C  C2  . NAG B 2 .   ? 1.843   35.760  33.554  1.00 14.37 ? 2    NAG B C2  1 
+HETATM 4250 C  C3  . NAG B 2 .   ? 1.296   35.515  32.141  1.00 13.65 ? 2    NAG B C3  1 
+HETATM 4251 C  C4  . NAG B 2 .   ? 1.833   34.196  31.626  1.00 14.28 ? 2    NAG B C4  1 
+HETATM 4252 C  C5  . NAG B 2 .   ? 1.621   33.086  32.626  1.00 15.51 ? 2    NAG B C5  1 
+HETATM 4253 C  C6  . NAG B 2 .   ? 2.151   31.705  32.236  1.00 16.47 ? 2    NAG B C6  1 
+HETATM 4254 C  C7  . NAG B 2 .   ? 1.825   37.950  34.757  1.00 17.74 ? 2    NAG B C7  1 
+HETATM 4255 C  C8  . NAG B 2 .   ? 0.908   38.975  35.377  1.00 20.34 ? 2    NAG B C8  1 
+HETATM 4256 N  N2  . NAG B 2 .   ? 1.171   36.917  34.143  1.00 15.07 ? 2    NAG B N2  1 
+HETATM 4257 O  O3  . NAG B 2 .   ? 1.606   36.647  31.340  1.00 15.88 ? 2    NAG B O3  1 
+HETATM 4258 O  O4  . NAG B 2 .   ? 1.198   33.944  30.384  1.00 13.69 ? 2    NAG B O4  1 
+HETATM 4259 O  O5  . NAG B 2 .   ? 2.268   33.470  33.829  1.00 16.04 ? 2    NAG B O5  1 
+HETATM 4260 O  O6  . NAG B 2 .   ? 3.431   31.829  31.723  1.00 15.59 ? 2    NAG B O6  1 
+HETATM 4261 O  O7  . NAG B 2 .   ? 3.036   38.016  34.854  1.00 16.65 ? 2    NAG B O7  1 
+HETATM 4262 C  C1  . NAG B 2 .   ? 2.030   33.272  29.248  1.00 12.50 ? 3    NAG B C1  1 
+HETATM 4263 C  C2  . NAG B 2 .   ? 1.073   33.393  28.097  1.00 14.59 ? 3    NAG B C2  1 
+HETATM 4264 C  C3  . NAG B 2 .   ? 1.274   34.668  27.308  1.00 15.07 ? 3    NAG B C3  1 
+HETATM 4265 C  C4  . NAG B 2 .   ? 2.126   35.666  28.113  1.00 12.57 ? 3    NAG B C4  1 
+HETATM 4266 C  C5  . NAG B 2 .   ? 3.429   35.033  28.459  1.00 13.40 ? 3    NAG B C5  1 
+HETATM 4267 C  C6  . NAG B 2 .   ? 4.355   36.017  29.200  1.00 15.92 ? 3    NAG B C6  1 
+HETATM 4268 C  C7  . NAG B 2 .   ? 2.244   31.598  26.762  1.00 14.79 ? 3    NAG B C7  1 
+HETATM 4269 C  C8  . NAG B 2 .   ? 2.110   30.416  25.847  1.00 14.51 ? 3    NAG B C8  1 
+HETATM 4270 N  N2  . NAG B 2 .   ? 1.065   32.172  27.238  1.00 14.93 ? 3    NAG B N2  1 
+HETATM 4271 O  O3  . NAG B 2 .   ? -0.046  35.227  27.079  1.00 15.98 ? 3    NAG B O3  1 
+HETATM 4272 O  O4  . NAG B 2 .   ? 2.353   36.849  27.317  1.00 14.08 ? 3    NAG B O4  1 
+HETATM 4273 O  O5  . NAG B 2 .   ? 3.236   33.907  29.271  1.00 12.89 ? 3    NAG B O5  1 
+HETATM 4274 O  O6  . NAG B 2 .   ? 5.477   35.374  29.678  1.00 15.54 ? 3    NAG B O6  1 
+HETATM 4275 O  O7  . NAG B 2 .   ? 3.351   31.972  27.059  1.00 14.45 ? 3    NAG B O7  1 
+HETATM 4276 C  C1  . NAG B 2 .   ? 1.476   38.083  27.506  1.00 17.11 ? 4    NAG B C1  1 
+HETATM 4277 C  C2  . NAG B 2 .   ? 2.263   39.278  27.073  1.00 17.13 ? 4    NAG B C2  1 
+HETATM 4278 C  C3  . NAG B 2 .   ? 1.359   40.503  27.196  1.00 16.86 ? 4    NAG B C3  1 
+HETATM 4279 C  C4  . NAG B 2 .   ? -0.002  40.238  26.531  1.00 19.52 ? 4    NAG B C4  1 
+HETATM 4280 C  C5  . NAG B 2 .   ? -0.629  38.900  26.947  1.00 18.16 ? 4    NAG B C5  1 
+HETATM 4281 C  C6  . NAG B 2 .   ? -1.847  38.483  26.095  1.00 18.61 ? 4    NAG B C6  1 
+HETATM 4282 C  C7  . NAG B 2 .   ? 4.756   39.461  27.216  1.00 14.24 ? 4    NAG B C7  1 
+HETATM 4283 C  C8  . NAG B 2 .   ? 5.923   39.743  28.158  1.00 13.32 ? 4    NAG B C8  1 
+HETATM 4284 N  N2  . NAG B 2 .   ? 3.513   39.447  27.796  1.00 15.78 ? 4    NAG B N2  1 
+HETATM 4285 O  O3  . NAG B 2 .   ? 1.987   41.667  26.688  1.00 16.11 ? 4    NAG B O3  1 
+HETATM 4286 O  O4  . NAG B 2 .   ? -0.856  41.280  26.909  1.00 19.82 ? 4    NAG B O4  1 
+HETATM 4287 O  O5  . NAG B 2 .   ? 0.287   37.853  26.771  1.00 15.87 ? 4    NAG B O5  1 
+HETATM 4288 O  O6  . NAG B 2 .   ? -2.452  37.313  26.608  1.00 17.85 ? 4    NAG B O6  1 
+HETATM 4289 O  O7  . NAG B 2 .   ? 4.905   39.269  25.967  1.00 14.49 ? 4    NAG B O7  1 
+HETATM 4290 C  C1  . GOL C 3 .   ? -3.577  3.739   44.554  1.00 26.41 ? 601  GOL A C1  1 
+HETATM 4291 O  O1  . GOL C 3 .   ? -4.002  2.401   44.825  1.00 25.04 ? 601  GOL A O1  1 
+HETATM 4292 C  C2  . GOL C 3 .   ? -4.298  4.345   43.349  1.00 26.69 ? 601  GOL A C2  1 
+HETATM 4293 O  O2  . GOL C 3 .   ? -3.929  3.529   42.249  1.00 25.54 ? 601  GOL A O2  1 
+HETATM 4294 C  C3  . GOL C 3 .   ? -5.804  4.524   43.541  1.00 25.40 ? 601  GOL A C3  1 
+HETATM 4295 O  O3  . GOL C 3 .   ? -6.091  5.452   44.636  1.00 22.81 ? 601  GOL A O3  1 
+HETATM 4296 C  C1  . GOL D 3 .   ? -8.338  28.724  39.147  1.00 28.13 ? 602  GOL A C1  1 
+HETATM 4297 O  O1  . GOL D 3 .   ? -7.708  29.774  38.465  1.00 28.61 ? 602  GOL A O1  1 
+HETATM 4298 C  C2  . GOL D 3 .   ? -8.237  27.400  38.414  1.00 26.51 ? 602  GOL A C2  1 
+HETATM 4299 O  O2  . GOL D 3 .   ? -8.640  27.508  37.067  1.00 23.22 ? 602  GOL A O2  1 
+HETATM 4300 C  C3  . GOL D 3 .   ? -6.835  26.875  38.333  1.00 25.02 ? 602  GOL A C3  1 
+HETATM 4301 O  O3  . GOL D 3 .   ? -6.337  26.601  39.641  1.00 25.52 ? 602  GOL A O3  1 
+HETATM 4302 C  C1  . GOL E 3 .   ? -18.215 35.138  16.232  1.00 56.12 ? 603  GOL A C1  1 
+HETATM 4303 O  O1  . GOL E 3 .   ? -17.805 36.187  17.113  1.00 55.06 ? 603  GOL A O1  1 
+HETATM 4304 C  C2  . GOL E 3 .   ? -18.345 33.930  17.155  1.00 56.19 ? 603  GOL A C2  1 
+HETATM 4305 O  O2  . GOL E 3 .   ? -17.964 34.539  18.349  1.00 54.01 ? 603  GOL A O2  1 
+HETATM 4306 C  C3  . GOL E 3 .   ? -19.787 33.400  17.256  1.00 58.31 ? 603  GOL A C3  1 
+HETATM 4307 O  O3  . GOL E 3 .   ? -19.893 31.987  17.176  1.00 59.54 ? 603  GOL A O3  1 
+HETATM 4308 NA NA  . NA  F 4 .   ? -2.984  25.164  6.456   1.00 18.38 ? 604  NA  A NA  1 
+HETATM 4309 S  S   . SO4 G 5 .   ? 4.455   42.791  31.832  0.60 35.14 ? 605  SO4 A S   1 
+HETATM 4310 O  O1  . SO4 G 5 .   ? 3.398   42.185  31.023  0.60 27.96 ? 605  SO4 A O1  1 
+HETATM 4311 O  O2  . SO4 G 5 .   ? 5.783   42.287  31.499  0.60 30.54 ? 605  SO4 A O2  1 
+HETATM 4312 O  O3  . SO4 G 5 .   ? 4.313   44.287  31.763  0.60 32.44 ? 605  SO4 A O3  1 
+HETATM 4313 O  O4  . SO4 G 5 .   ? 4.097   42.527  33.259  0.60 36.89 ? 605  SO4 A O4  1 
+HETATM 4314 N  N   . GLY H 6 .   ? -1.976  11.411  18.447  1.00 51.61 ? 606  GLY A N   1 
+HETATM 4315 C  CA  . GLY H 6 .   ? -1.592  11.942  17.144  1.00 52.18 ? 606  GLY A CA  1 
+HETATM 4316 C  C   . GLY H 6 .   ? -2.778  12.520  16.377  1.00 52.66 ? 606  GLY A C   1 
+HETATM 4317 O  O   . GLY H 6 .   ? -3.949  12.191  16.606  1.00 52.69 ? 606  GLY A O   1 
+HETATM 4318 O  OXT . GLY H 6 .   ? -2.621  13.358  15.506  1.00 52.23 ? 606  GLY A OXT 1 
+HETATM 4319 N  N   . GLY I 6 .   ? 20.080  42.266  26.551  1.00 55.53 ? 607  GLY A N   1 
+HETATM 4320 C  CA  . GLY I 6 .   ? 21.121  41.555  25.839  1.00 56.14 ? 607  GLY A CA  1 
+HETATM 4321 C  C   . GLY I 6 .   ? 20.639  41.317  24.430  1.00 55.03 ? 607  GLY A C   1 
+HETATM 4322 O  O   . GLY I 6 .   ? 19.779  42.062  23.922  1.00 52.48 ? 607  GLY A O   1 
+HETATM 4323 O  OXT . GLY I 6 .   ? 21.078  40.389  23.768  1.00 54.31 ? 607  GLY A OXT 1 
+HETATM 4324 N  N   . GLY J 6 .   ? 4.866   19.229  42.033  1.00 50.44 ? 608  GLY A N   1 
+HETATM 4325 C  CA  . GLY J 6 .   ? 4.103   20.325  42.634  1.00 52.74 ? 608  GLY A CA  1 
+HETATM 4326 C  C   . GLY J 6 .   ? 3.606   21.430  41.690  1.00 52.37 ? 608  GLY A C   1 
+HETATM 4327 O  O   . GLY J 6 .   ? 2.390   21.609  41.454  1.00 53.61 ? 608  GLY A O   1 
+HETATM 4328 O  OXT . GLY J 6 .   ? 4.390   22.208  41.114  1.00 50.14 ? 608  GLY A OXT 1 
+HETATM 4329 O  O   . HOH K 7 .   ? -1.873  27.258  32.136  1.00 13.48 ? 701  HOH A O   1 
+HETATM 4330 O  O   . HOH K 7 .   ? 3.431   39.878  15.177  1.00 14.35 ? 702  HOH A O   1 
+HETATM 4331 O  O   . HOH K 7 .   ? 4.181   42.386  20.064  1.00 15.73 ? 703  HOH A O   1 
+HETATM 4332 O  O   . HOH K 7 .   ? -8.101  15.712  12.050  1.00 20.38 ? 704  HOH A O   1 
+HETATM 4333 O  O   . HOH K 7 .   ? -2.521  1.219   23.191  1.00 20.27 ? 705  HOH A O   1 
+HETATM 4334 O  O   . HOH K 7 .   ? 1.848   24.201  19.789  1.00 12.55 ? 706  HOH A O   1 
+HETATM 4335 O  O   . HOH K 7 .   ? 12.833  26.999  32.893  1.00 13.58 ? 707  HOH A O   1 
+HETATM 4336 O  O   . HOH K 7 .   ? 17.095  6.990   22.548  1.00 20.54 ? 708  HOH A O   1 
+HETATM 4337 O  O   . HOH K 7 .   ? 15.632  25.640  37.086  1.00 15.46 ? 709  HOH A O   1 
+HETATM 4338 O  O   . HOH K 7 .   ? -10.975 5.870   29.494  1.00 21.73 ? 710  HOH A O   1 
+HETATM 4339 O  O   . HOH K 7 .   ? 17.894  29.926  26.592  1.00 15.41 ? 711  HOH A O   1 
+HETATM 4340 O  O   . HOH K 7 .   ? -19.930 46.170  23.494  1.00 48.69 ? 712  HOH A O   1 
+HETATM 4341 O  O   . HOH K 7 .   ? 3.756   41.341  24.494  1.00 15.13 ? 713  HOH A O   1 
+HETATM 4342 O  O   . HOH K 7 .   ? -14.244 22.173  6.432   1.00 28.15 ? 714  HOH A O   1 
+HETATM 4343 O  O   . HOH K 7 .   ? -3.776  30.509  4.317   1.00 16.20 ? 715  HOH A O   1 
+HETATM 4344 O  O   . HOH K 7 .   ? 11.558  5.711   22.346  1.00 22.54 ? 716  HOH A O   1 
+HETATM 4345 O  O   . HOH K 7 .   ? -22.018 5.017   69.444  1.00 36.10 ? 717  HOH A O   1 
+HETATM 4346 O  O   . HOH K 7 .   ? 19.041  28.952  33.552  1.00 19.21 ? 718  HOH A O   1 
+HETATM 4347 O  O   . HOH K 7 .   ? 19.597  37.621  12.753  1.00 21.43 ? 719  HOH A O   1 
+HETATM 4348 O  O   . HOH K 7 .   ? 13.927  8.911   37.510  1.00 23.43 ? 720  HOH A O   1 
+HETATM 4349 O  O   . HOH K 7 .   ? 6.724   8.274   27.492  1.00 14.50 ? 721  HOH A O   1 
+HETATM 4350 O  O   . HOH K 7 .   ? -28.477 -5.637  79.665  1.00 26.23 ? 722  HOH A O   1 
+HETATM 4351 O  O   . HOH K 7 .   ? -19.673 14.720  116.885 1.00 23.71 ? 723  HOH A O   1 
+HETATM 4352 O  O   . HOH K 7 .   ? 16.057  35.991  22.242  1.00 15.09 ? 724  HOH A O   1 
+HETATM 4353 O  O   . HOH K 7 .   ? 10.925  9.431   20.365  1.00 15.72 ? 725  HOH A O   1 
+HETATM 4354 O  O   . HOH K 7 .   ? -29.046 3.982   96.908  1.00 17.41 ? 726  HOH A O   1 
+HETATM 4355 O  O   . HOH K 7 .   ? -13.523 6.131   33.945  1.00 23.35 ? 727  HOH A O   1 
+HETATM 4356 O  O   . HOH K 7 .   ? -8.310  43.385  5.295   1.00 27.56 ? 728  HOH A O   1 
+HETATM 4357 O  O   . HOH K 7 .   ? -6.009  4.785   50.353  1.00 17.14 ? 729  HOH A O   1 
+HETATM 4358 O  O   . HOH K 7 .   ? 12.198  18.650  12.949  1.00 17.55 ? 730  HOH A O   1 
+HETATM 4359 O  O   . HOH K 7 .   ? -35.228 -3.234  66.380  1.00 23.73 ? 731  HOH A O   1 
+HETATM 4360 O  O   . HOH K 7 .   ? -0.889  9.598   34.373  1.00 26.29 ? 732  HOH A O   1 
+HETATM 4361 O  O   A HOH K 7 .   ? 3.673   10.446  18.384  0.68 30.37 ? 733  HOH A O   1 
+HETATM 4362 O  O   B HOH K 7 .   ? 5.062   9.646   17.291  0.32 19.31 ? 733  HOH A O   1 
+HETATM 4363 O  O   . HOH K 7 .   ? 5.846   46.882  16.366  1.00 20.76 ? 734  HOH A O   1 
+HETATM 4364 O  O   . HOH K 7 .   ? -2.439  43.235  10.328  1.00 18.42 ? 735  HOH A O   1 
+HETATM 4365 O  O   . HOH K 7 .   ? -5.847  8.022   43.751  1.00 21.34 ? 736  HOH A O   1 
+HETATM 4366 O  O   . HOH K 7 .   ? 15.467  44.532  28.919  1.00 18.98 ? 737  HOH A O   1 
+HETATM 4367 O  O   . HOH K 7 .   ? -29.454 9.881   88.412  1.00 21.34 ? 738  HOH A O   1 
+HETATM 4368 O  O   . HOH K 7 .   ? -7.237  5.093   36.755  1.00 20.11 ? 739  HOH A O   1 
+HETATM 4369 O  O   . HOH K 7 .   ? 8.585   32.754  7.815   1.00 21.21 ? 740  HOH A O   1 
+HETATM 4370 O  O   . HOH K 7 .   ? 17.730  34.267  24.061  1.00 19.11 ? 741  HOH A O   1 
+HETATM 4371 O  O   . HOH K 7 .   ? 20.998  24.718  18.101  1.00 18.72 ? 742  HOH A O   1 
+HETATM 4372 O  O   . HOH K 7 .   ? -5.040  24.674  5.449   1.00 26.26 ? 743  HOH A O   1 
+HETATM 4373 O  O   . HOH K 7 .   ? 15.211  29.863  27.621  1.00 13.63 ? 744  HOH A O   1 
+HETATM 4374 O  O   . HOH K 7 .   ? -1.100  46.278  18.719  1.00 20.96 ? 745  HOH A O   1 
+HETATM 4375 O  O   . HOH K 7 .   ? 10.168  11.999  20.660  1.00 16.65 ? 746  HOH A O   1 
+HETATM 4376 O  O   . HOH K 7 .   ? 15.438  14.398  24.331  1.00 16.27 ? 747  HOH A O   1 
+HETATM 4377 O  O   . HOH K 7 .   ? -2.344  34.101  33.315  1.00 16.93 ? 748  HOH A O   1 
+HETATM 4378 O  O   . HOH K 7 .   ? -12.710 4.820   27.534  1.00 25.03 ? 749  HOH A O   1 
+HETATM 4379 O  O   . HOH K 7 .   ? 15.560  30.017  34.825  1.00 19.34 ? 750  HOH A O   1 
+HETATM 4380 O  O   . HOH K 7 .   ? 13.128  9.437   18.606  1.00 14.85 ? 751  HOH A O   1 
+HETATM 4381 O  O   . HOH K 7 .   ? 19.195  36.016  25.591  1.00 21.66 ? 752  HOH A O   1 
+HETATM 4382 O  O   . HOH K 7 .   ? -14.797 23.368  33.585  1.00 28.35 ? 753  HOH A O   1 
+HETATM 4383 O  O   . HOH K 7 .   ? 13.070  34.414  32.682  1.00 22.93 ? 754  HOH A O   1 
+HETATM 4384 O  O   . HOH K 7 .   ? -22.443 15.059  110.114 1.00 19.91 ? 755  HOH A O   1 
+HETATM 4385 O  O   . HOH K 7 .   ? 21.558  15.351  20.831  1.00 19.53 ? 756  HOH A O   1 
+HETATM 4386 O  O   . HOH K 7 .   ? 21.194  45.768  18.554  1.00 29.81 ? 757  HOH A O   1 
+HETATM 4387 O  O   . HOH K 7 .   ? 13.998  34.242  15.581  1.00 14.71 ? 758  HOH A O   1 
+HETATM 4388 O  O   . HOH K 7 .   ? 10.461  8.541   36.685  1.00 18.79 ? 759  HOH A O   1 
+HETATM 4389 O  O   . HOH K 7 .   ? 17.868  37.158  27.880  1.00 19.08 ? 760  HOH A O   1 
+HETATM 4390 O  O   . HOH K 7 .   ? -41.820 -0.823  93.542  1.00 32.12 ? 761  HOH A O   1 
+HETATM 4391 O  O   . HOH K 7 .   ? 22.631  32.000  24.850  1.00 26.67 ? 762  HOH A O   1 
+HETATM 4392 O  O   . HOH K 7 .   ? -2.783  30.237  35.294  1.00 14.81 ? 763  HOH A O   1 
+HETATM 4393 O  O   . HOH K 7 .   ? 13.154  7.263   14.846  1.00 21.68 ? 764  HOH A O   1 
+HETATM 4394 O  O   . HOH K 7 .   ? 11.919  34.421  13.941  1.00 17.39 ? 765  HOH A O   1 
+HETATM 4395 O  O   . HOH K 7 .   ? -12.369 3.371   41.327  1.00 20.94 ? 766  HOH A O   1 
+HETATM 4396 O  O   . HOH K 7 .   ? -23.502 25.288  20.472  1.00 29.00 ? 767  HOH A O   1 
+HETATM 4397 O  O   . HOH K 7 .   ? -2.763  27.922  3.879   1.00 20.18 ? 768  HOH A O   1 
+HETATM 4398 O  O   . HOH K 7 .   ? 13.045  38.397  33.638  1.00 17.25 ? 769  HOH A O   1 
+HETATM 4399 O  O   . HOH K 7 .   ? 18.397  31.477  24.340  1.00 18.66 ? 770  HOH A O   1 
+HETATM 4400 O  O   . HOH K 7 .   ? -17.539 3.443   64.684  1.00 22.27 ? 771  HOH A O   1 
+HETATM 4401 O  O   . HOH K 7 .   ? 23.143  29.017  34.654  1.00 32.28 ? 772  HOH A O   1 
+HETATM 4402 O  O   . HOH K 7 .   ? -36.562 5.418   80.319  1.00 24.90 ? 773  HOH A O   1 
+HETATM 4403 O  O   . HOH K 7 .   ? 23.324  39.833  12.946  1.00 34.32 ? 774  HOH A O   1 
+HETATM 4404 O  O   . HOH K 7 .   ? -19.095 30.185  13.596  1.00 28.56 ? 775  HOH A O   1 
+HETATM 4405 O  O   . HOH K 7 .   ? -20.673 33.824  20.541  1.00 33.40 ? 776  HOH A O   1 
+HETATM 4406 O  O   . HOH K 7 .   ? -5.005  36.682  25.414  1.00 18.20 ? 777  HOH A O   1 
+HETATM 4407 O  O   . HOH K 7 .   ? 5.272   1.697   22.603  1.00 26.09 ? 778  HOH A O   1 
+HETATM 4408 O  O   . HOH K 7 .   ? 2.446   45.521  26.716  1.00 28.53 ? 779  HOH A O   1 
+HETATM 4409 O  O   . HOH K 7 .   ? -18.581 -6.922  70.258  1.00 33.24 ? 780  HOH A O   1 
+HETATM 4410 O  O   . HOH K 7 .   ? 3.604   43.032  28.392  1.00 20.36 ? 781  HOH A O   1 
+HETATM 4411 O  O   . HOH K 7 .   ? -16.961 32.891  27.038  1.00 26.41 ? 782  HOH A O   1 
+HETATM 4412 O  O   . HOH K 7 .   ? -6.373  -6.632  28.101  1.00 28.05 ? 783  HOH A O   1 
+HETATM 4413 O  O   . HOH K 7 .   ? 8.197   42.145  9.854   1.00 24.10 ? 784  HOH A O   1 
+HETATM 4414 O  O   . HOH K 7 .   ? 2.254   13.126  17.887  1.00 25.83 ? 785  HOH A O   1 
+HETATM 4415 O  O   . HOH K 7 .   ? 7.893   33.978  38.057  1.00 18.92 ? 786  HOH A O   1 
+HETATM 4416 O  O   . HOH K 7 .   ? 2.991   39.529  30.617  1.00 15.45 ? 787  HOH A O   1 
+HETATM 4417 O  O   . HOH K 7 .   ? -19.470 -0.954  74.899  1.00 28.51 ? 788  HOH A O   1 
+HETATM 4418 O  O   . HOH K 7 .   ? 14.631  11.861  18.606  1.00 14.79 ? 789  HOH A O   1 
+HETATM 4419 O  O   . HOH K 7 .   ? 20.266  26.618  15.713  1.00 16.98 ? 790  HOH A O   1 
+HETATM 4420 O  O   . HOH K 7 .   ? -9.690  10.427  24.335  1.00 23.40 ? 791  HOH A O   1 
+HETATM 4421 O  O   . HOH K 7 .   ? -45.022 2.479   94.131  1.00 35.78 ? 792  HOH A O   1 
+HETATM 4422 O  O   . HOH K 7 .   ? -11.863 27.169  39.696  1.00 22.83 ? 793  HOH A O   1 
+HETATM 4423 O  O   . HOH K 7 .   ? 17.146  32.894  34.197  1.00 22.13 ? 794  HOH A O   1 
+HETATM 4424 O  O   . HOH K 7 .   ? -36.863 -0.993  86.390  1.00 32.81 ? 795  HOH A O   1 
+HETATM 4425 O  O   . HOH K 7 .   ? -0.233  48.762  17.444  1.00 27.19 ? 796  HOH A O   1 
+HETATM 4426 O  O   . HOH K 7 .   ? -11.385 -9.654  35.140  1.00 29.84 ? 797  HOH A O   1 
+HETATM 4427 O  O   . HOH K 7 .   ? -1.733  36.734  34.087  1.00 19.87 ? 798  HOH A O   1 
+HETATM 4428 O  O   A HOH K 7 .   ? -35.144 11.854  98.512  0.65 24.11 ? 799  HOH A O   1 
+HETATM 4429 O  O   B HOH K 7 .   ? -33.771 11.562  98.377  0.35 23.26 ? 799  HOH A O   1 
+HETATM 4430 O  O   . HOH K 7 .   ? 5.264   23.466  -1.711  1.00 38.35 ? 800  HOH A O   1 
+HETATM 4431 O  O   . HOH K 7 .   ? 14.364  14.318  20.082  1.00 15.74 ? 801  HOH A O   1 
+HETATM 4432 O  O   . HOH K 7 .   ? 26.797  26.433  24.413  1.00 34.98 ? 802  HOH A O   1 
+HETATM 4433 O  O   . HOH K 7 .   ? 12.686  14.546  14.643  1.00 19.89 ? 803  HOH A O   1 
+HETATM 4434 O  O   . HOH K 7 .   ? -2.665  11.981  22.130  1.00 27.45 ? 804  HOH A O   1 
+HETATM 4435 O  O   . HOH K 7 .   ? -8.163  41.653  2.864   1.00 19.09 ? 805  HOH A O   1 
+HETATM 4436 O  O   . HOH K 7 .   ? 11.691  12.733  18.505  1.00 17.85 ? 806  HOH A O   1 
+HETATM 4437 O  O   . HOH K 7 .   ? -23.548 17.638  120.078 1.00 31.35 ? 807  HOH A O   1 
+HETATM 4438 O  O   . HOH K 7 .   ? 14.615  7.157   18.928  1.00 18.35 ? 808  HOH A O   1 
+HETATM 4439 O  O   . HOH K 7 .   ? 6.392   2.743   18.618  1.00 33.02 ? 809  HOH A O   1 
+HETATM 4440 O  O   . HOH K 7 .   ? 21.823  36.855  18.857  1.00 24.70 ? 810  HOH A O   1 
+HETATM 4441 O  O   . HOH K 7 .   ? -1.223  43.897  3.675   1.00 23.64 ? 811  HOH A O   1 
+HETATM 4442 O  O   . HOH K 7 .   ? -14.420 5.600   49.255  1.00 20.18 ? 812  HOH A O   1 
+HETATM 4443 O  O   . HOH K 7 .   ? -4.918  42.925  0.563   1.00 19.65 ? 813  HOH A O   1 
+HETATM 4444 O  O   . HOH K 7 .   ? -10.502 6.030   49.748  1.00 17.35 ? 814  HOH A O   1 
+HETATM 4445 O  O   . HOH K 7 .   ? 6.315   16.574  8.930   1.00 34.71 ? 815  HOH A O   1 
+HETATM 4446 O  O   . HOH K 7 .   ? -4.555  1.079   18.697  1.00 30.93 ? 816  HOH A O   1 
+HETATM 4447 O  O   . HOH K 7 .   ? 21.427  27.781  32.897  1.00 22.56 ? 817  HOH A O   1 
+HETATM 4448 O  O   . HOH K 7 .   ? -3.881  10.296  30.335  1.00 37.49 ? 818  HOH A O   1 
+HETATM 4449 O  O   . HOH K 7 .   ? -8.969  3.400   53.619  1.00 21.01 ? 819  HOH A O   1 
+HETATM 4450 O  O   . HOH K 7 .   ? 10.371  6.673   14.220  1.00 25.43 ? 820  HOH A O   1 
+HETATM 4451 O  O   . HOH K 7 .   ? -23.475 17.334  116.302 1.00 23.81 ? 821  HOH A O   1 
+HETATM 4452 O  O   . HOH K 7 .   ? -40.427 0.748   90.242  1.00 26.65 ? 822  HOH A O   1 
+HETATM 4453 O  O   . HOH K 7 .   ? -15.071 2.570   61.185  1.00 22.92 ? 823  HOH A O   1 
+HETATM 4454 O  O   . HOH K 7 .   ? 0.152   39.013  31.397  1.00 24.86 ? 824  HOH A O   1 
+HETATM 4455 O  O   . HOH K 7 .   ? -6.129  43.823  8.659   1.00 23.82 ? 825  HOH A O   1 
+HETATM 4456 O  O   A HOH K 7 .   ? 19.919  10.441  33.504  0.59 18.50 ? 826  HOH A O   1 
+HETATM 4457 O  O   B HOH K 7 .   ? 20.977  10.998  33.285  0.41 18.14 ? 826  HOH A O   1 
+HETATM 4458 O  O   . HOH K 7 .   ? 4.914   19.014  7.175   1.00 39.41 ? 827  HOH A O   1 
+HETATM 4459 O  O   . HOH K 7 .   ? 22.116  10.309  24.769  1.00 26.05 ? 828  HOH A O   1 
+HETATM 4460 O  O   . HOH K 7 .   ? 15.130  34.127  9.473   1.00 21.34 ? 829  HOH A O   1 
+HETATM 4461 O  O   . HOH K 7 .   ? -5.015  24.309  40.327  1.00 21.35 ? 830  HOH A O   1 
+HETATM 4462 O  O   . HOH K 7 .   ? 7.059   43.282  3.406   1.00 45.80 ? 831  HOH A O   1 
+HETATM 4463 O  O   . HOH K 7 .   ? -6.822  31.996  29.238  1.00 16.06 ? 832  HOH A O   1 
+HETATM 4464 O  O   . HOH K 7 .   ? -6.364  20.231  3.815   1.00 34.90 ? 833  HOH A O   1 
+HETATM 4465 O  O   . HOH K 7 .   ? 21.695  10.625  19.616  1.00 36.05 ? 834  HOH A O   1 
+HETATM 4466 O  O   . HOH K 7 .   ? -4.099  -4.353  20.169  1.00 42.24 ? 835  HOH A O   1 
+HETATM 4467 O  O   . HOH K 7 .   ? -41.355 1.638   76.179  1.00 43.89 ? 836  HOH A O   1 
+HETATM 4468 O  O   . HOH K 7 .   ? 18.390  41.468  28.034  1.00 24.77 ? 837  HOH A O   1 
+HETATM 4469 O  O   . HOH K 7 .   ? -26.110 17.415  104.019 1.00 26.88 ? 838  HOH A O   1 
+HETATM 4470 O  O   . HOH K 7 .   ? -37.920 1.937   73.421  1.00 32.96 ? 839  HOH A O   1 
+HETATM 4471 O  O   . HOH K 7 .   ? 7.664   31.772  43.673  1.00 30.96 ? 840  HOH A O   1 
+HETATM 4472 O  O   . HOH K 7 .   ? 8.646   5.255   26.783  1.00 27.49 ? 841  HOH A O   1 
+HETATM 4473 O  O   . HOH K 7 .   ? -30.484 12.475  87.621  1.00 33.10 ? 842  HOH A O   1 
+HETATM 4474 O  O   . HOH K 7 .   ? -15.702 -0.015  41.178  1.00 23.29 ? 843  HOH A O   1 
+HETATM 4475 O  O   . HOH K 7 .   ? -30.584 -1.626  89.597  1.00 21.11 ? 844  HOH A O   1 
+HETATM 4476 O  O   . HOH K 7 .   ? -44.522 5.808   99.203  1.00 33.08 ? 845  HOH A O   1 
+HETATM 4477 O  O   . HOH K 7 .   ? -18.938 2.354   34.812  1.00 37.88 ? 846  HOH A O   1 
+HETATM 4478 O  O   . HOH K 7 .   ? -3.287  4.826   32.905  1.00 23.40 ? 847  HOH A O   1 
+HETATM 4479 O  O   . HOH K 7 .   ? -20.211 1.554   51.430  1.00 33.12 ? 848  HOH A O   1 
+HETATM 4480 O  O   . HOH K 7 .   ? -11.407 35.696  26.332  1.00 26.42 ? 849  HOH A O   1 
+HETATM 4481 O  O   . HOH K 7 .   ? 14.204  31.856  36.337  1.00 21.49 ? 850  HOH A O   1 
+HETATM 4482 O  O   . HOH K 7 .   ? 15.669  20.888  49.041  1.00 34.98 ? 851  HOH A O   1 
+HETATM 4483 O  O   . HOH K 7 .   ? 9.669   11.220  9.590   1.00 37.57 ? 852  HOH A O   1 
+HETATM 4484 O  O   . HOH K 7 .   ? -3.909  8.894   17.860  1.00 29.03 ? 853  HOH A O   1 
+HETATM 4485 O  O   . HOH K 7 .   ? 13.782  16.463  12.861  1.00 21.79 ? 854  HOH A O   1 
+HETATM 4486 O  O   . HOH K 7 .   ? 2.182   29.257  -1.777  1.00 31.02 ? 855  HOH A O   1 
+HETATM 4487 O  O   . HOH K 7 .   ? -17.437 36.133  21.643  1.00 30.61 ? 856  HOH A O   1 
+HETATM 4488 O  O   . HOH K 7 .   ? -0.146  4.996   29.572  1.00 24.66 ? 857  HOH A O   1 
+HETATM 4489 O  O   . HOH K 7 .   ? -28.789 -0.512  91.397  1.00 30.31 ? 858  HOH A O   1 
+HETATM 4490 O  O   . HOH K 7 .   ? 6.783   4.958   16.166  1.00 28.13 ? 859  HOH A O   1 
+HETATM 4491 O  O   . HOH K 7 .   ? -4.968  6.415   26.049  1.00 19.58 ? 860  HOH A O   1 
+HETATM 4492 O  O   . HOH K 7 .   ? -45.303 2.666   100.165 1.00 33.67 ? 861  HOH A O   1 
+HETATM 4493 O  O   . HOH K 7 .   ? 14.569  5.692   16.516  1.00 22.70 ? 862  HOH A O   1 
+HETATM 4494 O  O   . HOH K 7 .   ? -15.812 1.497   65.855  1.00 38.06 ? 863  HOH A O   1 
+HETATM 4495 O  O   . HOH K 7 .   ? 24.045  28.264  17.276  1.00 29.47 ? 864  HOH A O   1 
+HETATM 4496 O  O   . HOH K 7 .   ? 15.802  24.409  43.728  1.00 22.70 ? 865  HOH A O   1 
+HETATM 4497 O  O   . HOH K 7 .   ? 17.120  7.719   19.926  1.00 21.15 ? 866  HOH A O   1 
+HETATM 4498 O  O   . HOH K 7 .   ? -8.678  10.200  40.844  1.00 29.06 ? 867  HOH A O   1 
+HETATM 4499 O  O   . HOH K 7 .   ? 23.395  38.995  18.057  1.00 40.31 ? 868  HOH A O   1 
+HETATM 4500 O  O   . HOH K 7 .   ? -20.277 32.831  107.395 1.00 35.77 ? 869  HOH A O   1 
+HETATM 4501 O  O   . HOH K 7 .   ? 3.237   28.396  40.345  1.00 25.07 ? 870  HOH A O   1 
+HETATM 4502 O  O   . HOH K 7 .   ? 13.432  48.258  23.449  1.00 30.22 ? 871  HOH A O   1 
+HETATM 4503 O  O   . HOH K 7 .   ? 22.145  25.320  35.866  1.00 30.96 ? 872  HOH A O   1 
+HETATM 4504 O  O   . HOH K 7 .   ? -11.882 -8.186  29.802  1.00 22.06 ? 873  HOH A O   1 
+HETATM 4505 O  O   . HOH K 7 .   ? 15.116  29.193  43.669  1.00 43.30 ? 874  HOH A O   1 
+HETATM 4506 O  O   . HOH K 7 .   ? -17.992 -9.961  49.060  1.00 46.62 ? 875  HOH A O   1 
+HETATM 4507 O  O   . HOH K 7 .   ? -2.730  16.335  7.602   1.00 32.79 ? 876  HOH A O   1 
+HETATM 4508 O  O   . HOH K 7 .   ? -35.121 0.097   60.576  1.00 36.41 ? 877  HOH A O   1 
+HETATM 4509 O  O   . HOH K 7 .   ? -12.043 40.019  4.794   1.00 49.03 ? 878  HOH A O   1 
+HETATM 4510 O  O   . HOH K 7 .   ? -15.818 38.221  20.838  1.00 28.42 ? 879  HOH A O   1 
+HETATM 4511 O  O   . HOH K 7 .   ? 0.631   25.748  0.418   1.00 31.70 ? 880  HOH A O   1 
+HETATM 4512 O  O   . HOH K 7 .   ? -16.216 33.109  7.316   1.00 35.21 ? 881  HOH A O   1 
+HETATM 4513 O  O   . HOH K 7 .   ? -13.006 6.561   46.954  1.00 30.01 ? 882  HOH A O   1 
+HETATM 4514 O  O   . HOH K 7 .   ? -12.830 29.444  37.164  1.00 29.81 ? 883  HOH A O   1 
+HETATM 4515 O  O   . HOH K 7 .   ? -27.249 2.693   95.237  1.00 22.90 ? 884  HOH A O   1 
+HETATM 4516 O  O   . HOH K 7 .   ? 12.236  38.197  37.499  1.00 37.69 ? 885  HOH A O   1 
+HETATM 4517 O  O   . HOH K 7 .   ? 18.010  43.684  29.717  1.00 28.60 ? 886  HOH A O   1 
+HETATM 4518 O  O   . HOH K 7 .   ? -9.726  31.815  2.647   1.00 25.57 ? 887  HOH A O   1 
+HETATM 4519 O  O   . HOH K 7 .   ? -15.223 -7.345  30.170  1.00 40.79 ? 888  HOH A O   1 
+HETATM 4520 O  O   . HOH K 7 .   ? -13.651 -1.088  60.652  1.00 27.77 ? 889  HOH A O   1 
+HETATM 4521 O  O   . HOH K 7 .   ? -21.113 -14.600 56.538  1.00 41.13 ? 890  HOH A O   1 
+HETATM 4522 O  O   . HOH K 7 .   ? -1.927  12.649  28.533  1.00 23.40 ? 891  HOH A O   1 
+HETATM 4523 O  O   . HOH K 7 .   ? 23.967  29.527  19.973  1.00 36.55 ? 892  HOH A O   1 
+HETATM 4524 O  O   . HOH K 7 .   ? -16.850 21.363  32.906  1.00 34.21 ? 893  HOH A O   1 
+HETATM 4525 O  O   . HOH K 7 .   ? 7.298   48.380  24.865  1.00 31.87 ? 894  HOH A O   1 
+HETATM 4526 O  O   . HOH K 7 .   ? 18.915  9.135   31.723  1.00 24.65 ? 895  HOH A O   1 
+HETATM 4527 O  O   . HOH K 7 .   ? 8.819   20.816  9.132   1.00 38.43 ? 896  HOH A O   1 
+HETATM 4528 O  O   . HOH K 7 .   ? -14.595 29.750  6.552   1.00 25.13 ? 897  HOH A O   1 
+HETATM 4529 O  O   . HOH K 7 .   ? -18.162 4.138   52.116  1.00 33.05 ? 898  HOH A O   1 
+HETATM 4530 O  O   . HOH K 7 .   ? 11.806  46.420  19.285  1.00 24.01 ? 899  HOH A O   1 
+HETATM 4531 O  O   . HOH K 7 .   ? 11.540  49.117  25.359  1.00 31.48 ? 900  HOH A O   1 
+HETATM 4532 O  O   . HOH K 7 .   ? 19.192  46.234  28.668  1.00 33.10 ? 901  HOH A O   1 
+HETATM 4533 O  O   . HOH K 7 .   ? -3.178  34.852  37.579  1.00 46.43 ? 902  HOH A O   1 
+HETATM 4534 O  O   . HOH K 7 .   ? 18.697  47.498  17.863  1.00 46.39 ? 903  HOH A O   1 
+HETATM 4535 O  O   . HOH K 7 .   ? -0.740  5.602   32.084  1.00 28.13 ? 904  HOH A O   1 
+HETATM 4536 O  O   . HOH K 7 .   ? 1.654   10.386  38.918  1.00 40.57 ? 905  HOH A O   1 
+HETATM 4537 O  O   . HOH K 7 .   ? -9.070  32.052  39.333  1.00 34.37 ? 906  HOH A O   1 
+HETATM 4538 O  O   . HOH K 7 .   ? 1.955   8.304   22.229  1.00 25.42 ? 907  HOH A O   1 
+HETATM 4539 O  O   . HOH K 7 .   ? -31.645 -8.830  65.031  1.00 26.46 ? 908  HOH A O   1 
+HETATM 4540 O  O   . HOH K 7 .   ? 0.675   48.876  20.403  1.00 41.98 ? 909  HOH A O   1 
+HETATM 4541 O  O   . HOH K 7 .   ? -30.950 -7.694  85.773  1.00 21.44 ? 910  HOH A O   1 
+HETATM 4542 O  O   . HOH K 7 .   ? -33.909 -7.668  73.104  1.00 32.70 ? 911  HOH A O   1 
+HETATM 4543 O  O   . HOH K 7 .   ? 21.246  17.774  17.554  1.00 26.00 ? 912  HOH A O   1 
+HETATM 4544 O  O   . HOH K 7 .   ? -6.496  5.070   53.985  1.00 31.02 ? 913  HOH A O   1 
+HETATM 4545 O  O   . HOH K 7 .   ? 3.802   42.690  3.355   1.00 37.39 ? 914  HOH A O   1 
+HETATM 4546 O  O   . HOH K 7 .   ? 2.504   50.252  18.809  1.00 33.99 ? 915  HOH A O   1 
+HETATM 4547 O  O   . HOH K 7 .   ? -15.075 7.076   37.355  1.00 35.22 ? 916  HOH A O   1 
+HETATM 4548 O  O   . HOH K 7 .   ? -24.106 4.518   64.243  1.00 27.58 ? 917  HOH A O   1 
+HETATM 4549 O  O   . HOH K 7 .   ? -1.321  8.369   23.762  1.00 37.37 ? 918  HOH A O   1 
+HETATM 4550 O  O   . HOH K 7 .   ? 8.511   5.261   22.617  1.00 24.32 ? 919  HOH A O   1 
+HETATM 4551 O  O   . HOH K 7 .   ? -5.246  36.111  0.046   0.50 16.11 ? 920  HOH A O   1 
+HETATM 4552 O  O   . HOH K 7 .   ? 7.980   17.776  11.175  1.00 32.37 ? 921  HOH A O   1 
+HETATM 4553 O  O   . HOH K 7 .   ? -10.077 -9.584  28.299  1.00 35.51 ? 922  HOH A O   1 
+HETATM 4554 O  O   . HOH K 7 .   ? 15.125  34.793  34.473  1.00 27.50 ? 923  HOH A O   1 
+HETATM 4555 O  O   . HOH K 7 .   ? -21.740 -8.139  61.634  1.00 32.54 ? 924  HOH A O   1 
+HETATM 4556 O  O   . HOH K 7 .   ? 4.084   48.697  14.874  1.00 38.39 ? 925  HOH A O   1 
+HETATM 4557 O  O   . HOH K 7 .   ? -35.124 7.799   78.153  1.00 29.88 ? 926  HOH A O   1 
+HETATM 4558 O  O   . HOH K 7 .   ? 24.805  13.054  32.335  1.00 24.97 ? 927  HOH A O   1 
+HETATM 4559 O  O   . HOH K 7 .   ? -42.048 4.537   99.963  1.00 27.64 ? 928  HOH A O   1 
+HETATM 4560 O  O   . HOH K 7 .   ? -42.314 1.488   87.708  1.00 39.81 ? 929  HOH A O   1 
+HETATM 4561 O  O   . HOH K 7 .   ? 28.341  25.145  30.362  1.00 44.51 ? 930  HOH A O   1 
+HETATM 4562 O  O   . HOH K 7 .   ? -11.069 -1.439  58.027  1.00 32.95 ? 931  HOH A O   1 
+HETATM 4563 O  O   . HOH K 7 .   ? 4.337   31.750  -1.135  1.00 29.62 ? 932  HOH A O   1 
+HETATM 4564 O  O   . HOH K 7 .   ? -18.536 22.239  113.936 1.00 28.33 ? 933  HOH A O   1 
+HETATM 4565 O  O   . HOH K 7 .   ? 10.809  24.398  8.927   1.00 30.56 ? 934  HOH A O   1 
+HETATM 4566 O  O   . HOH K 7 .   ? -35.298 -4.141  73.368  1.00 28.56 ? 935  HOH A O   1 
+HETATM 4567 O  O   . HOH K 7 .   ? -26.604 20.829  104.874 1.00 25.63 ? 936  HOH A O   1 
+HETATM 4568 O  O   . HOH K 7 .   ? -16.747 -13.920 55.103  1.00 45.02 ? 937  HOH A O   1 
+HETATM 4569 O  O   . HOH K 7 .   ? -2.134  8.216   32.228  1.00 31.73 ? 938  HOH A O   1 
+HETATM 4570 O  O   . HOH K 7 .   ? -17.209 29.282  36.855  1.00 34.05 ? 939  HOH A O   1 
+HETATM 4571 O  O   . HOH K 7 .   ? 24.831  35.765  17.546  1.00 47.87 ? 940  HOH A O   1 
+HETATM 4572 O  O   . HOH K 7 .   ? -16.914 4.502   68.890  1.00 25.34 ? 941  HOH A O   1 
+HETATM 4573 O  O   . HOH K 7 .   ? -7.386  33.916  31.482  1.00 24.77 ? 942  HOH A O   1 
+HETATM 4574 O  O   . HOH K 7 .   ? -18.475 26.478  10.580  1.00 29.79 ? 943  HOH A O   1 
+HETATM 4575 O  O   . HOH K 7 .   ? -43.615 -1.614  95.473  1.00 34.61 ? 944  HOH A O   1 
+HETATM 4576 O  O   . HOH K 7 .   ? 5.227   36.337  35.736  1.00 23.97 ? 945  HOH A O   1 
+HETATM 4577 O  O   . HOH K 7 .   ? 21.115  13.590  17.330  1.00 41.11 ? 946  HOH A O   1 
+HETATM 4578 O  O   . HOH K 7 .   ? -4.485  -7.545  36.884  1.00 28.64 ? 947  HOH A O   1 
+HETATM 4579 O  O   . HOH K 7 .   ? -1.761  20.884  40.503  1.00 30.01 ? 948  HOH A O   1 
+HETATM 4580 O  O   . HOH K 7 .   ? -14.440 -3.427  32.289  1.00 27.53 ? 949  HOH A O   1 
+HETATM 4581 O  O   . HOH K 7 .   ? -16.675 6.500   33.842  1.00 47.19 ? 950  HOH A O   1 
+HETATM 4582 O  O   . HOH K 7 .   ? 4.565   35.392  2.131   1.00 22.89 ? 951  HOH A O   1 
+HETATM 4583 O  O   . HOH K 7 .   ? 1.356   22.096  3.034   1.00 33.07 ? 952  HOH A O   1 
+HETATM 4584 O  O   . HOH K 7 .   ? 20.895  25.102  44.297  1.00 28.59 ? 953  HOH A O   1 
+HETATM 4585 O  O   A HOH K 7 .   ? 17.901  11.739  18.023  0.50 17.79 ? 954  HOH A O   1 
+HETATM 4586 O  O   B HOH K 7 .   ? 16.860  10.613  19.442  0.50 21.30 ? 954  HOH A O   1 
+HETATM 4587 O  O   . HOH K 7 .   ? -40.647 7.578   86.705  1.00 30.02 ? 955  HOH A O   1 
+HETATM 4588 O  O   . HOH K 7 .   ? 11.337  10.768  43.510  1.00 29.16 ? 956  HOH A O   1 
+HETATM 4589 O  O   . HOH K 7 .   ? -26.959 4.940   63.371  1.00 37.79 ? 957  HOH A O   1 
+HETATM 4590 O  O   . HOH K 7 .   ? -14.880 -1.334  33.931  1.00 28.01 ? 958  HOH A O   1 
+HETATM 4591 O  O   . HOH K 7 .   ? 0.992   17.474  6.593   1.00 24.54 ? 959  HOH A O   1 
+HETATM 4592 O  O   . HOH K 7 .   ? -20.577 30.965  109.274 1.00 32.60 ? 960  HOH A O   1 
+HETATM 4593 O  O   . HOH K 7 .   ? -20.998 -1.262  59.807  1.00 32.26 ? 961  HOH A O   1 
+HETATM 4594 O  O   . HOH K 7 .   ? 21.999  4.723   27.852  1.00 40.18 ? 962  HOH A O   1 
+HETATM 4595 O  O   . HOH K 7 .   ? -14.742 37.163  14.441  1.00 35.34 ? 963  HOH A O   1 
+HETATM 4596 O  O   . HOH K 7 .   ? -13.721 -6.081  32.550  1.00 28.91 ? 964  HOH A O   1 
+HETATM 4597 O  O   . HOH K 7 .   ? 25.427  25.347  33.567  1.00 50.37 ? 965  HOH A O   1 
+HETATM 4598 O  O   . HOH K 7 .   ? -7.104  8.686   29.194  1.00 31.75 ? 966  HOH A O   1 
+HETATM 4599 O  O   . HOH K 7 .   ? -33.440 -3.376  62.100  1.00 38.49 ? 967  HOH A O   1 
+HETATM 4600 O  O   . HOH K 7 .   ? 19.235  30.803  40.657  1.00 31.98 ? 968  HOH A O   1 
+HETATM 4601 O  O   . HOH K 7 .   ? 0.533   6.078   25.237  1.00 26.29 ? 969  HOH A O   1 
+HETATM 4602 O  O   . HOH K 7 .   ? -7.144  25.046  7.181   1.00 23.24 ? 970  HOH A O   1 
+HETATM 4603 O  O   . HOH K 7 .   ? -7.104  -3.890  23.653  1.00 36.40 ? 971  HOH A O   1 
+HETATM 4604 O  O   . HOH K 7 .   ? -1.843  3.009   50.469  1.00 42.91 ? 972  HOH A O   1 
+HETATM 4605 O  O   . HOH K 7 .   ? 22.137  33.883  28.730  1.00 34.31 ? 973  HOH A O   1 
+HETATM 4606 O  O   . HOH K 7 .   ? 20.787  9.415   17.305  1.00 45.89 ? 974  HOH A O   1 
+HETATM 4607 O  O   . HOH K 7 .   ? -3.814  -7.608  43.282  1.00 44.28 ? 975  HOH A O   1 
+HETATM 4608 O  O   . HOH K 7 .   ? -46.308 8.686   96.767  1.00 44.00 ? 976  HOH A O   1 
+HETATM 4609 O  O   . HOH K 7 .   ? -3.088  3.914   35.386  1.00 29.40 ? 977  HOH A O   1 
+HETATM 4610 O  O   . HOH K 7 .   ? -28.183 8.059   75.118  1.00 33.46 ? 978  HOH A O   1 
+HETATM 4611 O  O   . HOH K 7 .   ? 1.605   17.092  14.182  1.00 29.85 ? 979  HOH A O   1 
+HETATM 4612 O  O   . HOH K 7 .   ? -6.945  8.255   41.376  1.00 34.18 ? 980  HOH A O   1 
+HETATM 4613 O  O   . HOH K 7 .   ? -4.760  38.774  23.577  1.00 26.09 ? 981  HOH A O   1 
+HETATM 4614 O  O   . HOH K 7 .   ? -14.854 6.031   44.703  1.00 42.56 ? 982  HOH A O   1 
+HETATM 4615 O  O   . HOH K 7 .   ? 13.865  35.932  11.423  1.00 27.87 ? 983  HOH A O   1 
+HETATM 4616 O  O   . HOH K 7 .   ? -9.213  23.766  5.818   1.00 28.81 ? 984  HOH A O   1 
+HETATM 4617 O  O   . HOH K 7 .   ? -9.935  -9.014  25.668  1.00 32.90 ? 985  HOH A O   1 
+HETATM 4618 O  O   . HOH K 7 .   ? -18.648 23.966  110.062 1.00 29.66 ? 986  HOH A O   1 
+HETATM 4619 O  O   . HOH K 7 .   ? -34.624 7.445   71.597  1.00 40.81 ? 987  HOH A O   1 
+HETATM 4620 O  O   . HOH K 7 .   ? -19.436 16.068  106.378 1.00 48.50 ? 988  HOH A O   1 
+HETATM 4621 O  O   . HOH K 7 .   ? -8.508  17.601  2.265   1.00 44.71 ? 989  HOH A O   1 
+HETATM 4622 O  O   . HOH K 7 .   ? -15.824 -8.269  59.791  1.00 34.29 ? 990  HOH A O   1 
+HETATM 4623 O  O   . HOH K 7 .   ? 16.358  15.148  21.794  1.00 21.65 ? 991  HOH A O   1 
+HETATM 4624 O  O   . HOH K 7 .   ? -9.091  1.697   50.530  1.00 23.76 ? 992  HOH A O   1 
+HETATM 4625 O  O   . HOH K 7 .   ? -21.990 34.384  107.117 1.00 48.84 ? 993  HOH A O   1 
+HETATM 4626 O  O   . HOH K 7 .   ? 8.231   43.331  7.640   1.00 37.15 ? 994  HOH A O   1 
+HETATM 4627 O  O   . HOH K 7 .   ? -23.170 25.342  103.906 1.00 30.43 ? 995  HOH A O   1 
+HETATM 4628 O  O   . HOH K 7 .   ? -3.101  2.295   48.316  1.00 38.19 ? 996  HOH A O   1 
+HETATM 4629 O  O   . HOH K 7 .   ? -1.853  10.670  24.778  1.00 35.33 ? 997  HOH A O   1 
+HETATM 4630 O  O   . HOH K 7 .   ? -12.122 0.015   20.456  1.00 43.34 ? 998  HOH A O   1 
+HETATM 4631 O  O   . HOH K 7 .   ? -1.185  26.716  -1.804  1.00 38.91 ? 999  HOH A O   1 
+HETATM 4632 O  O   . HOH K 7 .   ? -26.609 -16.181 67.637  1.00 31.48 ? 1000 HOH A O   1 
+HETATM 4633 O  O   . HOH K 7 .   ? 26.913  27.890  26.761  1.00 32.74 ? 1001 HOH A O   1 
+HETATM 4634 O  O   . HOH K 7 .   ? 3.207   36.889  0.784   1.00 39.57 ? 1002 HOH A O   1 
+HETATM 4635 O  O   . HOH K 7 .   ? -25.980 10.386  81.513  1.00 37.87 ? 1003 HOH A O   1 
+HETATM 4636 O  O   . HOH K 7 .   ? 9.387   4.379   14.856  1.00 33.76 ? 1004 HOH A O   1 
+HETATM 4637 O  O   . HOH K 7 .   ? 2.594   -6.098  26.887  1.00 38.19 ? 1005 HOH A O   1 
+HETATM 4638 O  O   . HOH K 7 .   ? 6.970   34.300  42.190  1.00 48.35 ? 1006 HOH A O   1 
+HETATM 4639 O  O   . HOH K 7 .   ? 7.204   35.330  1.285   1.00 30.38 ? 1007 HOH A O   1 
+HETATM 4640 O  O   . HOH K 7 .   ? -15.788 16.498  27.076  1.00 34.21 ? 1008 HOH A O   1 
+HETATM 4641 O  O   . HOH K 7 .   ? 15.547  37.582  34.775  1.00 31.66 ? 1009 HOH A O   1 
+HETATM 4642 O  O   . HOH K 7 .   ? -6.117  38.747  26.745  1.00 27.10 ? 1010 HOH A O   1 
+HETATM 4643 O  O   . HOH K 7 .   ? 8.596   49.086  17.301  1.00 42.40 ? 1011 HOH A O   1 
+HETATM 4644 O  O   . HOH K 7 .   ? -0.232  9.158   39.937  1.00 40.73 ? 1012 HOH A O   1 
+HETATM 4645 O  O   . HOH K 7 .   ? -19.785 29.070  11.249  1.00 36.53 ? 1013 HOH A O   1 
+HETATM 4646 O  O   . HOH K 7 .   ? -4.410  7.411   33.405  1.00 40.27 ? 1014 HOH A O   1 
+HETATM 4647 O  O   . HOH K 7 .   ? -14.430 -1.728  25.063  1.00 30.96 ? 1015 HOH A O   1 
+HETATM 4648 O  O   . HOH K 7 .   ? 12.139  50.263  29.210  1.00 32.49 ? 1016 HOH A O   1 
+HETATM 4649 O  O   . HOH K 7 .   ? -23.250 33.151  23.565  1.00 40.63 ? 1017 HOH A O   1 
+HETATM 4650 O  O   . HOH K 7 .   ? -26.340 31.154  104.616 1.00 47.57 ? 1018 HOH A O   1 
+HETATM 4651 O  O   . HOH K 7 .   ? -7.758  -0.864  20.034  1.00 33.57 ? 1019 HOH A O   1 
+HETATM 4652 O  O   . HOH K 7 .   ? 0.431   7.173   27.898  1.00 28.68 ? 1020 HOH A O   1 
+HETATM 4653 O  O   . HOH K 7 .   ? -17.667 15.586  21.064  1.00 33.13 ? 1021 HOH A O   1 
+HETATM 4654 O  O   . HOH K 7 .   ? -45.638 0.279   95.655  1.00 36.41 ? 1022 HOH A O   1 
+HETATM 4655 O  O   . HOH K 7 .   ? -8.621  34.478  35.578  1.00 35.30 ? 1023 HOH A O   1 
+HETATM 4656 O  O   . HOH K 7 .   ? -28.845 15.632  104.126 1.00 38.79 ? 1024 HOH A O   1 
+HETATM 4657 O  O   . HOH K 7 .   ? 5.757   33.207  40.038  1.00 36.96 ? 1025 HOH A O   1 
+HETATM 4658 O  O   . HOH K 7 .   ? -35.053 11.041  101.227 1.00 45.41 ? 1026 HOH A O   1 
+HETATM 4659 O  O   . HOH K 7 .   ? -12.667 1.430   61.011  1.00 43.02 ? 1027 HOH A O   1 
+HETATM 4660 O  O   . HOH K 7 .   ? -33.109 23.702  101.860 1.00 54.04 ? 1028 HOH A O   1 
+HETATM 4661 O  O   A HOH K 7 .   ? -6.565  -8.866  48.845  0.50 24.97 ? 1029 HOH A O   1 
+HETATM 4662 O  O   B HOH K 7 .   ? -7.194  -9.429  47.180  0.50 35.02 ? 1029 HOH A O   1 
+HETATM 4663 O  O   . HOH K 7 .   ? -27.738 10.528  92.277  1.00 28.05 ? 1030 HOH A O   1 
+HETATM 4664 O  O   . HOH K 7 .   ? -15.772 2.123   68.231  1.00 41.70 ? 1031 HOH A O   1 
+HETATM 4665 O  O   . HOH K 7 .   ? -38.228 7.588   81.368  1.00 39.13 ? 1032 HOH A O   1 
+HETATM 4666 O  O   . HOH K 7 .   ? -20.982 5.480   66.032  1.00 37.75 ? 1033 HOH A O   1 
+HETATM 4667 O  O   . HOH K 7 .   ? -0.734  2.718   36.294  1.00 33.58 ? 1034 HOH A O   1 
+HETATM 4668 O  O   . HOH K 7 .   ? -14.594 16.696  31.204  1.00 40.43 ? 1035 HOH A O   1 
+HETATM 4669 O  O   A HOH K 7 .   ? 13.582  9.322   44.190  0.41 21.22 ? 1036 HOH A O   1 
+HETATM 4670 O  O   B HOH K 7 .   ? 14.166  9.527   41.989  0.59 23.67 ? 1036 HOH A O   1 
+HETATM 4671 O  O   . HOH K 7 .   ? -45.711 8.031   87.006  1.00 43.90 ? 1037 HOH A O   1 
+HETATM 4672 O  O   . HOH K 7 .   ? 18.338  43.691  32.420  1.00 40.89 ? 1038 HOH A O   1 
+HETATM 4673 O  O   . HOH K 7 .   ? 4.810   11.474  14.747  1.00 52.61 ? 1039 HOH A O   1 
+HETATM 4674 O  O   . HOH K 7 .   ? -2.290  46.333  21.440  1.00 34.60 ? 1040 HOH A O   1 
+HETATM 4675 O  O   . HOH K 7 .   ? 14.853  26.735  45.184  1.00 28.12 ? 1041 HOH A O   1 
+HETATM 4676 O  O   . HOH K 7 .   ? -1.084  1.127   15.729  1.00 41.01 ? 1042 HOH A O   1 
+HETATM 4677 O  O   . HOH K 7 .   ? -11.000 19.578  4.738   1.00 45.40 ? 1043 HOH A O   1 
+HETATM 4678 O  O   . HOH K 7 .   ? -7.156  7.646   36.727  1.00 52.22 ? 1044 HOH A O   1 
+HETATM 4679 O  O   . HOH K 7 .   ? -17.452 16.291  13.670  1.00 36.71 ? 1045 HOH A O   1 
+HETATM 4680 O  O   . HOH K 7 .   ? -12.593 -3.602  23.130  1.00 45.48 ? 1046 HOH A O   1 
+HETATM 4681 O  O   . HOH K 7 .   ? 4.046   39.894  36.744  1.00 31.19 ? 1047 HOH A O   1 
+HETATM 4682 O  O   . HOH K 7 .   ? 13.607  15.460  10.457  1.00 43.22 ? 1048 HOH A O   1 
+HETATM 4683 O  O   . HOH K 7 .   ? -9.610  33.732  33.206  1.00 28.01 ? 1049 HOH A O   1 
+HETATM 4684 O  O   . HOH K 7 .   ? -38.433 -3.090  90.612  1.00 39.52 ? 1050 HOH A O   1 
+HETATM 4685 O  O   . HOH K 7 .   ? -9.561  8.773   29.316  1.00 38.04 ? 1051 HOH A O   1 
+HETATM 4686 O  O   . HOH K 7 .   ? -23.759 28.226  21.818  1.00 42.09 ? 1052 HOH A O   1 
+HETATM 4687 O  O   . HOH K 7 .   ? -27.601 10.523  95.035  1.00 35.55 ? 1053 HOH A O   1 
+HETATM 4688 O  O   . HOH K 7 .   ? -15.610 3.350   41.036  1.00 40.25 ? 1054 HOH A O   1 
+HETATM 4689 O  O   A HOH K 7 .   ? 15.086  34.092  37.683  0.50 25.47 ? 1055 HOH A O   1 
+HETATM 4690 O  O   B HOH K 7 .   ? 15.921  32.661  38.305  0.50 30.09 ? 1055 HOH A O   1 
+HETATM 4691 O  O   . HOH K 7 .   ? 4.334   -1.748  21.112  1.00 42.17 ? 1056 HOH A O   1 
+HETATM 4692 O  O   . HOH K 7 .   ? 4.235   40.145  1.055   1.00 38.46 ? 1057 HOH A O   1 
+HETATM 4693 O  O   . HOH K 7 .   ? -16.739 -0.628  64.510  1.00 49.84 ? 1058 HOH A O   1 
+HETATM 4694 O  O   . HOH K 7 .   ? -23.713 29.417  103.872 1.00 33.93 ? 1059 HOH A O   1 
+HETATM 4695 O  O   . HOH K 7 .   ? 25.294  15.969  33.247  1.00 32.58 ? 1060 HOH A O   1 
+HETATM 4696 O  O   . HOH K 7 .   ? 11.168  26.943  4.899   1.00 31.08 ? 1061 HOH A O   1 
+HETATM 4697 O  O   . HOH K 7 .   ? -0.721  18.965  3.865   1.00 44.33 ? 1062 HOH A O   1 
+HETATM 4698 O  O   A HOH K 7 .   ? -21.224 -9.339  58.996  0.44 19.92 ? 1063 HOH A O   1 
+HETATM 4699 O  O   B HOH K 7 .   ? -19.352 -9.834  59.128  0.50 27.45 ? 1063 HOH A O   1 
+HETATM 4700 O  O   . HOH K 7 .   ? -39.632 -1.665  79.464  1.00 45.76 ? 1064 HOH A O   1 
+HETATM 4701 O  O   . HOH K 7 .   ? -6.362  6.932   39.100  1.00 40.92 ? 1065 HOH A O   1 
+HETATM 4702 O  O   . HOH K 7 .   ? -5.770  -9.352  35.198  1.00 34.46 ? 1066 HOH A O   1 
+HETATM 4703 O  O   . HOH K 7 .   ? -1.484  -6.211  22.998  1.00 33.61 ? 1067 HOH A O   1 
+HETATM 4704 O  O   . HOH K 7 .   ? -35.559 10.040  74.313  1.00 49.55 ? 1068 HOH A O   1 
+HETATM 4705 O  O   . HOH K 7 .   ? 7.349   10.432  12.265  1.00 43.03 ? 1069 HOH A O   1 
+HETATM 4706 O  O   . HOH K 7 .   ? 3.169   -2.470  32.145  1.00 33.80 ? 1070 HOH A O   1 
+HETATM 4707 O  O   . HOH K 7 .   ? -4.806  41.305  19.561  1.00 30.54 ? 1071 HOH A O   1 
+HETATM 4708 O  O   . HOH K 7 .   ? 13.300  44.399  17.345  1.00 30.90 ? 1072 HOH A O   1 
+HETATM 4709 O  O   . HOH K 7 .   ? -20.310 7.143   63.259  1.00 34.07 ? 1073 HOH A O   1 
+HETATM 4710 O  O   . HOH K 7 .   ? -1.826  8.945   19.239  0.87 45.37 ? 1074 HOH A O   1 
+HETATM 4711 O  O   . HOH K 7 .   ? -7.310  45.680  4.756   1.00 45.24 ? 1075 HOH A O   1 
+HETATM 4712 O  O   . HOH K 7 .   ? -24.221 -2.863  54.424  1.00 46.17 ? 1076 HOH A O   1 
+HETATM 4713 O  O   . HOH K 7 .   ? -26.448 34.534  109.209 1.00 43.72 ? 1077 HOH A O   1 
+HETATM 4714 O  O   . HOH K 7 .   ? 24.878  14.987  13.229  1.00 53.20 ? 1078 HOH A O   1 
+HETATM 4715 O  O   . HOH K 7 .   ? -11.524 8.965   23.202  1.00 34.86 ? 1079 HOH A O   1 
+HETATM 4716 O  O   . HOH K 7 .   ? 1.739   -0.373  34.096  1.00 36.70 ? 1080 HOH A O   1 
+HETATM 4717 O  O   . HOH K 7 .   ? -9.117  21.156  4.633   1.00 42.59 ? 1081 HOH A O   1 
+HETATM 4718 O  O   . HOH K 7 .   ? -24.537 19.016  103.123 1.00 48.92 ? 1082 HOH A O   1 
+HETATM 4719 O  O   . HOH K 7 .   ? -17.558 27.221  8.053   1.00 37.13 ? 1083 HOH A O   1 
+HETATM 4720 O  O   . HOH K 7 .   ? -23.378 25.317  15.860  1.00 44.65 ? 1084 HOH A O   1 
+HETATM 4721 O  O   . HOH K 7 .   ? -35.582 -8.617  69.174  1.00 32.42 ? 1085 HOH A O   1 
+HETATM 4722 O  O   . HOH K 7 .   ? -22.476 -2.350  57.810  1.00 31.25 ? 1086 HOH A O   1 
+HETATM 4723 O  O   . HOH K 7 .   ? -27.600 -3.304  87.456  1.00 40.39 ? 1087 HOH A O   1 
+HETATM 4724 O  O   . HOH K 7 .   ? 0.119   2.887   39.135  1.00 35.23 ? 1088 HOH A O   1 
+HETATM 4725 O  O   A HOH K 7 .   ? 0.080   -1.830  39.375  0.95 34.96 ? 1089 HOH A O   1 
+HETATM 4726 O  O   A HOH K 7 .   ? -18.088 4.761   71.377  0.50 24.40 ? 1090 HOH A O   1 
+HETATM 4727 O  O   B HOH K 7 .   ? -19.999 5.523   71.146  0.50 27.45 ? 1090 HOH A O   1 
+HETATM 4728 O  O   . HOH K 7 .   ? -20.913 -10.782 64.617  1.00 38.50 ? 1091 HOH A O   1 
+HETATM 4729 O  O   . HOH K 7 .   ? -11.036 1.429   58.500  1.00 40.34 ? 1092 HOH A O   1 
+HETATM 4730 O  O   A HOH K 7 .   ? -7.246  -12.924 41.157  0.45 26.16 ? 1093 HOH A O   1 
+HETATM 4731 O  O   B HOH K 7 .   ? -8.540  -12.849 40.862  0.55 30.47 ? 1093 HOH A O   1 
+HETATM 4732 O  O   . HOH K 7 .   ? -28.997 13.459  119.386 1.00 36.98 ? 1094 HOH A O   1 
+HETATM 4733 O  O   . HOH K 7 .   ? -18.999 -3.604  69.600  1.00 39.48 ? 1095 HOH A O   1 
+HETATM 4734 O  O   . HOH K 7 .   ? 0.736   5.380   15.253  1.00 43.97 ? 1096 HOH A O   1 
+HETATM 4735 O  O   . HOH K 7 .   ? -40.372 6.135   82.453  1.00 34.38 ? 1097 HOH A O   1 
+HETATM 4736 O  O   . HOH K 7 .   ? -7.683  3.900   15.468  1.00 41.54 ? 1098 HOH A O   1 
+HETATM 4737 O  O   . HOH K 7 .   ? -25.211 25.524  18.242  1.00 50.22 ? 1099 HOH A O   1 
+HETATM 4738 O  O   . HOH K 7 .   ? -1.109  3.758   41.574  1.00 33.31 ? 1100 HOH A O   1 
+HETATM 4739 O  O   . HOH K 7 .   ? -15.052 36.645  28.661  1.00 42.24 ? 1101 HOH A O   1 
+HETATM 4740 O  O   . HOH K 7 .   ? -1.652  48.175  5.719   1.00 50.79 ? 1102 HOH A O   1 
+HETATM 4741 O  O   . HOH K 7 .   ? -8.772  4.267   50.990  1.00 16.92 ? 1103 HOH A O   1 
+HETATM 4742 O  O   A HOH K 7 .   ? 13.542  23.573  10.303  0.50 15.61 ? 1104 HOH A O   1 
+HETATM 4743 O  O   B HOH K 7 .   ? 12.173  22.490  10.287  0.50 22.72 ? 1104 HOH A O   1 
+HETATM 4744 O  O   . HOH K 7 .   ? -18.213 5.350   66.521  1.00 23.49 ? 1105 HOH A O   1 
+HETATM 4745 O  O   . HOH K 7 .   ? -37.677 5.236   100.593 1.00 22.11 ? 1106 HOH A O   1 
+HETATM 4746 O  O   . HOH K 7 .   ? 12.834  6.972   34.275  1.00 18.56 ? 1107 HOH A O   1 
+HETATM 4747 O  O   A HOH K 7 .   ? 12.181  34.365  41.134  0.66 26.32 ? 1108 HOH A O   1 
+HETATM 4748 O  O   B HOH K 7 .   ? 13.802  34.544  40.485  0.34 19.37 ? 1108 HOH A O   1 
+HETATM 4749 O  O   . HOH K 7 .   ? 13.341  3.202   16.682  1.00 31.63 ? 1109 HOH A O   1 
+HETATM 4750 O  O   . HOH K 7 .   ? 11.075  24.823  6.094   1.00 36.13 ? 1110 HOH A O   1 
+HETATM 4751 O  O   . HOH K 7 .   ? -37.582 -6.160  72.495  1.00 44.21 ? 1111 HOH A O   1 
+HETATM 4752 O  O   . HOH K 7 .   ? 14.500  33.937  6.697   1.00 37.55 ? 1112 HOH A O   1 
+HETATM 4753 O  O   . HOH K 7 .   ? 23.489  23.988  43.834  1.00 47.21 ? 1113 HOH A O   1 
+HETATM 4754 O  O   . HOH K 7 .   ? 14.692  25.302  8.519   1.00 22.65 ? 1114 HOH A O   1 
+HETATM 4755 O  O   . HOH K 7 .   ? 18.102  38.350  34.582  1.00 41.43 ? 1115 HOH A O   1 
+HETATM 4756 O  O   . HOH K 7 .   ? 2.109   12.851  13.647  1.00 44.69 ? 1116 HOH A O   1 
+HETATM 4757 O  O   . HOH K 7 .   ? -1.995  1.029   46.099  1.00 30.60 ? 1117 HOH A O   1 
+HETATM 4758 O  O   . HOH K 7 .   ? 15.893  39.932  14.157  1.00 45.40 ? 1118 HOH A O   1 
+HETATM 4759 O  O   . HOH K 7 .   ? 16.668  5.941   11.743  1.00 40.88 ? 1119 HOH A O   1 
+HETATM 4760 O  O   . HOH K 7 .   ? -38.208 15.616  90.930  1.00 53.31 ? 1120 HOH A O   1 
+HETATM 4761 O  O   . HOH K 7 .   ? -23.350 21.411  103.969 1.00 40.39 ? 1121 HOH A O   1 
+HETATM 4762 O  O   . HOH K 7 .   ? 25.461  31.818  16.191  1.00 32.84 ? 1122 HOH A O   1 
+HETATM 4763 O  O   . HOH K 7 .   ? -0.156  23.634  1.418   1.00 32.46 ? 1123 HOH A O   1 
+HETATM 4764 O  O   B HOH K 7 .   ? 1.494   14.515  11.325  0.50 34.78 ? 1124 HOH A O   1 
+HETATM 4765 O  O   A HOH K 7 .   ? 4.093   46.072  10.653  0.53 28.42 ? 1125 HOH A O   1 
+HETATM 4766 O  O   B HOH K 7 .   ? 4.820   44.275  11.094  0.47 28.98 ? 1125 HOH A O   1 
+HETATM 4767 O  O   . HOH K 7 .   ? 19.229  20.800  12.187  1.00 24.42 ? 1126 HOH A O   1 
+HETATM 4768 O  O   . HOH K 7 .   ? 23.501  20.638  11.277  1.00 40.09 ? 1127 HOH A O   1 
+HETATM 4769 O  O   . HOH K 7 .   ? -25.889 11.701  104.240 1.00 24.92 ? 1128 HOH A O   1 
+HETATM 4770 O  O   . HOH K 7 .   ? -25.348 36.885  21.001  1.00 52.76 ? 1129 HOH A O   1 
+HETATM 4771 O  O   . HOH K 7 .   ? -9.673  38.878  11.547  1.00 24.08 ? 1130 HOH A O   1 
+HETATM 4772 O  O   . HOH K 7 .   ? -13.530 36.435  10.306  1.00 37.46 ? 1131 HOH A O   1 
+HETATM 4773 O  O   . HOH K 7 .   ? -11.787 40.806  11.987  1.00 38.33 ? 1132 HOH A O   1 
+HETATM 4774 O  O   . HOH K 7 .   ? -8.099  42.543  9.882   1.00 29.96 ? 1133 HOH A O   1 
+HETATM 4775 O  O   . HOH K 7 .   ? -4.193  44.539  19.817  1.00 27.61 ? 1134 HOH A O   1 
+HETATM 4776 O  O   . HOH K 7 .   ? -37.800 24.944  111.975 1.00 35.28 ? 1135 HOH A O   1 
+HETATM 4777 O  O   A HOH K 7 .   ? -23.021 23.978  13.739  0.50 35.72 ? 1136 HOH A O   1 
+HETATM 4778 O  O   B HOH K 7 .   ? -22.787 24.767  12.085  0.50 38.82 ? 1136 HOH A O   1 
+HETATM 4779 O  O   . HOH K 7 .   ? -22.729 28.255  15.036  1.00 36.79 ? 1137 HOH A O   1 
+HETATM 4780 O  O   . HOH K 7 .   ? -20.252 29.180  15.896  1.00 30.64 ? 1138 HOH A O   1 
+HETATM 4781 O  O   . HOH K 7 .   ? -5.578  12.537  12.640  1.00 37.18 ? 1139 HOH A O   1 
+HETATM 4782 O  O   . HOH K 7 .   ? -5.420  12.129  9.557   1.00 43.47 ? 1140 HOH A O   1 
+HETATM 4783 O  O   . HOH K 7 .   ? -4.042  21.978  39.277  1.00 19.62 ? 1141 HOH A O   1 
+HETATM 4784 O  O   . HOH K 7 .   ? 15.723  4.488   22.299  1.00 21.26 ? 1142 HOH A O   1 
+HETATM 4785 O  O   . HOH K 7 .   ? 13.673  5.203   20.715  1.00 21.35 ? 1143 HOH A O   1 
+HETATM 4786 O  O   A HOH K 7 .   ? 16.062  41.311  17.644  0.50 13.03 ? 1144 HOH A O   1 
+HETATM 4787 O  O   . HOH K 7 .   ? 24.955  32.213  19.047  1.00 29.95 ? 1145 HOH A O   1 
+HETATM 4788 O  O   . HOH K 7 .   ? 23.528  19.125  17.057  1.00 46.11 ? 1146 HOH A O   1 
+HETATM 4789 O  O   . HOH K 7 .   ? -8.226  5.680   29.920  1.00 23.92 ? 1147 HOH A O   1 
+HETATM 4790 O  O   . HOH K 7 .   ? -13.933 6.442   39.777  1.00 40.34 ? 1148 HOH A O   1 
+HETATM 4791 O  O   . HOH K 7 .   ? -13.984 4.450   21.066  1.00 36.13 ? 1149 HOH A O   1 
+HETATM 4792 O  O   . HOH K 7 .   ? -5.957  -7.769  30.610  1.00 37.81 ? 1150 HOH A O   1 
+HETATM 4793 O  O   . HOH K 7 .   ? -7.630  -11.713 36.164  1.00 41.78 ? 1151 HOH A O   1 
+HETATM 4794 O  O   . HOH K 7 .   ? -20.279 -7.443  46.796  1.00 39.79 ? 1152 HOH A O   1 
+HETATM 4795 O  O   . HOH K 7 .   ? 3.827   -2.386  28.194  1.00 33.26 ? 1153 HOH A O   1 
+HETATM 4796 O  O   . HOH K 7 .   ? -24.045 5.292   71.738  1.00 29.55 ? 1154 HOH A O   1 
+HETATM 4797 O  O   . HOH K 7 .   ? -29.387 6.261   68.050  1.00 34.90 ? 1155 HOH A O   1 
+HETATM 4798 O  O   . HOH K 7 .   ? -31.717 5.474   67.759  1.00 29.80 ? 1156 HOH A O   1 
+HETATM 4799 O  O   . HOH K 7 .   ? -33.738 14.160  85.690  1.00 37.45 ? 1157 HOH A O   1 
+HETATM 4800 O  O   . HOH K 7 .   ? -40.933 11.532  88.336  1.00 32.38 ? 1158 HOH A O   1 
+HETATM 4801 O  O   . HOH K 7 .   ? -28.167 -8.503  63.948  1.00 27.75 ? 1159 HOH A O   1 
+HETATM 4802 O  O   . HOH K 7 .   ? -34.288 -6.397  78.873  1.00 32.26 ? 1160 HOH A O   1 
+HETATM 4803 O  O   . HOH K 7 .   ? -27.654 -12.085 61.748  1.00 37.63 ? 1161 HOH A O   1 
+HETATM 4804 O  O   . HOH K 7 .   ? -24.451 26.222  112.924 1.00 31.42 ? 1162 HOH A O   1 
+HETATM 4805 O  O   . HOH K 7 .   ? -24.495 27.887  110.589 1.00 34.81 ? 1163 HOH A O   1 
+HETATM 4806 O  O   . HOH K 7 .   ? -24.965 23.277  103.031 1.00 37.84 ? 1164 HOH A O   1 
+HETATM 4807 O  O   . HOH K 7 .   ? -33.350 16.901  116.612 1.00 33.90 ? 1165 HOH A O   1 
+HETATM 4808 O  O   . HOH K 7 .   ? -1.522  9.647   29.998  1.00 28.56 ? 1166 HOH A O   1 
+HETATM 4809 O  O   . HOH K 7 .   ? -1.967  6.881   25.636  1.00 44.21 ? 1167 HOH A O   1 
+HETATM 4810 O  O   . HOH K 7 .   ? -19.572 -0.667  43.934  1.00 39.44 ? 1168 HOH A O   1 
+HETATM 4811 O  O   . HOH K 7 .   ? -43.170 1.631   92.469  1.00 32.52 ? 1169 HOH A O   1 
+HETATM 4812 O  O   . HOH K 7 .   ? -21.252 22.853  120.145 1.00 42.73 ? 1170 HOH A O   1 
+HETATM 4813 O  O   . HOH K 7 .   ? 18.846  18.610  10.824  1.00 34.36 ? 1171 HOH A O   1 
+HETATM 4814 O  O   . HOH K 7 .   ? 13.386  2.770   19.366  1.00 34.15 ? 1172 HOH A O   1 
+HETATM 4815 O  O   . HOH K 7 .   ? 1.746   24.818  42.540  1.00 33.36 ? 1173 HOH A O   1 
+HETATM 4816 O  O   . HOH K 7 .   ? -31.378 -4.765  90.083  1.00 31.29 ? 1174 HOH A O   1 
+HETATM 4817 O  O   . HOH K 7 .   ? 16.547  9.144   36.923  1.00 35.17 ? 1175 HOH A O   1 
+HETATM 4818 O  O   . HOH K 7 .   ? -15.770 19.738  115.498 1.00 38.04 ? 1176 HOH A O   1 
+HETATM 4819 O  O   . HOH K 7 .   ? -31.329 9.721   105.546 1.00 40.13 ? 1177 HOH A O   1 
+HETATM 4820 O  O   . HOH K 7 .   ? -29.973 10.747  74.150  1.00 38.15 ? 1178 HOH A O   1 
+HETATM 4821 O  O   . HOH K 7 .   ? -0.029  -1.594  16.948  1.00 40.78 ? 1179 HOH A O   1 
+HETATM 4822 O  O   . HOH K 7 .   ? -5.163  38.400  20.682  1.00 32.10 ? 1180 HOH A O   1 
+HETATM 4823 O  O   . HOH K 7 .   ? -14.168 11.286  11.198  1.00 42.01 ? 1181 HOH A O   1 
+HETATM 4824 O  O   . HOH K 7 .   ? 20.693  7.146   31.704  1.00 37.10 ? 1182 HOH A O   1 
+HETATM 4825 O  O   . HOH K 7 .   ? -2.109  32.905  35.912  1.00 19.74 ? 1183 HOH A O   1 
+HETATM 4826 O  O   . HOH K 7 .   ? -1.451  36.578  36.967  1.00 36.36 ? 1184 HOH A O   1 
+HETATM 4827 O  O   . HOH K 7 .   ? -9.753  38.334  -0.054  1.00 48.86 ? 1185 HOH A O   1 
+HETATM 4828 O  O   . HOH K 7 .   ? -6.619  33.471  -0.534  1.00 37.48 ? 1186 HOH A O   1 
+HETATM 4829 O  O   . HOH K 7 .   ? -10.844 37.078  3.342   1.00 42.00 ? 1187 HOH A O   1 
+HETATM 4830 O  O   . HOH K 7 .   ? 2.597   15.139  7.528   1.00 46.64 ? 1188 HOH A O   1 
+HETATM 4831 O  O   . HOH K 7 .   ? 9.890   7.054   11.660  1.00 40.55 ? 1189 HOH A O   1 
+HETATM 4832 O  O   . HOH K 7 .   ? 14.567  51.858  27.982  1.00 43.00 ? 1190 HOH A O   1 
+HETATM 4833 O  O   . HOH K 7 .   ? 9.210   44.330  13.143  1.00 45.19 ? 1191 HOH A O   1 
+HETATM 4834 O  O   A HOH K 7 .   ? 9.377   39.499  0.919   0.50 32.96 ? 1192 HOH A O   1 
+HETATM 4835 O  O   B HOH K 7 .   ? 8.537   37.882  0.348   0.50 29.53 ? 1192 HOH A O   1 
+HETATM 4836 O  O   . HOH K 7 .   ? -28.903 31.129  122.316 1.00 50.08 ? 1193 HOH A O   1 
+HETATM 4837 O  O   . HOH K 7 .   ? 9.469   42.501  35.831  1.00 38.81 ? 1194 HOH A O   1 
+HETATM 4838 O  O   . HOH K 7 .   ? 10.241  47.072  33.912  1.00 53.46 ? 1195 HOH A O   1 
+HETATM 4839 O  O   . HOH K 7 .   ? 9.354   32.579  5.009   1.00 33.19 ? 1196 HOH A O   1 
+HETATM 4840 O  O   . HOH K 7 .   ? -10.776 38.080  26.633  1.00 40.90 ? 1197 HOH A O   1 
+HETATM 4841 O  O   . HOH K 7 .   ? -11.386 38.416  29.259  1.00 40.05 ? 1198 HOH A O   1 
+HETATM 4842 O  O   . HOH K 7 .   ? -9.606  42.848  12.446  1.00 41.89 ? 1199 HOH A O   1 
+HETATM 4843 O  O   . HOH K 7 .   ? -11.430 37.842  6.234   1.00 34.74 ? 1200 HOH A O   1 
+HETATM 4844 O  O   A HOH K 7 .   ? -5.095  28.670  40.892  0.50 24.10 ? 1201 HOH A O   1 
+HETATM 4845 O  O   B HOH K 7 .   ? -3.468  29.540  39.429  0.50 35.55 ? 1201 HOH A O   1 
+HETATM 4846 O  O   . HOH K 7 .   ? 4.407   30.138  41.835  1.00 46.24 ? 1202 HOH A O   1 
+HETATM 4847 O  O   A HOH K 7 .   ? -13.699 14.399  31.895  0.50 21.47 ? 1203 HOH A O   1 
+HETATM 4848 O  O   B HOH K 7 .   ? -12.141 13.910  32.273  0.50 28.86 ? 1203 HOH A O   1 
+HETATM 4849 O  O   . HOH K 7 .   ? 13.037  8.451   50.339  1.00 44.09 ? 1204 HOH A O   1 
+HETATM 4850 O  O   . HOH K 7 .   ? 19.960  10.653  35.913  1.00 43.82 ? 1205 HOH A O   1 
+HETATM 4851 O  O   . HOH K 7 .   ? 18.553  10.215  38.198  1.00 38.97 ? 1206 HOH A O   1 
+HETATM 4852 O  O   . HOH K 7 .   ? 0.821   7.579   35.977  1.00 35.80 ? 1207 HOH A O   1 
+HETATM 4853 O  O   . HOH K 7 .   ? 1.942   5.814   34.111  1.00 44.82 ? 1208 HOH A O   1 
+HETATM 4854 O  O   . HOH K 7 .   ? 2.982   4.252   30.716  1.00 35.20 ? 1209 HOH A O   1 
+HETATM 4855 O  O   . HOH K 7 .   ? 5.847   4.379   28.906  1.00 37.91 ? 1210 HOH A O   1 
+HETATM 4856 O  O   . HOH K 7 .   ? 24.978  27.144  22.408  1.00 36.42 ? 1211 HOH A O   1 
+HETATM 4857 O  O   . HOH K 7 .   ? 28.081  22.560  22.428  1.00 43.28 ? 1212 HOH A O   1 
+HETATM 4858 O  O   . HOH K 7 .   ? -11.612 -7.353  22.499  1.00 40.35 ? 1213 HOH A O   1 
+HETATM 4859 O  O   . HOH K 7 .   ? 16.057  47.049  32.517  1.00 49.79 ? 1214 HOH A O   1 
+HETATM 4860 O  O   . HOH K 7 .   ? 16.309  19.475  9.760   1.00 37.10 ? 1215 HOH A O   1 
+HETATM 4861 O  O   . HOH K 7 .   ? -28.266 -5.647  58.082  1.00 48.34 ? 1216 HOH A O   1 
+HETATM 4862 O  O   . HOH K 7 .   ? -14.012 -7.976  44.048  1.00 43.59 ? 1217 HOH A O   1 
+HETATM 4863 O  O   . HOH K 7 .   ? -17.022 1.435   32.964  1.00 39.47 ? 1218 HOH A O   1 
+HETATM 4864 O  O   . HOH K 7 .   ? -3.582  -7.023  30.450  1.00 35.10 ? 1219 HOH A O   1 
+HETATM 4865 O  O   . HOH K 7 .   ? -6.612  -6.526  56.204  1.00 43.51 ? 1220 HOH A O   1 
+HETATM 4866 O  O   . HOH K 7 .   ? -33.621 10.591  80.741  1.00 33.56 ? 1221 HOH A O   1 
+HETATM 4867 O  O   . HOH K 7 .   ? -24.038 7.059   83.768  1.00 58.05 ? 1222 HOH A O   1 
+HETATM 4868 O  O   . HOH K 7 .   ? -37.136 9.320   83.070  1.00 45.85 ? 1223 HOH A O   1 
+HETATM 4869 O  O   . HOH K 7 .   ? -45.126 1.823   89.866  1.00 53.07 ? 1224 HOH A O   1 
+HETATM 4870 O  O   . HOH K 7 .   ? -35.252 -2.582  84.572  1.00 35.89 ? 1225 HOH A O   1 
+HETATM 4871 O  O   . HOH K 7 .   ? -36.298 -4.037  82.540  1.00 38.94 ? 1226 HOH A O   1 
+HETATM 4872 O  O   . HOH K 7 .   ? -36.251 -4.772  78.373  1.00 48.39 ? 1227 HOH A O   1 
+HETATM 4873 O  O   . HOH K 7 .   ? -38.848 -0.585  73.198  1.00 42.59 ? 1228 HOH A O   1 
+HETATM 4874 O  O   . HOH K 7 .   ? -28.432 -9.676  78.333  1.00 46.22 ? 1229 HOH A O   1 
+HETATM 4875 O  O   . HOH K 7 .   ? -32.291 9.713   96.376  1.00 34.80 ? 1230 HOH A O   1 
+HETATM 4876 O  O   . HOH K 7 .   ? -28.823 -15.734 63.429  1.00 37.35 ? 1231 HOH A O   1 
+HETATM 4877 O  O   . HOH K 7 .   ? -31.125 26.456  106.774 1.00 42.04 ? 1232 HOH A O   1 
+HETATM 4878 O  O   . HOH K 7 .   ? 23.707  21.295  18.108  1.00 39.02 ? 1233 HOH A O   1 
+HETATM 4879 O  O   . HOH K 7 .   ? 18.060  22.545  46.291  1.00 49.34 ? 1234 HOH A O   1 
+HETATM 4880 O  O   . HOH K 7 .   ? -15.513 23.769  36.847  1.00 37.00 ? 1235 HOH A O   1 
+HETATM 4881 O  O   . HOH K 7 .   ? -14.563 31.391  36.822  1.00 46.96 ? 1236 HOH A O   1 
+HETATM 4882 O  O   A HOH K 7 .   ? 19.833  38.967  28.919  0.52 27.30 ? 1237 HOH A O   1 
+HETATM 4883 O  O   B HOH K 7 .   ? 20.089  37.321  29.697  0.48 20.53 ? 1237 HOH A O   1 
+HETATM 4884 O  O   . HOH K 7 .   ? -20.477 22.104  14.804  1.00 47.99 ? 1238 HOH A O   1 
+HETATM 4885 O  O   . HOH K 7 .   ? -18.826 19.804  13.449  1.00 51.01 ? 1239 HOH A O   1 
+HETATM 4886 O  O   . HOH K 7 .   ? -15.703 17.949  5.047   1.00 44.51 ? 1240 HOH A O   1 
+HETATM 4887 O  O   . HOH K 7 .   ? -17.022 -7.468  61.834  1.00 45.69 ? 1241 HOH A O   1 
+HETATM 4888 O  O   . HOH K 7 .   ? -28.973 -9.362  84.114  1.00 33.68 ? 1242 HOH A O   1 
+HETATM 4889 O  O   . HOH K 7 .   ? 10.710  23.545  3.833   1.00 37.61 ? 1243 HOH A O   1 
+HETATM 4890 O  O   . HOH K 7 .   ? -26.013 0.720   91.971  1.00 55.27 ? 1244 HOH A O   1 
+HETATM 4891 O  O   . HOH K 7 .   ? -20.303 0.805   87.546  1.00 50.44 ? 1245 HOH A O   1 
+HETATM 4892 O  O   . HOH K 7 .   ? 15.687  49.201  33.344  1.00 50.69 ? 1246 HOH A O   1 
+HETATM 4893 O  O   . HOH K 7 .   ? 19.539  48.157  30.679  1.00 40.35 ? 1247 HOH A O   1 
+HETATM 4894 O  O   . HOH K 7 .   ? -11.355 -11.271 37.373  1.00 52.10 ? 1248 HOH A O   1 
+HETATM 4895 O  O   . HOH K 7 .   ? -21.003 -5.516  80.053  1.00 47.41 ? 1249 HOH A O   1 
+HETATM 4896 O  O   . HOH K 7 .   ? -20.950 2.295   74.174  1.00 46.82 ? 1250 HOH A O   1 
+HETATM 4897 O  O   . HOH K 7 .   ? -21.457 3.558   80.295  1.00 39.95 ? 1251 HOH A O   1 
+HETATM 4898 O  O   . HOH K 7 .   ? -36.210 15.032  97.569  1.00 50.62 ? 1252 HOH A O   1 
+HETATM 4899 O  O   . HOH K 7 .   ? -34.500 15.030  106.309 1.00 50.39 ? 1253 HOH A O   1 
+HETATM 4900 O  O   . HOH K 7 .   ? -33.987 -5.853  65.815  1.00 37.73 ? 1254 HOH A O   1 
+HETATM 4901 O  O   . HOH K 7 .   ? -26.240 13.854  121.358 1.00 39.33 ? 1255 HOH A O   1 
+HETATM 4902 O  O   . HOH K 7 .   ? -24.110 27.285  102.029 1.00 42.06 ? 1256 HOH A O   1 
+HETATM 4903 O  O   . HOH K 7 .   ? -21.435 5.276   54.720  1.00 38.74 ? 1257 HOH A O   1 
+HETATM 4904 O  O   . HOH K 7 .   ? -18.805 13.805  123.051 1.00 39.16 ? 1258 HOH A O   1 
+HETATM 4905 O  O   . HOH K 7 .   ? -16.695 6.128   51.323  1.00 45.04 ? 1259 HOH A O   1 
+HETATM 4906 O  O   . HOH K 7 .   ? 5.260   0.470   20.083  1.00 44.33 ? 1260 HOH A O   1 
+HETATM 4907 O  O   . HOH K 7 .   ? -10.258 39.663  2.121   1.00 39.07 ? 1261 HOH A O   1 
+HETATM 4908 O  O   . HOH K 7 .   ? -8.496  2.282   57.642  1.00 38.49 ? 1262 HOH A O   1 
+HETATM 4909 O  O   A HOH K 7 .   ? 21.945  7.652   23.592  0.50 31.99 ? 1263 HOH A O   1 
+HETATM 4910 O  O   B HOH K 7 .   ? -17.234 17.159  107.981 0.50 22.15 ? 1263 HOH A O   1 
+HETATM 4911 O  O   . HOH K 7 .   ? 23.582  23.560  17.325  1.00 45.59 ? 1264 HOH A O   1 
+HETATM 4912 O  O   . HOH K 7 .   ? -23.577 31.417  22.183  1.00 54.65 ? 1265 HOH A O   1 
+HETATM 4913 O  O   . HOH K 7 .   ? -13.669 9.886   21.828  1.00 40.08 ? 1266 HOH A O   1 
+HETATM 4914 O  O   . HOH K 7 .   ? -8.878  9.676   18.331  1.00 49.91 ? 1267 HOH A O   1 
+HETATM 4915 O  O   . HOH K 7 .   ? -22.373 4.124   74.050  1.00 48.86 ? 1268 HOH A O   1 
+HETATM 4916 O  O   . HOH K 7 .   ? 14.122  6.696   12.272  1.00 42.58 ? 1269 HOH A O   1 
+HETATM 4917 O  O   . HOH K 7 .   ? -16.738 -3.355  31.734  1.00 49.07 ? 1270 HOH A O   1 
+HETATM 4918 O  O   . HOH K 7 .   ? -29.337 33.475  109.161 1.00 53.76 ? 1271 HOH A O   1 
+HETATM 4919 O  O   . HOH K 7 .   ? 10.728  18.597  10.270  1.00 39.65 ? 1272 HOH A O   1 
+HETATM 4920 O  O   . HOH K 7 .   ? -36.829 -3.114  80.111  1.00 49.00 ? 1273 HOH A O   1 
+HETATM 4921 O  O   . HOH K 7 .   ? -39.619 0.060   87.050  1.00 54.75 ? 1274 HOH A O   1 
+HETATM 4922 O  O   . HOH K 7 .   ? 2.523   39.615  39.056  1.00 49.83 ? 1275 HOH A O   1 
+HETATM 4923 O  O   A HOH K 7 .   ? 6.097   35.959  38.160  0.50 25.14 ? 1276 HOH A O   1 
+HETATM 4924 O  O   B HOH K 7 .   ? 5.866   37.740  37.873  0.50 26.01 ? 1276 HOH A O   1 
+HETATM 4925 O  O   . HOH K 7 .   ? -6.243  8.453   32.110  1.00 37.59 ? 1277 HOH A O   1 
+HETATM 4926 O  O   . HOH K 7 .   ? 6.919   9.041   14.154  1.00 49.27 ? 1278 HOH A O   1 
+HETATM 4927 O  O   . HOH K 7 .   ? 16.310  37.159  9.102   1.00 48.50 ? 1279 HOH A O   1 
+HETATM 4928 O  O   . HOH K 7 .   ? 9.338   35.077  40.382  1.00 33.87 ? 1280 HOH A O   1 
+HETATM 4929 O  O   . HOH K 7 .   ? 7.560   2.942   23.386  1.00 48.88 ? 1281 HOH A O   1 
+HETATM 4930 O  O   . HOH K 7 .   ? -1.754  10.349  36.644  1.00 41.65 ? 1282 HOH A O   1 
+HETATM 4931 O  O   . HOH K 7 .   ? -20.939 -2.782  36.378  1.00 46.28 ? 1283 HOH A O   1 
+HETATM 4932 O  O   . HOH K 7 .   ? -23.264 -16.516 60.356  1.00 42.47 ? 1284 HOH A O   1 
+HETATM 4933 O  O   . HOH K 7 .   ? -16.936 31.149  6.382   1.00 48.08 ? 1285 HOH A O   1 
+HETATM 4934 O  O   . HOH K 7 .   ? -15.377 35.187  5.648   1.00 41.08 ? 1286 HOH A O   1 
+HETATM 4935 O  O   . HOH K 7 .   ? 0.353   8.811   18.243  1.00 43.76 ? 1287 HOH A O   1 
+HETATM 4936 O  O   . HOH K 7 .   ? -26.354 -8.190  59.884  1.00 50.96 ? 1288 HOH A O   1 
+HETATM 4937 O  O   . HOH K 7 .   ? -1.605  43.333  0.898   0.95 39.53 ? 1289 HOH A O   1 
+HETATM 4938 O  O   . HOH K 7 .   ? -4.554  10.390  40.871  1.00 37.22 ? 1290 HOH A O   1 
+HETATM 4939 O  O   . HOH K 7 .   ? -12.572 -8.749  41.809  1.00 42.96 ? 1291 HOH A O   1 
+HETATM 4940 O  O   . HOH K 7 .   ? -40.133 8.823   101.470 1.00 44.86 ? 1292 HOH A O   1 
+HETATM 4941 O  O   . HOH K 7 .   ? 2.172   1.224   30.623  1.00 41.87 ? 1293 HOH A O   1 
+HETATM 4942 O  O   . HOH K 7 .   ? 27.225  22.216  31.826  1.00 37.92 ? 1294 HOH A O   1 
+HETATM 4943 O  O   . HOH K 7 .   ? -40.318 4.820   73.878  1.00 42.97 ? 1295 HOH A O   1 
+HETATM 4944 O  O   . HOH K 7 .   ? -23.154 -3.922  86.317  1.00 47.94 ? 1296 HOH A O   1 
+HETATM 4945 O  O   A HOH K 7 .   ? -5.436  29.416  2.307   0.50 21.27 ? 1297 HOH A O   1 
+HETATM 4946 O  O   B HOH K 7 .   ? -6.963  29.202  3.155   0.50 31.19 ? 1297 HOH A O   1 
+HETATM 4947 O  O   . HOH K 7 .   ? 21.857  38.184  21.865  1.00 49.65 ? 1298 HOH A O   1 
+HETATM 4948 O  O   . HOH K 7 .   ? -13.173 36.723  12.638  1.00 46.19 ? 1299 HOH A O   1 
+HETATM 4949 O  O   . HOH K 7 .   ? 1.975   14.462  15.507  1.00 44.48 ? 1300 HOH A O   1 
+HETATM 4950 O  O   . HOH K 7 .   ? -2.983  41.708  23.778  1.00 45.64 ? 1301 HOH A O   1 
+HETATM 4951 O  O   . HOH K 7 .   ? 18.899  9.788   18.756  1.00 41.30 ? 1302 HOH A O   1 
+HETATM 4952 O  O   . HOH K 7 .   ? -13.265 17.553  6.166   1.00 40.01 ? 1303 HOH A O   1 
+HETATM 4953 O  O   . HOH K 7 .   ? 6.976   39.890  37.593  1.00 46.52 ? 1304 HOH A O   1 
+HETATM 4954 O  O   . HOH K 7 .   ? 12.043  33.870  6.938   1.00 39.95 ? 1305 HOH A O   1 
+HETATM 4955 O  O   . HOH K 7 .   ? 9.923   40.234  36.768  1.00 53.84 ? 1306 HOH A O   1 
+HETATM 4956 O  O   . HOH K 7 .   ? -41.089 10.320  86.279  1.00 42.42 ? 1307 HOH A O   1 
+HETATM 4957 O  O   . HOH K 7 .   ? -5.194  -2.444  18.340  1.00 48.46 ? 1308 HOH A O   1 
+HETATM 4958 O  O   . HOH K 7 .   ? -2.837  40.729  29.313  1.00 45.06 ? 1309 HOH A O   1 
+HETATM 4959 O  O   . HOH K 7 .   ? -22.802 27.640  12.523  1.00 47.10 ? 1310 HOH A O   1 
+HETATM 4960 O  O   . HOH K 7 .   ? -20.129 30.533  8.954   1.00 40.79 ? 1311 HOH A O   1 
+HETATM 4961 O  O   . HOH K 7 .   ? 19.870  37.322  32.817  1.00 49.70 ? 1312 HOH A O   1 
+HETATM 4962 O  O   . HOH K 7 .   ? -40.862 -2.152  91.671  1.00 50.01 ? 1313 HOH A O   1 
+HETATM 4963 O  O   . HOH K 7 .   ? -23.955 34.374  27.965  1.00 45.68 ? 1314 HOH A O   1 
+HETATM 4964 O  O   . HOH K 7 .   ? -3.990  46.723  8.066   1.00 46.39 ? 1315 HOH A O   1 
+HETATM 4965 O  O   . HOH K 7 .   ? -34.940 -7.224  75.882  1.00 51.29 ? 1316 HOH A O   1 
+HETATM 4966 O  O   . HOH K 7 .   ? -18.364 17.554  10.196  1.00 48.00 ? 1317 HOH A O   1 
+HETATM 4967 O  O   . HOH K 7 .   ? 21.036  28.671  43.342  1.00 51.20 ? 1318 HOH A O   1 
+HETATM 4968 O  O   . HOH K 7 .   ? -35.985 32.135  124.601 1.00 53.41 ? 1319 HOH A O   1 
+HETATM 4969 O  O   . HOH K 7 .   ? 29.115  21.480  34.153  1.00 52.16 ? 1320 HOH A O   1 
+HETATM 4970 O  O   . HOH K 7 .   ? 24.929  20.000  13.500  1.00 47.77 ? 1321 HOH A O   1 
+HETATM 4971 O  O   . HOH K 7 .   ? -24.773 -1.840  49.031  1.00 51.50 ? 1322 HOH A O   1 
+HETATM 4972 O  O   . HOH K 7 .   ? -17.785 -7.199  38.006  1.00 41.87 ? 1323 HOH A O   1 
+HETATM 4973 O  O   . HOH K 7 .   ? -0.740  -3.754  41.518  1.00 42.52 ? 1324 HOH A O   1 
+HETATM 4974 O  O   . HOH K 7 .   ? 11.174  2.271   16.139  1.00 44.80 ? 1325 HOH A O   1 
+HETATM 4975 O  O   . HOH K 7 .   ? 25.076  21.969  32.420  1.00 50.44 ? 1326 HOH A O   1 
+HETATM 4976 O  O   . HOH K 7 .   ? 3.066   9.422   40.321  1.00 44.86 ? 1327 HOH A O   1 
+HETATM 4977 O  O   . HOH K 7 .   ? 10.540  41.390  10.923  1.00 39.18 ? 1328 HOH A O   1 
+HETATM 4978 O  O   . HOH K 7 .   ? -5.316  14.542  2.188   1.00 54.25 ? 1329 HOH A O   1 
+HETATM 4979 O  O   . HOH K 7 .   ? -23.822 21.911  21.249  1.00 44.88 ? 1330 HOH A O   1 
+HETATM 4980 O  O   . HOH K 7 .   ? -24.138 13.298  102.768 1.00 48.94 ? 1331 HOH A O   1 
+HETATM 4981 O  O   . HOH K 7 .   ? -16.508 14.816  25.049  1.00 45.90 ? 1332 HOH A O   1 
+HETATM 4982 O  O   . HOH K 7 .   ? -20.253 32.929  13.068  1.00 52.37 ? 1333 HOH A O   1 
+HETATM 4983 O  O   . HOH K 7 .   ? -13.110 10.189  27.150  1.00 46.45 ? 1334 HOH A O   1 
+HETATM 4984 O  O   . HOH K 7 .   ? 29.402  22.915  29.089  1.00 37.56 ? 1335 HOH A O   1 
+HETATM 4985 O  O   . HOH K 7 .   ? -4.999  7.915   15.703  1.00 46.10 ? 1336 HOH A O   1 
+HETATM 4986 O  O   . HOH K 7 .   ? -0.549  -6.857  44.018  1.00 59.27 ? 1337 HOH A O   1 
+HETATM 4987 O  O   . HOH K 7 .   ? -13.938 -8.184  34.250  1.00 51.38 ? 1338 HOH A O   1 
+HETATM 4988 O  O   . HOH K 7 .   ? -16.749 2.403   43.505  1.00 45.50 ? 1339 HOH A O   1 
+HETATM 4989 O  O   . HOH K 7 .   ? -13.614 43.449  19.266  1.00 52.81 ? 1340 HOH A O   1 
+HETATM 4990 O  O   . HOH K 7 .   ? -24.402 18.870  26.091  1.00 49.33 ? 1341 HOH A O   1 
+HETATM 4991 O  O   . HOH K 7 .   ? -26.115 7.635   81.254  1.00 44.17 ? 1342 HOH A O   1 
+HETATM 4992 O  O   . HOH K 7 .   ? 10.825  4.091   25.126  1.00 37.07 ? 1343 HOH A O   1 
+HETATM 4993 O  O   . HOH K 7 .   ? -23.255 26.790  126.421 1.00 55.42 ? 1344 HOH A O   1 
+HETATM 4994 O  O   . HOH K 7 .   ? -17.336 22.621  116.710 1.00 41.83 ? 1345 HOH A O   1 
+HETATM 4995 O  O   A HOH K 7 .   ? 2.845   -1.242  36.303  0.50 36.63 ? 1346 HOH A O   1 
+HETATM 4996 O  O   B HOH K 7 .   ? -0.478  -6.455  34.377  0.56 30.76 ? 1347 HOH A O   1 
+HETATM 4997 O  O   . HOH K 7 .   ? -15.957 26.564  6.384   1.00 40.83 ? 1348 HOH A O   1 
+HETATM 4998 O  O   . HOH K 7 .   ? -9.934  9.067   4.200   1.00 55.22 ? 1349 HOH A O   1 
+HETATM 4999 O  O   . HOH K 7 .   ? -14.436 4.855   42.807  1.00 54.48 ? 1350 HOH A O   1 
+HETATM 5000 O  O   . HOH K 7 .   ? 12.593  47.155  33.922  1.00 48.66 ? 1351 HOH A O   1 
+HETATM 5001 O  O   . HOH K 7 .   ? 18.841  6.636   34.492  1.00 56.46 ? 1352 HOH A O   1 
+HETATM 5002 O  O   . HOH K 7 .   ? 11.966  31.535  44.817  1.00 37.28 ? 1353 HOH A O   1 
+HETATM 5003 O  O   . HOH K 7 .   ? 1.073   29.542  41.675  1.00 42.32 ? 1354 HOH A O   1 
+HETATM 5004 O  O   . HOH K 7 .   ? -26.751 10.621  88.359  1.00 38.77 ? 1355 HOH A O   1 
+HETATM 5005 O  O   . HOH K 7 .   ? -8.686  40.030  26.661  1.00 36.10 ? 1356 HOH A O   1 
+HETATM 5006 O  O   . HOH K 7 .   ? -13.543 29.904  4.122   1.00 36.24 ? 1357 HOH A O   1 
+HETATM 5007 O  O   . HOH K 7 .   ? -6.854  -2.882  21.210  1.00 38.29 ? 1358 HOH A O   1 
+HETATM 5008 O  O   . HOH K 7 .   ? -24.277 23.231  33.007  1.00 44.59 ? 1359 HOH A O   1 
+HETATM 5009 O  O   . HOH K 7 .   ? -26.537 37.049  120.122 1.00 54.10 ? 1360 HOH A O   1 
+HETATM 5010 O  O   . HOH K 7 .   ? -19.411 -1.097  34.801  1.00 51.21 ? 1361 HOH A O   1 
+HETATM 5011 O  O   A HOH K 7 .   ? -6.628  46.181  7.231   0.62 41.21 ? 1362 HOH A O   1 
+HETATM 5012 O  O   B HOH K 7 .   ? -4.803  46.602  5.512   0.38 25.93 ? 1362 HOH A O   1 
+HETATM 5013 O  O   . HOH K 7 .   ? -2.586  46.040  3.554   1.00 42.55 ? 1363 HOH A O   1 
+HETATM 5014 O  O   . HOH K 7 .   ? 18.413  14.355  11.246  1.00 52.11 ? 1364 HOH A O   1 
+HETATM 5015 O  O   . HOH K 7 .   ? -10.640 7.768   18.279  1.00 53.74 ? 1365 HOH A O   1 
+HETATM 5016 O  O   . HOH K 7 .   ? -13.293 20.260  5.100   1.00 52.42 ? 1366 HOH A O   1 
+HETATM 5017 O  O   . HOH K 7 .   ? -39.285 18.317  98.357  1.00 54.22 ? 1367 HOH A O   1 
+HETATM 5018 O  O   . HOH K 7 .   ? 12.838  7.144   10.193  1.00 50.15 ? 1368 HOH A O   1 
+HETATM 5019 O  O   . HOH K 7 .   ? 0.456   42.407  31.093  1.00 53.49 ? 1369 HOH A O   1 
+HETATM 5020 O  O   A HOH K 7 .   ? -1.160  43.111  24.580  0.50 36.75 ? 1370 HOH A O   1 
+HETATM 5021 O  O   B HOH K 7 .   ? 0.385   44.131  24.805  0.50 30.56 ? 1370 HOH A O   1 
+HETATM 5022 O  O   . HOH K 7 .   ? 3.343   35.100  42.029  1.00 54.39 ? 1371 HOH A O   1 
+HETATM 5023 O  O   . HOH K 7 .   ? -18.224 17.571  6.685   1.00 54.38 ? 1372 HOH A O   1 
+HETATM 5024 O  O   A HOH K 7 .   ? -15.972 13.153  17.328  0.57 37.93 ? 1373 HOH A O   1 
+HETATM 5025 O  O   B HOH K 7 .   ? -14.431 11.798  17.710  0.43 27.61 ? 1373 HOH A O   1 
+HETATM 5026 O  O   . HOH K 7 .   ? -17.895 3.304   48.418  1.00 46.94 ? 1374 HOH A O   1 
+HETATM 5027 O  O   . HOH K 7 .   ? 17.388  30.220  43.168  1.00 48.56 ? 1375 HOH A O   1 
+HETATM 5028 O  O   . HOH K 7 .   ? 22.415  22.699  35.929  1.00 26.05 ? 1376 HOH A O   1 
+HETATM 5029 O  O   . HOH K 7 .   ? -12.382 32.917  32.375  1.00 30.74 ? 1377 HOH A O   1 
+HETATM 5030 O  O   . HOH K 7 .   ? -14.118 33.449  33.789  1.00 42.74 ? 1378 HOH A O   1 
+HETATM 5031 O  O   . HOH K 7 .   ? 2.871   16.447  43.749  1.00 23.99 ? 1379 HOH A O   1 
+HETATM 5032 O  O   . HOH K 7 .   ? 4.058   16.500  41.679  1.00 27.88 ? 1380 HOH A O   1 
+HETATM 5033 O  O   . HOH K 7 .   ? -11.041 34.520  1.866   1.00 48.69 ? 1381 HOH A O   1 
+HETATM 5034 O  O   . HOH K 7 .   ? -23.235 -10.605 71.372  1.00 41.73 ? 1382 HOH A O   1 
+HETATM 5035 O  O   . HOH K 7 .   ? 5.854   50.688  16.405  1.00 51.80 ? 1383 HOH A O   1 
+HETATM 5036 O  O   . HOH K 7 .   ? 7.619   51.238  21.872  1.00 57.11 ? 1384 HOH A O   1 
+HETATM 5037 O  O   . HOH K 7 .   ? -13.089 40.670  26.550  1.00 48.83 ? 1385 HOH A O   1 
+HETATM 5038 O  O   . HOH K 7 .   ? -38.969 23.814  113.967 1.00 54.87 ? 1386 HOH A O   1 
+HETATM 5039 O  O   . HOH K 7 .   ? -25.394 21.172  127.542 1.00 51.27 ? 1387 HOH A O   1 
+# 
+loop_
+_atom_site_anisotrop.id 
+_atom_site_anisotrop.type_symbol 
+_atom_site_anisotrop.pdbx_label_atom_id 
+_atom_site_anisotrop.pdbx_label_alt_id 
+_atom_site_anisotrop.pdbx_label_comp_id 
+_atom_site_anisotrop.pdbx_label_asym_id 
+_atom_site_anisotrop.pdbx_label_seq_id 
+_atom_site_anisotrop.pdbx_PDB_ins_code 
+_atom_site_anisotrop.U[1][1] 
+_atom_site_anisotrop.U[2][2] 
+_atom_site_anisotrop.U[3][3] 
+_atom_site_anisotrop.U[1][2] 
+_atom_site_anisotrop.U[1][3] 
+_atom_site_anisotrop.U[2][3] 
+_atom_site_anisotrop.pdbx_auth_seq_id 
+_atom_site_anisotrop.pdbx_auth_comp_id 
+_atom_site_anisotrop.pdbx_auth_asym_id 
+_atom_site_anisotrop.pdbx_auth_atom_id 
+1    N  N   . GLY A 1   ? 0.6503 0.4097 0.2120 0.1913  -0.0919 -0.0414 23  GLY A N   
+2    C  CA  . GLY A 1   ? 0.6631 0.4495 0.2022 0.1559  -0.0770 -0.0323 23  GLY A CA  
+3    C  C   . GLY A 1   ? 0.6751 0.4264 0.2119 0.1524  -0.0697 -0.0361 23  GLY A C   
+4    O  O   . GLY A 1   ? 0.6717 0.5044 0.2322 0.1226  -0.0667 -0.0574 23  GLY A O   
+5    N  N   . THR A 2   ? 0.6288 0.4420 0.1957 0.1456  -0.0826 -0.0208 24  THR A N   
+6    C  CA  . THR A 2   ? 0.6075 0.4401 0.1807 0.0948  -0.0706 -0.0057 24  THR A CA  
+7    C  C   . THR A 2   ? 0.4833 0.4060 0.1519 0.0592  -0.0787 0.0134  24  THR A C   
+8    O  O   . THR A 2   ? 0.4238 0.3112 0.1326 0.0598  -0.0380 -0.0267 24  THR A O   
+9    C  CB  . THR A 2   ? 0.7024 0.5183 0.2007 0.1276  -0.0274 -0.0137 24  THR A CB  
+10   O  OG1 . THR A 2   ? 0.7903 0.5130 0.2296 0.1449  0.0161  -0.0404 24  THR A OG1 
+11   C  CG2 . THR A 2   ? 0.7316 0.6042 0.1970 0.0950  -0.0244 -0.0070 24  THR A CG2 
+12   N  N   . ILE A 3   ? 0.4330 0.4403 0.1422 0.0085  -0.0702 -0.0213 25  ILE A N   
+13   C  CA  . ILE A 3   ? 0.3883 0.3330 0.1355 -0.0327 -0.0622 -0.0294 25  ILE A CA  
+14   C  C   . ILE A 3   ? 0.3386 0.2179 0.1468 -0.0644 -0.0579 -0.0506 25  ILE A C   
+15   O  O   . ILE A 3   ? 0.3962 0.2695 0.1798 -0.0412 -0.0825 -0.0769 25  ILE A O   
+16   C  CB  . ILE A 3   ? 0.4278 0.3248 0.1368 -0.0311 -0.0243 -0.0215 25  ILE A CB  
+17   C  CG1 . ILE A 3   ? 0.4934 0.4293 0.1496 0.0952  0.0198  -0.0063 25  ILE A CG1 
+18   C  CG2 . ILE A 3   ? 0.4695 0.3571 0.1285 0.0234  0.0373  0.0281  25  ILE A CG2 
+19   C  CD1 . ILE A 3   ? 0.5382 0.4663 0.1784 0.1505  0.0609  -0.0027 25  ILE A CD1 
+20   N  N   . THR A 4   ? 0.2882 0.2049 0.1332 -0.0332 -0.0572 -0.0242 26  THR A N   
+21   C  CA  . THR A 4   ? 0.2831 0.2392 0.1257 0.0145  -0.0498 -0.0197 26  THR A CA  
+22   C  C   . THR A 4   ? 0.2967 0.1863 0.1235 -0.0044 -0.0385 -0.0168 26  THR A C   
+23   O  O   . THR A 4   ? 0.3237 0.1646 0.1156 0.0700  -0.0370 -0.0166 26  THR A O   
+24   C  CB  . THR A 4   ? 0.3298 0.2527 0.1318 0.0175  -0.0375 -0.0266 26  THR A CB  
+25   O  OG1 . THR A 4   ? 0.3863 0.2224 0.1287 0.0486  -0.0468 0.0001  26  THR A OG1 
+26   C  CG2 . THR A 4   ? 0.3238 0.1997 0.1429 0.0044  -0.0489 -0.0461 26  THR A CG2 
+27   N  N   . SER A 5   ? 0.3547 0.1793 0.1298 0.0281  -0.0339 -0.0154 27  SER A N   
+28   C  CA  A SER A 5   ? 0.3508 0.1431 0.1312 0.0327  -0.0266 -0.0400 27  SER A CA  
+29   C  CA  B SER A 5   ? 0.3501 0.1409 0.1344 0.0548  -0.0334 -0.0246 27  SER A CA  
+30   C  C   . SER A 5   ? 0.3149 0.1990 0.1237 0.0997  -0.0368 -0.0440 27  SER A C   
+31   O  O   . SER A 5   ? 0.3787 0.3185 0.1154 0.0763  -0.0416 -0.0121 27  SER A O   
+32   C  CB  A SER A 5   ? 0.4428 0.1842 0.1473 0.0338  -0.0113 -0.0395 27  SER A CB  
+33   C  CB  B SER A 5   ? 0.4592 0.1872 0.1556 0.1125  -0.0266 -0.0100 27  SER A CB  
+34   O  OG  A SER A 5   ? 0.5093 0.2735 0.1746 0.0080  -0.0103 -0.0098 27  SER A OG  
+35   O  OG  B SER A 5   ? 0.5503 0.1787 0.1747 0.0812  -0.0112 -0.0043 27  SER A OG  
+36   N  N   . GLN A 6   ? 0.3022 0.2029 0.1215 0.0969  -0.0365 -0.0245 28  GLN A N   
+37   C  CA  . GLN A 6   ? 0.3600 0.1552 0.1263 0.0914  -0.0139 -0.0101 28  GLN A CA  
+38   C  C   . GLN A 6   ? 0.4397 0.2017 0.1534 0.0933  -0.0275 -0.0066 28  GLN A C   
+39   O  O   . GLN A 6   ? 0.5313 0.2447 0.1738 0.0957  -0.0243 0.0035  28  GLN A O   
+40   C  CB  . GLN A 6   ? 0.4014 0.1804 0.1265 0.0849  -0.0214 -0.0342 28  GLN A CB  
+41   C  CG  . GLN A 6   ? 0.3256 0.1952 0.1182 0.0696  -0.0211 -0.0399 28  GLN A CG  
+42   C  CD  . GLN A 6   ? 0.2879 0.2057 0.1309 0.0835  -0.0241 -0.0390 28  GLN A CD  
+43   O  OE1 . GLN A 6   ? 0.3178 0.2822 0.1458 0.0667  -0.0501 -0.0474 28  GLN A OE1 
+44   N  NE2 . GLN A 6   ? 0.2509 0.1631 0.1441 0.0547  -0.0090 -0.0143 28  GLN A NE2 
+45   N  N   . ASP A 7   ? 0.3988 0.2201 0.1886 0.1050  -0.0934 -0.0251 29  ASP A N   
+46   C  CA  A ASP A 7   ? 0.4158 0.2114 0.2042 0.0596  -0.1038 -0.0414 29  ASP A CA  
+47   C  CA  B ASP A 7   ? 0.4357 0.2171 0.1998 0.0682  -0.1065 -0.0325 29  ASP A CA  
+48   C  C   . ASP A 7   ? 0.4105 0.1728 0.1839 0.0775  -0.1001 -0.0404 29  ASP A C   
+49   O  O   . ASP A 7   ? 0.4159 0.2147 0.2201 0.0804  -0.0706 -0.0200 29  ASP A O   
+50   C  CB  A ASP A 7   ? 0.4341 0.2317 0.2302 0.0510  -0.1082 -0.0533 29  ASP A CB  
+51   C  CB  B ASP A 7   ? 0.4956 0.1897 0.2212 0.0444  -0.1172 -0.0318 29  ASP A CB  
+52   C  CG  A ASP A 7   ? 0.4608 0.2877 0.2472 0.0243  -0.0993 -0.0180 29  ASP A CG  
+53   C  CG  B ASP A 7   ? 0.5348 0.2110 0.2341 -0.0040 -0.0981 -0.0215 29  ASP A CG  
+54   O  OD1 A ASP A 7   ? 0.4534 0.2799 0.2554 -0.0530 -0.0838 -0.0019 29  ASP A OD1 
+55   O  OD1 B ASP A 7   ? 0.5320 0.1883 0.2429 0.0354  -0.0996 -0.0042 29  ASP A OD1 
+56   O  OD2 A ASP A 7   ? 0.4898 0.2756 0.2539 0.0130  -0.0980 0.0046  29  ASP A OD2 
+57   O  OD2 B ASP A 7   ? 0.5801 0.3286 0.2413 0.0013  -0.0981 -0.0222 29  ASP A OD2 
+58   N  N   . ASP A 8   ? 0.3726 0.1597 0.1375 0.0204  -0.0423 -0.0252 30  ASP A N   
+59   C  CA  . ASP A 8   ? 0.3753 0.1398 0.1321 -0.0122 -0.0177 -0.0374 30  ASP A CA  
+60   C  C   . ASP A 8   ? 0.3181 0.1317 0.1093 0.0108  -0.0295 -0.0197 30  ASP A C   
+61   O  O   . ASP A 8   ? 0.3066 0.1832 0.0930 0.0528  -0.0110 -0.0015 30  ASP A O   
+62   C  CB  . ASP A 8   ? 0.4461 0.2201 0.1621 0.0049  -0.0004 -0.0740 30  ASP A CB  
+63   C  CG  . ASP A 8   ? 0.5943 0.3301 0.1912 0.0469  -0.0243 -0.0602 30  ASP A CG  
+64   O  OD1 . ASP A 8   ? 0.6565 0.3505 0.2224 0.1198  -0.0580 -0.0758 30  ASP A OD1 
+65   O  OD2 . ASP A 8   ? 0.6350 0.4100 0.1992 0.0522  0.0383  -0.0718 30  ASP A OD2 
+66   N  N   . ASN A 9   ? 0.3271 0.1210 0.1109 0.0181  -0.0131 -0.0110 31  ASN A N   
+67   C  CA  . ASN A 9   ? 0.3042 0.1362 0.1020 0.0063  -0.0085 -0.0004 31  ASN A CA  
+68   C  C   . ASN A 9   ? 0.2324 0.1307 0.0806 0.0142  -0.0074 -0.0303 31  ASN A C   
+69   O  O   . ASN A 9   ? 0.2789 0.1535 0.0844 0.0852  -0.0125 -0.0155 31  ASN A O   
+70   C  CB  . ASN A 9   ? 0.2909 0.1492 0.1121 0.0667  0.0056  0.0008  31  ASN A CB  
+71   C  CG  . ASN A 9   ? 0.3454 0.1815 0.1450 0.0858  -0.0143 0.0095  31  ASN A CG  
+72   O  OD1 . ASN A 9   ? 0.2583 0.2043 0.1715 0.0395  -0.0226 -0.0165 31  ASN A OD1 
+73   N  ND2 . ASN A 9   ? 0.4224 0.1927 0.1265 0.1073  -0.0021 0.0043  31  ASN A ND2 
+74   N  N   . VAL A 10  ? 0.2757 0.1287 0.0769 0.0119  -0.0186 -0.0191 32  VAL A N   
+75   C  CA  . VAL A 10  ? 0.2830 0.1183 0.0791 0.0509  -0.0108 -0.0137 32  VAL A CA  
+76   C  C   . VAL A 10  ? 0.2620 0.1758 0.0747 0.0465  -0.0056 0.0032  32  VAL A C   
+77   O  O   . VAL A 10  ? 0.2811 0.1248 0.0842 0.0608  -0.0143 -0.0094 32  VAL A O   
+78   C  CB  . VAL A 10  ? 0.2716 0.1342 0.0812 0.0559  -0.0121 -0.0215 32  VAL A CB  
+79   C  CG1 . VAL A 10  ? 0.2932 0.1281 0.0837 0.0479  -0.0008 -0.0173 32  VAL A CG1 
+80   C  CG2 . VAL A 10  ? 0.2366 0.1645 0.0781 0.0167  -0.0103 -0.0191 32  VAL A CG2 
+81   N  N   . VAL A 11  ? 0.2352 0.1544 0.0713 0.0450  -0.0306 -0.0141 33  VAL A N   
+82   C  CA  . VAL A 11  ? 0.2111 0.1565 0.0886 0.0590  -0.0236 -0.0033 33  VAL A CA  
+83   C  C   . VAL A 11  ? 0.2489 0.1362 0.0759 0.0294  -0.0273 -0.0247 33  VAL A C   
+84   O  O   . VAL A 11  ? 0.2534 0.1714 0.0729 0.0480  -0.0239 -0.0015 33  VAL A O   
+85   C  CB  . VAL A 11  ? 0.1907 0.1662 0.1014 0.0201  -0.0188 0.0072  33  VAL A CB  
+86   C  CG1 . VAL A 11  ? 0.2705 0.1981 0.1287 0.0449  -0.0293 -0.0041 33  VAL A CG1 
+87   C  CG2 . VAL A 11  ? 0.1804 0.2333 0.1011 0.0564  -0.0028 0.0046  33  VAL A CG2 
+88   N  N   . VAL A 12  ? 0.2338 0.1172 0.0661 0.0326  -0.0267 -0.0087 34  VAL A N   
+89   C  CA  . VAL A 12  ? 0.2373 0.1234 0.0777 0.0459  -0.0144 0.0212  34  VAL A CA  
+90   C  C   . VAL A 12  ? 0.2459 0.1424 0.0771 0.0186  -0.0338 0.0006  34  VAL A C   
+91   O  O   . VAL A 12  ? 0.2358 0.1138 0.0863 0.0168  -0.0468 -0.0144 34  VAL A O   
+92   C  CB  . VAL A 12  ? 0.2146 0.1576 0.0685 0.0039  -0.0099 0.0129  34  VAL A CB  
+93   C  CG1 . VAL A 12  ? 0.2179 0.1684 0.0683 0.0239  -0.0222 0.0102  34  VAL A CG1 
+94   C  CG2 . VAL A 12  ? 0.2583 0.1868 0.0826 0.0235  0.0033  0.0063  34  VAL A CG2 
+95   N  N   . GLY A 13  ? 0.2413 0.1222 0.0756 0.0411  -0.0043 -0.0169 35  GLY A N   
+96   C  CA  . GLY A 13  ? 0.2647 0.1118 0.0867 0.0608  0.0129  -0.0123 35  GLY A CA  
+97   C  C   . GLY A 13  ? 0.2479 0.1261 0.0782 0.0588  0.0032  -0.0102 35  GLY A C   
+98   O  O   . GLY A 13  ? 0.2198 0.1680 0.0788 0.0510  -0.0257 -0.0227 35  GLY A O   
+99   N  N   . TYR A 14  ? 0.2515 0.1530 0.0790 0.0670  -0.0023 -0.0052 36  TYR A N   
+100  C  CA  . TYR A 14  ? 0.2384 0.1168 0.0810 0.0216  -0.0277 -0.0101 36  TYR A CA  
+101  C  C   . TYR A 14  ? 0.2151 0.1575 0.0801 0.0318  -0.0037 -0.0075 36  TYR A C   
+102  O  O   . TYR A 14  ? 0.2465 0.1514 0.0846 0.0463  -0.0163 0.0089  36  TYR A O   
+103  C  CB  . TYR A 14  ? 0.2387 0.1711 0.0747 0.0307  -0.0107 0.0017  36  TYR A CB  
+104  C  CG  . TYR A 14  ? 0.1986 0.1707 0.0653 0.0468  -0.0195 -0.0232 36  TYR A CG  
+105  C  CD1 . TYR A 14  ? 0.2254 0.1578 0.0669 0.0571  -0.0177 -0.0068 36  TYR A CD1 
+106  C  CD2 . TYR A 14  ? 0.1812 0.2717 0.0819 0.0656  -0.0189 0.0056  36  TYR A CD2 
+107  C  CE1 . TYR A 14  ? 0.2225 0.1705 0.0661 0.0030  -0.0137 0.0149  36  TYR A CE1 
+108  C  CE2 . TYR A 14  ? 0.2074 0.2163 0.0815 0.0605  -0.0197 0.0273  36  TYR A CE2 
+109  C  CZ  . TYR A 14  ? 0.2588 0.1383 0.0758 0.0472  -0.0164 0.0056  36  TYR A CZ  
+110  O  OH  . TYR A 14  ? 0.2952 0.1442 0.0997 0.0613  -0.0142 0.0264  36  TYR A OH  
+111  N  N   . TRP A 15  ? 0.2024 0.1236 0.0930 0.0249  -0.0127 -0.0036 37  TRP A N   
+112  C  CA  . TRP A 15  ? 0.2053 0.1029 0.0942 0.0408  -0.0032 -0.0032 37  TRP A CA  
+113  C  C   . TRP A 15  ? 0.2760 0.1061 0.0900 0.0497  -0.0016 -0.0090 37  TRP A C   
+114  O  O   . TRP A 15  ? 0.3013 0.1427 0.0805 0.0399  -0.0001 0.0127  37  TRP A O   
+115  C  CB  . TRP A 15  ? 0.2621 0.1544 0.0974 0.0490  0.0067  0.0163  37  TRP A CB  
+116  C  CG  . TRP A 15  ? 0.2391 0.1533 0.0919 0.0690  -0.0289 0.0031  37  TRP A CG  
+117  C  CD1 . TRP A 15  ? 0.2671 0.1355 0.1138 0.0389  -0.0224 -0.0091 37  TRP A CD1 
+118  C  CD2 . TRP A 15  ? 0.2761 0.1345 0.1010 0.0828  -0.0079 -0.0029 37  TRP A CD2 
+119  N  NE1 . TRP A 15  ? 0.2651 0.1634 0.1051 0.0408  0.0123  0.0190  37  TRP A NE1 
+120  C  CE2 . TRP A 15  ? 0.2565 0.1830 0.1006 0.0685  -0.0021 0.0255  37  TRP A CE2 
+121  C  CE3 . TRP A 15  ? 0.2695 0.2161 0.1077 0.0452  -0.0248 -0.0120 37  TRP A CE3 
+122  C  CZ2 . TRP A 15  ? 0.2767 0.1748 0.0951 0.0582  -0.0176 0.0273  37  TRP A CZ2 
+123  C  CZ3 . TRP A 15  ? 0.2039 0.2774 0.1010 0.0374  -0.0136 -0.0037 37  TRP A CZ3 
+124  C  CH2 . TRP A 15  ? 0.2663 0.2464 0.0989 0.0746  -0.0228 0.0001  37  TRP A CH2 
+125  N  N   . HIS A 16  ? 0.2655 0.1200 0.1041 0.0571  -0.0146 0.0024  38  HIS A N   
+126  C  CA  . HIS A 16  ? 0.3138 0.1634 0.1038 0.1104  0.0102  0.0008  38  HIS A CA  
+127  C  C   . HIS A 16  ? 0.2819 0.1782 0.1027 0.0978  0.0208  0.0085  38  HIS A C   
+128  O  O   . HIS A 16  ? 0.2733 0.1791 0.0972 0.0706  0.0233  0.0004  38  HIS A O   
+129  C  CB  . HIS A 16  ? 0.2582 0.1488 0.1117 0.0642  -0.0043 -0.0124 38  HIS A CB  
+130  C  CG  . HIS A 16  ? 0.2732 0.1440 0.1117 0.0345  -0.0095 -0.0036 38  HIS A CG  
+131  N  ND1 . HIS A 16  ? 0.2917 0.1631 0.1149 0.0525  -0.0244 -0.0124 38  HIS A ND1 
+132  C  CD2 . HIS A 16  ? 0.2945 0.1303 0.1101 0.0251  -0.0046 -0.0086 38  HIS A CD2 
+133  C  CE1 . HIS A 16  ? 0.2722 0.1553 0.1118 0.0336  -0.0131 -0.0209 38  HIS A CE1 
+134  N  NE2 . HIS A 16  ? 0.2726 0.1553 0.1071 0.0436  -0.0129 -0.0232 38  HIS A NE2 
+135  N  N   . ASN A 17  ? 0.2674 0.1513 0.1151 0.0666  0.0191  0.0070  39  ASN A N   
+136  C  CA  . ASN A 17  ? 0.2696 0.1952 0.1174 0.1032  0.0286  0.0234  39  ASN A CA  
+137  C  C   . ASN A 17  ? 0.3170 0.1815 0.1273 0.1328  0.0056  0.0078  39  ASN A C   
+138  O  O   . ASN A 17  ? 0.3344 0.1505 0.1400 0.1095  0.0073  -0.0094 39  ASN A O   
+139  C  CB  . ASN A 17  ? 0.2500 0.2259 0.1259 0.0890  0.0131  0.0439  39  ASN A CB  
+140  C  CG  . ASN A 17  ? 0.2594 0.1686 0.1383 0.0555  0.0040  0.0125  39  ASN A CG  
+141  O  OD1 . ASN A 17  ? 0.2809 0.2057 0.1330 0.0937  0.0084  0.0315  39  ASN A OD1 
+142  N  ND2 . ASN A 17  ? 0.3051 0.1792 0.1523 0.0763  -0.0099 0.0171  39  ASN A ND2 
+143  N  N   . TRP A 18  ? 0.2830 0.1947 0.1260 0.1107  -0.0006 0.0063  40  TRP A N   
+144  C  CA  . TRP A 18  ? 0.2892 0.1587 0.1312 0.0935  0.0079  0.0145  40  TRP A CA  
+145  C  C   . TRP A 18  ? 0.3254 0.1487 0.1460 0.1111  -0.0136 -0.0090 40  TRP A C   
+146  O  O   . TRP A 18  ? 0.3354 0.1136 0.1534 0.0675  -0.0124 0.0059  40  TRP A O   
+147  C  CB  . TRP A 18  ? 0.2746 0.1393 0.1264 0.1007  0.0155  -0.0056 40  TRP A CB  
+148  C  CG  . TRP A 18  ? 0.3533 0.1409 0.1245 0.1034  -0.0036 -0.0014 40  TRP A CG  
+149  C  CD1 . TRP A 18  ? 0.4066 0.1915 0.1168 0.0911  0.0003  -0.0001 40  TRP A CD1 
+150  C  CD2 . TRP A 18  ? 0.3389 0.1456 0.1107 0.1086  -0.0003 0.0003  40  TRP A CD2 
+151  N  NE1 . TRP A 18  ? 0.3581 0.2022 0.1118 0.0937  0.0108  -0.0020 40  TRP A NE1 
+152  C  CE2 . TRP A 18  ? 0.3620 0.1504 0.1144 0.0763  0.0180  0.0032  40  TRP A CE2 
+153  C  CE3 . TRP A 18  ? 0.3588 0.1574 0.1053 0.0734  -0.0079 -0.0216 40  TRP A CE3 
+154  C  CZ2 . TRP A 18  ? 0.3471 0.1935 0.1143 0.0799  0.0263  0.0005  40  TRP A CZ2 
+155  C  CZ3 . TRP A 18  ? 0.3641 0.1559 0.1048 0.0503  0.0187  -0.0187 40  TRP A CZ3 
+156  C  CH2 . TRP A 18  ? 0.3807 0.1903 0.1086 0.0875  0.0135  0.0192  40  TRP A CH2 
+157  N  N   . CYS A 19  ? 0.3876 0.1174 0.1480 0.0670  -0.0034 -0.0072 41  CYS A N   
+158  C  CA  . CYS A 19  ? 0.4045 0.1176 0.1557 0.0622  -0.0112 -0.0054 41  CYS A CA  
+159  C  C   . CYS A 19  ? 0.3626 0.1205 0.1666 0.0707  -0.0027 0.0011  41  CYS A C   
+160  O  O   . CYS A 19  ? 0.3849 0.1867 0.1821 0.0383  0.0060  -0.0228 41  CYS A O   
+161  C  CB  . CYS A 19  ? 0.4341 0.1494 0.1721 0.0738  -0.0276 -0.0186 41  CYS A CB  
+162  S  SG  . CYS A 19  ? 0.4156 0.2099 0.1804 0.0648  -0.0159 0.0194  41  CYS A SG  
+163  N  N   . ASP A 20  ? 0.3858 0.1482 0.1657 0.0750  -0.0103 0.0122  42  ASP A N   
+164  C  CA  . ASP A 20  ? 0.3880 0.1579 0.1813 0.0408  -0.0154 -0.0074 42  ASP A CA  
+165  C  C   . ASP A 20  ? 0.3871 0.1002 0.1704 0.0054  0.0133  0.0041  42  ASP A C   
+166  O  O   . ASP A 20  ? 0.4495 0.1554 0.1707 0.0856  0.0104  -0.0254 42  ASP A O   
+167  C  CB  . ASP A 20  ? 0.4468 0.1581 0.1962 0.0572  -0.0477 -0.0200 42  ASP A CB  
+168  C  CG  . ASP A 20  ? 0.5269 0.2180 0.2284 0.0806  -0.0106 0.0269  42  ASP A CG  
+169  O  OD1 . ASP A 20  ? 0.4978 0.1852 0.2289 0.0363  -0.0067 0.0239  42  ASP A OD1 
+170  O  OD2 . ASP A 20  ? 0.6318 0.2769 0.2554 0.1039  0.0148  0.0400  42  ASP A OD2 
+171  N  N   . GLY A 21  ? 0.3863 0.1356 0.1610 0.0066  -0.0030 0.0036  43  GLY A N   
+172  C  CA  . GLY A 21  ? 0.3974 0.1484 0.1579 0.0085  -0.0057 0.0190  43  GLY A CA  
+173  C  C   . GLY A 21  ? 0.4260 0.1459 0.1539 0.0311  0.0011  -0.0048 43  GLY A C   
+174  O  O   . GLY A 21  ? 0.3680 0.1770 0.1575 0.0380  -0.0003 -0.0316 43  GLY A O   
+175  N  N   . ARG A 22  ? 0.4149 0.1838 0.1405 0.0536  -0.0054 -0.0128 44  ARG A N   
+176  C  CA  . ARG A 22  ? 0.4278 0.1658 0.1625 0.0872  -0.0125 -0.0398 44  ARG A CA  
+177  C  C   . ARG A 22  ? 0.3673 0.1189 0.1576 0.0486  -0.0011 -0.0321 44  ARG A C   
+178  O  O   . ARG A 22  ? 0.3827 0.1339 0.1512 0.0711  0.0144  -0.0093 44  ARG A O   
+179  C  CB  . ARG A 22  ? 0.4776 0.2086 0.1633 0.1336  -0.0268 -0.0351 44  ARG A CB  
+180  C  CG  . ARG A 22  ? 0.5578 0.3510 0.1812 0.2190  -0.0170 -0.0272 44  ARG A CG  
+181  C  CD  . ARG A 22  ? 0.5770 0.3486 0.1829 0.2186  -0.0155 -0.0239 44  ARG A CD  
+182  N  NE  . ARG A 22  ? 0.5952 0.3494 0.1847 0.2176  -0.0142 -0.0210 44  ARG A NE  
+183  C  CZ  . ARG A 22  ? 0.6092 0.3505 0.1861 0.2171  -0.0134 -0.0184 44  ARG A CZ  
+184  N  NH1 . ARG A 22  ? 0.6138 0.3509 0.1867 0.2168  -0.0131 -0.0176 44  ARG A NH1 
+185  N  NH2 . ARG A 22  ? 0.6138 0.3509 0.1867 0.2168  -0.0131 -0.0176 44  ARG A NH2 
+186  N  N   . GLY A 23  ? 0.3624 0.1114 0.1514 -0.0114 0.0263  -0.0343 45  GLY A N   
+187  C  CA  . GLY A 23  ? 0.3109 0.1552 0.1413 0.0205  0.0312  -0.0524 45  GLY A CA  
+188  C  C   . GLY A 23  ? 0.3460 0.1331 0.1417 -0.0061 0.0019  -0.0507 45  GLY A C   
+189  O  O   . GLY A 23  ? 0.3714 0.1681 0.1439 0.0079  0.0070  -0.0576 45  GLY A O   
+190  N  N   . TYR A 24  ? 0.3400 0.1526 0.1251 -0.0127 -0.0134 -0.0469 46  TYR A N   
+191  C  CA  . TYR A 24  ? 0.3200 0.1483 0.1313 -0.0034 0.0215  -0.0500 46  TYR A CA  
+192  C  C   . TYR A 24  ? 0.3838 0.1766 0.1415 -0.0022 0.0121  -0.0563 46  TYR A C   
+193  O  O   . TYR A 24  ? 0.3627 0.2447 0.1466 -0.0674 0.0077  -0.0660 46  TYR A O   
+194  C  CB  . TYR A 24  ? 0.3622 0.1362 0.1398 0.0177  0.0093  -0.0419 46  TYR A CB  
+195  C  CG  . TYR A 24  ? 0.3583 0.1449 0.1329 -0.0027 0.0179  -0.0379 46  TYR A CG  
+196  C  CD1 . TYR A 24  ? 0.3464 0.1402 0.1171 0.0191  -0.0080 -0.0249 46  TYR A CD1 
+197  C  CD2 . TYR A 24  ? 0.3235 0.1486 0.1272 0.0051  0.0186  -0.0416 46  TYR A CD2 
+198  C  CE1 . TYR A 24  ? 0.3404 0.1581 0.1206 -0.0259 0.0260  -0.0408 46  TYR A CE1 
+199  C  CE2 . TYR A 24  ? 0.3324 0.1350 0.1236 -0.0295 0.0164  -0.0264 46  TYR A CE2 
+200  C  CZ  . TYR A 24  ? 0.3116 0.1363 0.1267 -0.0178 0.0045  -0.0260 46  TYR A CZ  
+201  O  OH  . TYR A 24  ? 0.3099 0.1748 0.1370 0.0387  -0.0040 -0.0243 46  TYR A OH  
+202  N  N   . GLN A 25  ? 0.3593 0.1939 0.1453 -0.0479 0.0042  -0.0468 47  GLN A N   
+203  C  CA  . GLN A 25  ? 0.3796 0.1246 0.1621 -0.0038 0.0025  -0.0412 47  GLN A CA  
+204  C  C   . GLN A 25  ? 0.3727 0.1508 0.1623 -0.0172 -0.0108 -0.0613 47  GLN A C   
+205  O  O   . GLN A 25  ? 0.3902 0.1741 0.1705 0.0004  -0.0060 -0.0560 47  GLN A O   
+206  C  CB  . GLN A 25  ? 0.4258 0.1617 0.1819 -0.0243 -0.0094 -0.0621 47  GLN A CB  
+207  C  CG  . GLN A 25  ? 0.4023 0.1996 0.1817 -0.0703 -0.0260 -0.0527 47  GLN A CG  
+208  C  CD  . GLN A 25  ? 0.4941 0.1917 0.1926 -0.0178 -0.0591 -0.0545 47  GLN A CD  
+209  O  OE1 . GLN A 25  ? 0.5450 0.2172 0.2076 -0.0520 -0.0854 -0.0455 47  GLN A OE1 
+210  N  NE2 . GLN A 25  ? 0.5516 0.2123 0.2042 -0.0581 -0.0434 -0.0392 47  GLN A NE2 
+211  N  N   . GLY A 26  ? 0.3893 0.1873 0.1611 -0.0188 -0.0209 -0.0474 48  GLY A N   
+212  C  CA  . GLY A 26  ? 0.4221 0.2019 0.1634 0.0155  -0.0194 -0.0539 48  GLY A CA  
+213  C  C   . GLY A 26  ? 0.4030 0.1300 0.1603 0.0060  -0.0208 -0.0323 48  GLY A C   
+214  O  O   . GLY A 26  ? 0.3848 0.1829 0.1750 -0.0154 -0.0107 -0.0177 48  GLY A O   
+215  N  N   . GLY A 27  ? 0.4143 0.1142 0.1550 -0.0041 0.0058  -0.0233 49  GLY A N   
+216  C  CA  . GLY A 27  ? 0.4298 0.1592 0.1558 0.0255  0.0010  -0.0446 49  GLY A CA  
+217  C  C   . GLY A 27  ? 0.3644 0.1312 0.1583 -0.0198 0.0177  -0.0452 49  GLY A C   
+218  O  O   . GLY A 27  ? 0.4021 0.1707 0.1764 0.0396  0.0224  -0.0229 49  GLY A O   
+219  N  N   . ASN A 28  ? 0.3568 0.1336 0.1508 -0.0019 0.0151  -0.0517 50  ASN A N   
+220  C  CA  . ASN A 28  ? 0.3755 0.1134 0.1590 -0.0296 -0.0070 -0.0264 50  ASN A CA  
+221  C  C   . ASN A 28  ? 0.3600 0.1650 0.1548 0.0025  0.0029  -0.0305 50  ASN A C   
+222  O  O   . ASN A 28  ? 0.3682 0.1656 0.1573 0.0188  0.0111  -0.0430 50  ASN A O   
+223  C  CB  . ASN A 28  ? 0.4177 0.1401 0.1685 0.0097  -0.0299 -0.0433 50  ASN A CB  
+224  C  CG  . ASN A 28  ? 0.3742 0.1221 0.1826 0.0215  -0.0395 -0.0150 50  ASN A CG  
+225  O  OD1 . ASN A 28  ? 0.4508 0.1679 0.1935 0.0794  -0.0384 -0.0170 50  ASN A OD1 
+226  N  ND2 . ASN A 28  ? 0.3935 0.1828 0.1939 -0.0026 -0.0287 0.0110  50  ASN A ND2 
+227  N  N   . ALA A 29  ? 0.3273 0.1194 0.1532 -0.0237 0.0099  -0.0311 51  ALA A N   
+228  C  CA  . ALA A 29  ? 0.3262 0.1794 0.1422 0.0503  -0.0102 -0.0315 51  ALA A CA  
+229  C  C   . ALA A 29  ? 0.3211 0.1530 0.1391 0.0419  -0.0060 -0.0363 51  ALA A C   
+230  O  O   . ALA A 29  ? 0.3474 0.1348 0.1346 0.0689  0.0029  -0.0128 51  ALA A O   
+231  C  CB  . ALA A 29  ? 0.3482 0.1460 0.1351 0.0261  -0.0201 -0.0170 51  ALA A CB  
+232  N  N   . PRO A 30  ? 0.3506 0.1910 0.1495 0.0591  0.0025  -0.0240 52  PRO A N   
+233  C  CA  . PRO A 30  ? 0.3161 0.1831 0.1497 0.0307  0.0055  0.0004  52  PRO A CA  
+234  C  C   . PRO A 30  ? 0.3344 0.1275 0.1483 0.0591  0.0078  0.0100  52  PRO A C   
+235  O  O   . PRO A 30  ? 0.3420 0.1272 0.1502 0.0411  0.0057  -0.0062 52  PRO A O   
+236  C  CB  . PRO A 30  ? 0.3139 0.1944 0.1562 0.0387  0.0120  0.0298  52  PRO A CB  
+237  C  CG  . PRO A 30  ? 0.3730 0.2529 0.1666 0.0293  0.0159  0.0227  52  PRO A CG  
+238  C  CD  . PRO A 30  ? 0.3497 0.2549 0.1551 0.0322  0.0249  0.0051  52  PRO A CD  
+239  N  N   . CYS A 31  ? 0.3330 0.1266 0.1542 0.0750  0.0083  -0.0064 53  CYS A N   
+240  C  CA  . CYS A 31  ? 0.3473 0.1443 0.1438 0.0275  0.0057  0.0058  53  CYS A CA  
+241  C  C   . CYS A 31  ? 0.3388 0.1276 0.1331 -0.0200 0.0280  0.0114  53  CYS A C   
+242  O  O   . CYS A 31  ? 0.3733 0.1713 0.1315 0.0066  0.0418  -0.0097 53  CYS A O   
+243  C  CB  . CYS A 31  ? 0.4061 0.1407 0.1615 0.0300  -0.0108 0.0445  53  CYS A CB  
+244  S  SG  . CYS A 31  ? 0.4388 0.2092 0.1884 0.0624  -0.0247 0.0339  53  CYS A SG  
+245  N  N   . VAL A 32  ? 0.3112 0.1399 0.1267 0.0138  0.0054  0.0044  54  VAL A N   
+246  C  CA  . VAL A 32  ? 0.3382 0.1271 0.1222 0.0667  0.0075  -0.0001 54  VAL A CA  
+247  C  C   . VAL A 32  ? 0.3151 0.1164 0.1137 0.0557  -0.0016 0.0250  54  VAL A C   
+248  O  O   . VAL A 32  ? 0.3269 0.1905 0.1081 0.0182  0.0012  0.0148  54  VAL A O   
+249  C  CB  . VAL A 32  ? 0.3262 0.1457 0.1378 0.0250  0.0135  -0.0272 54  VAL A CB  
+250  C  CG1 . VAL A 32  ? 0.3199 0.1998 0.1564 0.0462  -0.0022 -0.0249 54  VAL A CG1 
+251  C  CG2 . VAL A 32  ? 0.2784 0.1595 0.1512 0.0411  0.0092  -0.0276 54  VAL A CG2 
+252  N  N   . GLU A 33  ? 0.3491 0.1569 0.1010 0.0397  0.0173  0.0207  55  GLU A N   
+253  C  CA  . GLU A 33  ? 0.3228 0.2105 0.1061 -0.0023 -0.0038 0.0163  55  GLU A CA  
+254  C  C   . GLU A 33  ? 0.2764 0.1892 0.1121 -0.0319 -0.0043 0.0315  55  GLU A C   
+255  O  O   . GLU A 33  ? 0.3036 0.2051 0.1228 0.0276  -0.0167 0.0054  55  GLU A O   
+256  C  CB  . GLU A 33  ? 0.3746 0.2303 0.1137 0.0145  0.0014  0.0377  55  GLU A CB  
+257  C  CG  . GLU A 33  ? 0.4269 0.1933 0.1315 -0.0191 -0.0038 0.0457  55  GLU A CG  
+258  C  CD  . GLU A 33  ? 0.5462 0.2346 0.1796 -0.0161 -0.0042 0.0646  55  GLU A CD  
+259  O  OE1 . GLU A 33  ? 0.4832 0.2417 0.1630 0.0192  0.0079  0.0443  55  GLU A OE1 
+260  O  OE2 . GLU A 33  ? 0.7376 0.3834 0.2022 -0.0594 -0.0267 0.0534  55  GLU A OE2 
+261  N  N   . LEU A 34  ? 0.2609 0.2032 0.1210 0.0475  -0.0013 0.0498  56  LEU A N   
+262  C  CA  . LEU A 34  ? 0.3309 0.1917 0.1189 0.0303  -0.0297 0.0511  56  LEU A CA  
+263  C  C   . LEU A 34  ? 0.3633 0.1309 0.1217 0.0316  -0.0343 0.0250  56  LEU A C   
+264  O  O   . LEU A 34  ? 0.3732 0.1557 0.1211 0.0104  -0.0435 0.0303  56  LEU A O   
+265  C  CB  . LEU A 34  ? 0.3378 0.2912 0.1202 0.0276  -0.0533 0.0495  56  LEU A CB  
+266  C  CG  . LEU A 34  ? 0.3752 0.3685 0.1206 0.0356  -0.0622 0.0224  56  LEU A CG  
+267  C  CD1 . LEU A 34  ? 0.3784 0.4096 0.1311 -0.0487 -0.0578 0.0423  56  LEU A CD1 
+268  C  CD2 . LEU A 34  ? 0.3444 0.3353 0.1175 -0.0220 -0.0536 0.0534  56  LEU A CD2 
+269  N  N   . LYS A 35  ? 0.3463 0.1472 0.1122 0.0438  -0.0144 0.0313  57  LYS A N   
+270  C  CA  . LYS A 35  ? 0.3777 0.2283 0.1178 0.1093  0.0005  0.0235  57  LYS A CA  
+271  C  C   . LYS A 35  ? 0.3639 0.2149 0.1202 0.1045  0.0151  0.0202  57  LYS A C   
+272  O  O   . LYS A 35  ? 0.4239 0.3633 0.1470 0.1861  -0.0146 -0.0160 57  LYS A O   
+273  C  CB  . LYS A 35  ? 0.3607 0.2164 0.1281 0.0803  -0.0046 0.0409  57  LYS A CB  
+274  C  CG  . LYS A 35  ? 0.3757 0.2687 0.1583 0.1155  0.0209  0.0743  57  LYS A CG  
+275  C  CD  . LYS A 35  ? 0.4428 0.3175 0.1946 0.1211  0.0307  0.1006  57  LYS A CD  
+276  C  CE  . LYS A 35  ? 0.5253 0.3730 0.2081 0.1155  0.0425  0.1104  57  LYS A CE  
+277  N  NZ  . LYS A 35  ? 0.5728 0.4225 0.2215 0.1267  0.0569  0.1168  57  LYS A NZ  
+278  N  N   . THR A 36  ? 0.3032 0.1692 0.1250 0.0667  0.0146  0.0281  58  THR A N   
+279  C  CA  . THR A 36  ? 0.3247 0.2046 0.1509 0.0503  0.0321  0.0583  58  THR A CA  
+280  C  C   . THR A 36  ? 0.2527 0.2081 0.1541 0.0590  0.0052  0.0396  58  THR A C   
+281  O  O   . THR A 36  ? 0.2650 0.2202 0.1747 0.0675  0.0055  0.0357  58  THR A O   
+282  C  CB  . THR A 36  ? 0.3998 0.2175 0.1815 0.0130  0.0079  0.0780  58  THR A CB  
+283  O  OG1 . THR A 36  ? 0.4526 0.2541 0.2139 0.0185  -0.0016 0.0228  58  THR A OG1 
+284  C  CG2 . THR A 36  ? 0.3596 0.1796 0.1994 0.0173  -0.0112 0.0869  58  THR A CG2 
+285  N  N   . VAL A 37  ? 0.2269 0.1978 0.1284 0.0316  0.0001  0.0066  59  VAL A N   
+286  C  CA  . VAL A 37  ? 0.2552 0.1705 0.1082 0.0791  -0.0234 -0.0311 59  VAL A CA  
+287  C  C   . VAL A 37  ? 0.2365 0.1088 0.1020 0.0075  -0.0445 0.0022  59  VAL A C   
+288  O  O   . VAL A 37  ? 0.2896 0.2147 0.1012 0.0576  -0.0452 -0.0415 59  VAL A O   
+289  C  CB  . VAL A 37  ? 0.2968 0.2026 0.1048 0.0543  0.0020  -0.0016 59  VAL A CB  
+290  C  CG1 . VAL A 37  ? 0.3229 0.1503 0.1045 0.0431  0.0031  0.0068  59  VAL A CG1 
+291  C  CG2 . VAL A 37  ? 0.3374 0.1938 0.0976 0.0379  -0.0128 0.0061  59  VAL A CG2 
+292  N  N   . ASN A 38  ? 0.2528 0.1649 0.1259 0.0195  -0.0420 -0.0100 60  ASN A N   
+293  C  CA  . ASN A 38  ? 0.2113 0.1429 0.1214 0.0115  -0.0244 0.0166  60  ASN A CA  
+294  C  C   . ASN A 38  ? 0.1990 0.1188 0.1126 0.0123  -0.0118 0.0016  60  ASN A C   
+295  O  O   . ASN A 38  ? 0.2306 0.1769 0.0927 0.0317  0.0181  0.0041  60  ASN A O   
+296  C  CB  . ASN A 38  ? 0.2254 0.1791 0.1359 -0.0109 -0.0180 0.0145  60  ASN A CB  
+297  C  CG  . ASN A 38  ? 0.2356 0.1588 0.1496 -0.0124 -0.0115 0.0209  60  ASN A CG  
+298  O  OD1 . ASN A 38  ? 0.2741 0.1470 0.1534 0.0359  -0.0084 -0.0108 60  ASN A OD1 
+299  N  ND2 . ASN A 38  ? 0.2450 0.2072 0.1632 0.0028  -0.0193 0.0254  60  ASN A ND2 
+300  N  N   . PRO A 39  ? 0.2675 0.1779 0.1174 0.0525  -0.0174 -0.0103 61  PRO A N   
+301  C  CA  . PRO A 39  ? 0.2920 0.1922 0.1189 0.0687  -0.0188 -0.0164 61  PRO A CA  
+302  C  C   . PRO A 39  ? 0.2738 0.1326 0.1086 0.0562  -0.0046 -0.0367 61  PRO A C   
+303  O  O   . PRO A 39  ? 0.2894 0.1690 0.1132 0.0143  -0.0043 -0.0252 61  PRO A O   
+304  C  CB  . PRO A 39  ? 0.4256 0.1532 0.1232 0.1032  0.0160  0.0002  61  PRO A CB  
+305  C  CG  . PRO A 39  ? 0.3456 0.2629 0.1365 0.0241  0.0510  -0.0168 61  PRO A CG  
+306  C  CD  . PRO A 39  ? 0.2648 0.2679 0.1170 0.0362  0.0146  -0.0081 61  PRO A CD  
+307  N  N   . GLN A 40  ? 0.2423 0.1202 0.0929 0.0205  0.0008  -0.0036 62  GLN A N   
+308  C  CA  . GLN A 40  ? 0.2622 0.1400 0.0992 0.0233  0.0160  0.0048  62  GLN A CA  
+309  C  C   . GLN A 40  ? 0.2193 0.1385 0.0956 0.0459  -0.0094 -0.0130 62  GLN A C   
+310  O  O   . GLN A 40  ? 0.2404 0.1560 0.0935 0.0584  -0.0159 -0.0056 62  GLN A O   
+311  C  CB  . GLN A 40  ? 0.2709 0.1723 0.0937 0.0595  0.0055  -0.0116 62  GLN A CB  
+312  C  CG  . GLN A 40  ? 0.2177 0.1867 0.1145 0.0523  -0.0022 -0.0069 62  GLN A CG  
+313  C  CD  . GLN A 40  ? 0.2383 0.2150 0.1131 0.0597  -0.0016 -0.0016 62  GLN A CD  
+314  O  OE1 . GLN A 40  ? 0.2616 0.1987 0.1277 0.0493  -0.0255 -0.0095 62  GLN A OE1 
+315  N  NE2 . GLN A 40  ? 0.2845 0.2052 0.1100 0.0640  -0.0131 -0.0056 62  GLN A NE2 
+316  N  N   . TYR A 41  ? 0.2372 0.1216 0.1015 0.0367  0.0044  -0.0071 63  TYR A N   
+317  C  CA  . TYR A 41  ? 0.2381 0.1041 0.0899 0.0495  -0.0146 -0.0128 63  TYR A CA  
+318  C  C   . TYR A 41  ? 0.2584 0.1376 0.0798 0.0508  -0.0211 -0.0151 63  TYR A C   
+319  O  O   . TYR A 41  ? 0.2642 0.1443 0.0889 0.0423  -0.0301 -0.0195 63  TYR A O   
+320  C  CB  . TYR A 41  ? 0.2456 0.1199 0.0886 0.0317  -0.0173 -0.0045 63  TYR A CB  
+321  C  CG  . TYR A 41  ? 0.2522 0.1052 0.0834 0.0238  -0.0121 -0.0048 63  TYR A CG  
+322  C  CD1 . TYR A 41  ? 0.2788 0.1063 0.0823 0.0358  0.0034  -0.0041 63  TYR A CD1 
+323  C  CD2 . TYR A 41  ? 0.2798 0.1491 0.0880 0.0457  -0.0096 -0.0181 63  TYR A CD2 
+324  C  CE1 . TYR A 41  ? 0.2624 0.1127 0.0704 0.0310  -0.0091 -0.0038 63  TYR A CE1 
+325  C  CE2 . TYR A 41  ? 0.2414 0.1221 0.0816 0.0438  -0.0054 -0.0195 63  TYR A CE2 
+326  C  CZ  . TYR A 41  ? 0.2578 0.1007 0.0826 0.0359  -0.0011 -0.0213 63  TYR A CZ  
+327  O  OH  . TYR A 41  ? 0.2757 0.1427 0.0877 0.0381  -0.0148 -0.0127 63  TYR A OH  
+328  N  N   . ASN A 42  ? 0.2500 0.1374 0.0724 0.0464  -0.0139 0.0129  64  ASN A N   
+329  C  CA  . ASN A 42  ? 0.2599 0.1343 0.0834 0.0493  -0.0258 0.0163  64  ASN A CA  
+330  C  C   . ASN A 42  ? 0.2416 0.1284 0.0782 0.0737  -0.0338 -0.0110 64  ASN A C   
+331  O  O   . ASN A 42  ? 0.2746 0.1481 0.0847 0.0322  -0.0349 -0.0080 64  ASN A O   
+332  C  CB  . ASN A 42  ? 0.2202 0.1190 0.0753 0.0084  -0.0049 -0.0144 64  ASN A CB  
+333  C  CG  . ASN A 42  ? 0.2432 0.1758 0.0878 0.0584  0.0033  -0.0315 64  ASN A CG  
+334  O  OD1 . ASN A 42  ? 0.3612 0.1337 0.0971 0.0745  0.0065  0.0059  64  ASN A OD1 
+335  N  ND2 . ASN A 42  ? 0.2963 0.1721 0.1017 0.0585  -0.0483 -0.0361 64  ASN A ND2 
+336  N  N   . VAL A 43  ? 0.2144 0.1394 0.0834 0.0207  -0.0324 -0.0146 65  VAL A N   
+337  C  CA  . VAL A 43  ? 0.2520 0.1410 0.1022 0.0594  -0.0309 0.0105  65  VAL A CA  
+338  C  C   . VAL A 43  ? 0.2483 0.1551 0.0877 0.0522  -0.0359 0.0000  65  VAL A C   
+339  O  O   . VAL A 43  ? 0.2679 0.1224 0.0895 0.0425  -0.0301 0.0146  65  VAL A O   
+340  C  CB  . VAL A 43  ? 0.2310 0.1245 0.1010 0.0485  -0.0157 -0.0110 65  VAL A CB  
+341  C  CG1 . VAL A 43  ? 0.2818 0.1342 0.1098 0.0077  -0.0287 -0.0057 65  VAL A CG1 
+342  C  CG2 . VAL A 43  ? 0.2074 0.1367 0.0999 0.0290  0.0136  0.0089  65  VAL A CG2 
+343  N  N   . VAL A 44  ? 0.2539 0.1135 0.0884 0.0203  -0.0399 0.0095  66  VAL A N   
+344  C  CA  . VAL A 44  ? 0.2007 0.1285 0.0924 0.0242  -0.0436 0.0164  66  VAL A CA  
+345  C  C   . VAL A 44  ? 0.2332 0.1785 0.0861 0.0311  -0.0258 0.0088  66  VAL A C   
+346  O  O   . VAL A 44  ? 0.2774 0.1796 0.0806 0.0571  0.0014  -0.0048 66  VAL A O   
+347  C  CB  . VAL A 44  ? 0.2244 0.1515 0.1024 0.0016  -0.0249 0.0124  66  VAL A CB  
+348  C  CG1 . VAL A 44  ? 0.2947 0.1579 0.1154 0.0572  -0.0129 -0.0046 66  VAL A CG1 
+349  C  CG2 . VAL A 44  ? 0.2367 0.1323 0.1069 -0.0194 -0.0097 0.0186  66  VAL A CG2 
+350  N  N   . ASN A 45  ? 0.2002 0.1433 0.0871 0.0219  -0.0127 -0.0069 67  ASN A N   
+351  C  CA  . ASN A 45  ? 0.2666 0.0848 0.0855 -0.0036 -0.0021 0.0063  67  ASN A CA  
+352  C  C   . ASN A 45  ? 0.2356 0.1303 0.0828 0.0114  -0.0018 0.0185  67  ASN A C   
+353  O  O   . ASN A 45  ? 0.2542 0.1613 0.0858 0.0586  -0.0026 0.0050  67  ASN A O   
+354  C  CB  . ASN A 45  ? 0.2504 0.0993 0.0986 0.0196  -0.0189 0.0090  67  ASN A CB  
+355  C  CG  . ASN A 45  ? 0.2430 0.1624 0.0908 -0.0041 -0.0214 0.0080  67  ASN A CG  
+356  O  OD1 . ASN A 45  ? 0.2723 0.1597 0.0792 0.0683  -0.0206 -0.0110 67  ASN A OD1 
+357  N  ND2 . ASN A 45  ? 0.2560 0.1663 0.0821 0.0532  -0.0303 0.0046  67  ASN A ND2 
+358  N  N   . ILE A 46  ? 0.2800 0.1465 0.0818 0.0537  -0.0340 -0.0076 68  ILE A N   
+359  C  CA  . ILE A 46  ? 0.2599 0.1262 0.0860 0.0462  -0.0321 0.0055  68  ILE A CA  
+360  C  C   . ILE A 46  ? 0.2537 0.1537 0.0858 0.0548  -0.0184 -0.0111 68  ILE A C   
+361  O  O   . ILE A 46  ? 0.2454 0.1590 0.1023 0.0393  -0.0168 -0.0030 68  ILE A O   
+362  C  CB  . ILE A 46  ? 0.2129 0.2362 0.0991 0.0789  -0.0179 0.0103  68  ILE A CB  
+363  C  CG1 . ILE A 46  ? 0.2825 0.1880 0.0987 0.0765  -0.0067 0.0041  68  ILE A CG1 
+364  C  CG2 . ILE A 46  ? 0.2203 0.2823 0.0998 0.0863  0.0214  0.0327  68  ILE A CG2 
+365  C  CD1 . ILE A 46  ? 0.2862 0.2190 0.0910 0.0437  0.0409  -0.0173 68  ILE A CD1 
+366  N  N   . SER A 47  ? 0.2600 0.1472 0.0819 0.0475  -0.0103 0.0256  69  SER A N   
+367  C  CA  . SER A 47  ? 0.2688 0.1338 0.0876 0.0677  0.0178  0.0258  69  SER A CA  
+368  C  C   . SER A 47  ? 0.2778 0.1517 0.0857 0.0258  0.0091  0.0135  69  SER A C   
+369  O  O   . SER A 47  ? 0.2656 0.2039 0.0966 0.0805  -0.0022 -0.0119 69  SER A O   
+370  C  CB  . SER A 47  ? 0.3056 0.1485 0.1019 0.1074  0.0165  0.0150  69  SER A CB  
+371  O  OG  . SER A 47  ? 0.2562 0.1451 0.1057 0.0638  -0.0386 -0.0027 69  SER A OG  
+372  N  N   . PHE A 48  ? 0.2355 0.2139 0.0962 0.0541  -0.0003 0.0033  70  PHE A N   
+373  C  CA  . PHE A 48  ? 0.2869 0.2074 0.1008 0.0884  -0.0009 0.0086  70  PHE A CA  
+374  C  C   . PHE A 48  ? 0.2780 0.1846 0.1184 0.1217  0.0107  0.0162  70  PHE A C   
+375  O  O   . PHE A 48  ? 0.2882 0.1966 0.1430 0.1140  -0.0092 0.0171  70  PHE A O   
+376  C  CB  . PHE A 48  ? 0.2671 0.1423 0.1031 0.0765  0.0065  0.0168  70  PHE A CB  
+377  C  CG  . PHE A 48  ? 0.2426 0.1605 0.0893 0.0586  -0.0053 0.0035  70  PHE A CG  
+378  C  CD1 . PHE A 48  ? 0.2927 0.1761 0.0873 0.0638  -0.0056 -0.0094 70  PHE A CD1 
+379  C  CD2 . PHE A 48  ? 0.2552 0.1657 0.0911 0.0627  0.0055  0.0202  70  PHE A CD2 
+380  C  CE1 . PHE A 48  ? 0.2906 0.1253 0.0863 0.0474  0.0000  0.0028  70  PHE A CE1 
+381  C  CE2 . PHE A 48  ? 0.2563 0.1838 0.0963 0.0140  0.0043  0.0208  70  PHE A CE2 
+382  C  CZ  . PHE A 48  ? 0.2328 0.1957 0.0874 0.0017  -0.0053 0.0228  70  PHE A CZ  
+383  N  N   . MET A 49  ? 0.2982 0.1629 0.1204 0.0673  -0.0006 -0.0162 71  MET A N   
+384  C  CA  . MET A 49  ? 0.2541 0.2436 0.1246 0.0240  0.0203  0.0100  71  MET A CA  
+385  C  C   . MET A 49  ? 0.2483 0.2496 0.1271 0.0713  0.0215  0.0301  71  MET A C   
+386  O  O   . MET A 49  ? 0.2601 0.2071 0.1190 0.0616  -0.0046 0.0266  71  MET A O   
+387  C  CB  . MET A 49  ? 0.3134 0.2773 0.1332 0.0581  0.0174  0.0105  71  MET A CB  
+388  C  CG  . MET A 49  ? 0.3046 0.2446 0.1375 0.0503  0.0051  0.0092  71  MET A CG  
+389  S  SD  . MET A 49  ? 0.2961 0.2654 0.1601 0.0581  -0.0106 -0.0085 71  MET A SD  
+390  C  CE  . MET A 49  ? 0.3273 0.2247 0.1572 0.0296  -0.0141 0.0080  71  MET A CE  
+391  N  N   . LYS A 50  ? 0.2525 0.3136 0.1441 0.1127  0.0135  0.0054  72  LYS A N   
+392  C  CA  . LYS A 50  ? 0.2329 0.2921 0.1606 0.0608  0.0116  -0.0071 72  LYS A CA  
+393  C  C   . LYS A 50  ? 0.2548 0.2822 0.1880 0.1040  0.0160  -0.0150 72  LYS A C   
+394  O  O   . LYS A 50  ? 0.2685 0.2802 0.1942 0.0868  0.0009  0.0006  72  LYS A O   
+395  C  CB  . LYS A 50  ? 0.2938 0.2199 0.1514 0.0483  0.0383  -0.0087 72  LYS A CB  
+396  C  CG  . LYS A 50  ? 0.3068 0.2664 0.1586 0.0370  0.0225  -0.0126 72  LYS A CG  
+397  C  CD  . LYS A 50  ? 0.3591 0.2955 0.1803 0.0518  0.0064  0.0058  72  LYS A CD  
+398  C  CE  . LYS A 50  ? 0.4706 0.3300 0.1876 0.0950  -0.0164 0.0347  72  LYS A CE  
+399  N  NZ  . LYS A 50  ? 0.5614 0.2763 0.1865 0.1315  -0.0307 0.0113  72  LYS A NZ  
+400  N  N   . VAL A 51  ? 0.2644 0.2880 0.2098 0.1232  0.0544  -0.0055 73  VAL A N   
+401  C  CA  . VAL A 51  ? 0.3189 0.3492 0.2495 0.1444  0.0581  -0.0183 73  VAL A CA  
+402  C  C   . VAL A 51  ? 0.3481 0.3438 0.2865 0.1590  0.0256  -0.0338 73  VAL A C   
+403  O  O   . VAL A 51  ? 0.3796 0.3464 0.2968 0.1299  0.0135  -0.0468 73  VAL A O   
+404  C  CB  . VAL A 51  ? 0.3742 0.4106 0.2665 0.2050  0.0779  -0.0074 73  VAL A CB  
+405  C  CG1 . VAL A 51  ? 0.4105 0.4007 0.2703 0.2192  0.0560  -0.0262 73  VAL A CG1 
+406  C  CG2 . VAL A 51  ? 0.3776 0.4661 0.2746 0.1537  0.1096  0.0389  73  VAL A CG2 
+407  N  N   . TYR A 52  ? 0.4129 0.3643 0.3212 0.1522  -0.0008 -0.0238 74  TYR A N   
+408  C  CA  . TYR A 52  ? 0.5554 0.4307 0.3518 0.2258  -0.0123 -0.0337 74  TYR A CA  
+409  C  C   . TYR A 52  ? 0.6320 0.5654 0.4253 0.3033  -0.0076 -0.0815 74  TYR A C   
+410  O  O   . TYR A 52  ? 0.6995 0.5888 0.4327 0.3211  -0.0094 -0.1213 74  TYR A O   
+411  C  CB  . TYR A 52  ? 0.6287 0.3223 0.3043 0.1604  -0.0443 0.0124  74  TYR A CB  
+412  C  CG  . TYR A 52  ? 0.6480 0.2617 0.2586 0.1604  -0.0454 0.0327  74  TYR A CG  
+413  C  CD1 . TYR A 52  ? 0.6478 0.2413 0.2425 0.1504  -0.0333 0.0245  74  TYR A CD1 
+414  C  CD2 . TYR A 52  ? 0.7008 0.2424 0.2325 0.0651  -0.0347 0.0109  74  TYR A CD2 
+415  C  CE1 . TYR A 52  ? 0.6824 0.2359 0.2187 0.1575  0.0093  0.0134  74  TYR A CE1 
+416  C  CE2 . TYR A 52  ? 0.7135 0.2260 0.2128 0.0775  0.0086  0.0131  74  TYR A CE2 
+417  C  CZ  . TYR A 52  ? 0.7425 0.2686 0.2135 0.1249  0.0498  0.0063  74  TYR A CZ  
+418  O  OH  . TYR A 52  ? 0.7813 0.2757 0.2450 0.1120  0.1412  0.0295  74  TYR A OH  
+419  N  N   . ASP A 53  ? 0.6072 0.6397 0.4803 0.3639  0.0042  -0.0690 75  ASP A N   
+420  C  CA  . ASP A 53  ? 0.6051 0.6749 0.5246 0.3755  0.0173  -0.0510 75  ASP A CA  
+421  C  C   . ASP A 53  ? 0.5196 0.6798 0.5513 0.3273  0.0293  -0.0405 75  ASP A C   
+422  O  O   . ASP A 53  ? 0.3371 0.6523 0.5595 0.2495  -0.0056 -0.0404 75  ASP A O   
+423  C  CB  . ASP A 53  ? 0.6352 0.7096 0.5351 0.3994  0.0059  -0.0329 75  ASP A CB  
+424  C  CG  . ASP A 53  ? 0.6884 0.7375 0.5418 0.4106  0.0009  -0.0208 75  ASP A CG  
+425  O  OD1 . ASP A 53  ? 0.7127 0.6828 0.5385 0.4135  0.0298  -0.0266 75  ASP A OD1 
+426  O  OD2 . ASP A 53  ? 0.6952 0.7813 0.5460 0.3937  -0.0366 0.0011  75  ASP A OD2 
+427  N  N   . ILE A 54  ? 0.6566 0.7278 0.5720 0.3662  0.0622  -0.0249 76  ILE A N   
+428  C  CA  . ILE A 54  ? 0.7037 0.7829 0.5873 0.3734  0.0798  -0.0076 76  ILE A CA  
+429  C  C   . ILE A 54  ? 0.6415 0.8200 0.5946 0.3674  0.0923  0.0204  76  ILE A C   
+430  O  O   . ILE A 54  ? 0.5737 0.8556 0.6016 0.3277  0.1104  0.0096  76  ILE A O   
+431  C  CB  . ILE A 54  ? 0.8009 0.8138 0.5963 0.3896  0.0706  -0.0108 76  ILE A CB  
+432  C  CG1 . ILE A 54  ? 0.8240 0.8506 0.5985 0.3583  0.0777  -0.0123 76  ILE A CG1 
+433  C  CG2 . ILE A 54  ? 0.8475 0.8175 0.5991 0.4147  0.0645  -0.0152 76  ILE A CG2 
+434  C  CD1 . ILE A 54  ? 0.8429 0.8752 0.6014 0.3609  0.0654  -0.0108 76  ILE A CD1 
+435  N  N   . ALA A 55  ? 0.6495 0.8306 0.5922 0.3733  0.0849  0.0524  77  ALA A N   
+436  C  CA  . ALA A 55  ? 0.6189 0.8249 0.5861 0.4014  0.0819  0.0853  77  ALA A CA  
+437  C  C   . ALA A 55  ? 0.5435 0.8244 0.5717 0.3787  0.0751  0.1098  77  ALA A C   
+438  O  O   . ALA A 55  ? 0.5362 0.8244 0.5802 0.3728  0.0847  0.1257  77  ALA A O   
+439  C  CB  . ALA A 55  ? 0.6703 0.8460 0.5904 0.4126  0.0859  0.0858  77  ALA A CB  
+440  N  N   . GLU A 56  ? 0.4561 0.8038 0.5480 0.3285  0.0672  0.1032  78  GLU A N   
+441  C  CA  . GLU A 56  ? 0.3992 0.7877 0.5202 0.2440  0.0454  0.1019  78  GLU A CA  
+442  C  C   . GLU A 56  ? 0.3551 0.6892 0.4893 0.2245  0.0283  0.0962  78  GLU A C   
+443  O  O   . GLU A 56  ? 0.3040 0.6673 0.4892 0.1292  0.0190  0.1176  78  GLU A O   
+444  C  CB  . GLU A 56  ? 0.3922 0.8782 0.5263 0.1356  0.0506  0.0972  78  GLU A CB  
+445  C  CG  . GLU A 56  ? 0.4067 0.9798 0.5368 0.0839  0.0542  0.0803  78  GLU A CG  
+446  C  CD  . GLU A 56  ? 0.4957 1.0644 0.5460 0.0449  0.0608  0.0620  78  GLU A CD  
+447  O  OE1 . GLU A 56  ? 0.5239 1.0831 0.5497 0.0270  0.0425  0.0618  78  GLU A OE1 
+448  O  OE2 . GLU A 56  ? 0.4916 1.0768 0.5475 0.0071  0.0873  0.0477  78  GLU A OE2 
+449  N  N   . GLY A 57  ? 0.3736 0.6126 0.4551 0.2597  0.0058  0.0903  79  GLY A N   
+450  C  CA  . GLY A 57  ? 0.3626 0.5940 0.4226 0.2243  0.0327  0.0702  79  GLY A CA  
+451  C  C   . GLY A 57  ? 0.3141 0.5463 0.3866 0.1943  0.0308  0.0521  79  GLY A C   
+452  O  O   . GLY A 57  ? 0.3313 0.5057 0.3777 0.2341  0.0255  0.0357  79  GLY A O   
+453  N  N   . ARG A 58  ? 0.2728 0.5341 0.3616 0.1104  0.0351  0.0273  80  ARG A N   
+454  C  CA  . ARG A 58  ? 0.2698 0.5635 0.3267 0.1662  0.0089  0.0312  80  ARG A CA  
+455  C  C   . ARG A 58  ? 0.2406 0.5118 0.2908 0.1581  0.0021  0.0335  80  ARG A C   
+456  O  O   . ARG A 58  ? 0.2268 0.4656 0.2909 0.1521  0.0361  0.0420  80  ARG A O   
+457  C  CB  . ARG A 58  ? 0.2534 0.6291 0.3328 0.1772  0.0087  0.0299  80  ARG A CB  
+458  C  CG  . ARG A 58  ? 0.3142 0.6824 0.3414 0.1493  -0.0086 0.0135  80  ARG A CG  
+459  C  CD  . ARG A 58  ? 0.3072 0.6747 0.3504 0.1192  -0.0009 -0.0013 80  ARG A CD  
+460  N  NE  . ARG A 58  ? 0.2263 0.6790 0.3555 0.0623  -0.0186 -0.0266 80  ARG A NE  
+461  C  CZ  . ARG A 58  ? 0.2553 0.7269 0.3745 0.0850  0.0240  -0.0386 80  ARG A CZ  
+462  N  NH1 . ARG A 58  ? 0.3368 0.7487 0.3840 0.1160  0.0452  -0.0302 80  ARG A NH1 
+463  N  NH2 . ARG A 58  ? 0.2804 0.7709 0.3775 0.1303  0.0158  -0.0444 80  ARG A NH2 
+464  N  N   . ILE A 59  ? 0.2451 0.4990 0.2622 0.1003  -0.0028 0.0340  81  ILE A N   
+465  C  CA  . ILE A 59  ? 0.2652 0.4716 0.2273 0.1109  -0.0178 0.0319  81  ILE A CA  
+466  C  C   . ILE A 59  ? 0.2537 0.4067 0.2104 0.0849  -0.0237 0.0196  81  ILE A C   
+467  O  O   . ILE A 59  ? 0.2836 0.4171 0.2092 0.1063  -0.0249 0.0391  81  ILE A O   
+468  C  CB  . ILE A 59  ? 0.2461 0.4844 0.2344 0.0238  -0.0575 0.0392  81  ILE A CB  
+469  C  CG1 . ILE A 59  ? 0.2606 0.5239 0.2463 0.0177  -0.0750 0.0560  81  ILE A CG1 
+470  C  CG2 . ILE A 59  ? 0.2668 0.4266 0.2245 0.0217  -0.0415 0.0404  81  ILE A CG2 
+471  C  CD1 . ILE A 59  ? 0.2845 0.5050 0.2586 -0.0042 -0.0681 0.0420  81  ILE A CD1 
+472  N  N   . PRO A 60  ? 0.2270 0.3494 0.1964 0.0797  0.0005  0.0296  82  PRO A N   
+473  C  CA  . PRO A 60  ? 0.2472 0.3704 0.1832 0.0868  -0.0065 0.0403  82  PRO A CA  
+474  C  C   . PRO A 60  ? 0.2800 0.3756 0.1709 0.0944  -0.0178 0.0369  82  PRO A C   
+475  O  O   . PRO A 60  ? 0.2629 0.3256 0.1829 0.0823  -0.0151 0.0358  82  PRO A O   
+476  C  CB  . PRO A 60  ? 0.2734 0.4102 0.1872 0.0918  0.0026  0.0657  82  PRO A CB  
+477  C  CG  . PRO A 60  ? 0.2534 0.4092 0.2057 0.0965  0.0226  0.0510  82  PRO A CG  
+478  C  CD  . PRO A 60  ? 0.2275 0.3866 0.2043 0.0302  0.0148  0.0312  82  PRO A CD  
+479  N  N   . THR A 61  ? 0.2343 0.3828 0.1572 0.1025  -0.0112 0.0543  83  THR A N   
+480  C  CA  . THR A 61  ? 0.2377 0.3037 0.1579 0.0782  -0.0130 0.0768  83  THR A CA  
+481  C  C   . THR A 61  ? 0.2722 0.3179 0.1519 0.0948  0.0031  0.0401  83  THR A C   
+482  O  O   . THR A 61  ? 0.2681 0.2475 0.1356 0.0958  0.0064  0.0252  83  THR A O   
+483  C  CB  . THR A 61  ? 0.3095 0.3593 0.1793 0.1375  -0.0174 0.0579  83  THR A CB  
+484  O  OG1 . THR A 61  ? 0.2875 0.3765 0.1744 0.0852  -0.0454 0.0545  83  THR A OG1 
+485  C  CG2 . THR A 61  ? 0.3302 0.3393 0.1991 0.1497  -0.0333 0.0653  83  THR A CG2 
+486  N  N   . PHE A 62  ? 0.2630 0.3012 0.1696 0.0642  0.0195  0.0502  84  PHE A N   
+487  C  CA  . PHE A 62  ? 0.2823 0.2640 0.1717 0.0701  -0.0042 0.0429  84  PHE A CA  
+488  C  C   . PHE A 62  ? 0.3066 0.2577 0.1694 0.1112  -0.0015 0.0478  84  PHE A C   
+489  O  O   . PHE A 62  ? 0.3468 0.3163 0.1840 0.1152  -0.0134 0.0698  84  PHE A O   
+490  C  CB  . PHE A 62  ? 0.2943 0.2511 0.1759 0.0702  -0.0305 0.0168  84  PHE A CB  
+491  C  CG  . PHE A 62  ? 0.2495 0.2189 0.1803 0.0844  -0.0085 0.0259  84  PHE A CG  
+492  C  CD1 . PHE A 62  ? 0.3208 0.2035 0.1946 0.0946  0.0059  0.0302  84  PHE A CD1 
+493  C  CD2 . PHE A 62  ? 0.3125 0.2610 0.1828 0.1167  0.0033  0.0489  84  PHE A CD2 
+494  C  CE1 . PHE A 62  ? 0.2994 0.1744 0.1963 0.0613  0.0115  -0.0053 84  PHE A CE1 
+495  C  CE2 . PHE A 62  ? 0.2992 0.2555 0.1846 0.1505  0.0204  0.0362  84  PHE A CE2 
+496  C  CZ  . PHE A 62  ? 0.3073 0.1909 0.1992 0.1339  0.0515  0.0295  84  PHE A CZ  
+497  N  N   . LYS A 63  ? 0.3025 0.2668 0.1660 0.1237  0.0029  0.0567  85  LYS A N   
+498  C  CA  . LYS A 63  ? 0.3065 0.2315 0.1658 0.1330  0.0005  0.0412  85  LYS A CA  
+499  C  C   . LYS A 63  ? 0.3132 0.2852 0.1426 0.1395  0.0090  0.0267  85  LYS A C   
+500  O  O   . LYS A 63  ? 0.3327 0.2850 0.1232 0.0971  0.0097  0.0433  85  LYS A O   
+501  C  CB  . LYS A 63  ? 0.3648 0.2425 0.1980 0.1629  -0.0021 0.0265  85  LYS A CB  
+502  C  CG  . LYS A 63  ? 0.3875 0.3250 0.2184 0.1677  0.0117  0.0334  85  LYS A CG  
+503  C  CD  . LYS A 63  ? 0.4009 0.4174 0.2386 0.1999  0.0265  0.0348  85  LYS A CD  
+504  C  CE  . LYS A 63  ? 0.4125 0.4292 0.2420 0.2042  0.0497  0.0530  85  LYS A CE  
+505  N  NZ  A LYS A 63  ? 0.3591 0.4274 0.2422 0.1526  0.0659  0.0680  85  LYS A NZ  
+506  N  NZ  B LYS A 63  ? 0.4806 0.4594 0.2488 0.2472  0.0439  0.0547  85  LYS A NZ  
+507  N  N   . LEU A 64  ? 0.3570 0.2985 0.1433 0.1537  -0.0005 0.0378  86  LEU A N   
+508  C  CA  . LEU A 64  ? 0.3299 0.1678 0.1549 0.1215  0.0279  0.0278  86  LEU A CA  
+509  C  C   . LEU A 64  ? 0.3295 0.1737 0.1905 0.0989  0.0309  0.0514  86  LEU A C   
+510  O  O   . LEU A 64  ? 0.3327 0.2353 0.2435 0.1476  -0.0363 0.0353  86  LEU A O   
+511  C  CB  . LEU A 64  ? 0.3571 0.2595 0.1292 0.0900  -0.0141 0.0437  86  LEU A CB  
+512  C  CG  . LEU A 64  ? 0.3608 0.2990 0.1258 0.0840  -0.0408 0.0323  86  LEU A CG  
+513  C  CD1 . LEU A 64  ? 0.3255 0.2824 0.1270 0.0888  -0.0341 0.0111  86  LEU A CD1 
+514  C  CD2 . LEU A 64  ? 0.3724 0.2622 0.1403 0.1026  -0.0148 0.0534  86  LEU A CD2 
+515  N  N   . ASP A 65  ? 0.3154 0.1799 0.1705 0.0919  0.0428  0.0363  87  ASP A N   
+516  C  CA  . ASP A 65  ? 0.3280 0.1998 0.1753 0.1412  0.0198  0.0294  87  ASP A CA  
+517  C  C   . ASP A 65  ? 0.3383 0.1812 0.1826 0.1189  0.0001  0.0268  87  ASP A C   
+518  O  O   . ASP A 65  ? 0.3195 0.2027 0.1765 0.1073  0.0181  0.0436  87  ASP A O   
+519  C  CB  . ASP A 65  ? 0.3605 0.1844 0.1654 0.1163  -0.0193 0.0144  87  ASP A CB  
+520  C  CG  . ASP A 65  ? 0.3965 0.2297 0.1677 0.1230  -0.0230 0.0038  87  ASP A CG  
+521  O  OD1 . ASP A 65  ? 0.4452 0.2116 0.1664 0.1357  -0.0043 -0.0086 87  ASP A OD1 
+522  O  OD2 . ASP A 65  ? 0.4409 0.2494 0.1678 0.1526  -0.0464 -0.0059 87  ASP A OD2 
+523  N  N   . PRO A 66  ? 0.3693 0.2077 0.1989 0.1354  -0.0056 0.0401  88  PRO A N   
+524  C  CA  . PRO A 66  ? 0.3803 0.2186 0.1981 0.1032  -0.0373 0.0317  88  PRO A CA  
+525  C  C   . PRO A 66  ? 0.4303 0.1879 0.2025 0.1257  -0.0371 0.0189  88  PRO A C   
+526  O  O   . PRO A 66  ? 0.4596 0.2418 0.2192 0.1033  -0.0503 0.0287  88  PRO A O   
+527  C  CB  . PRO A 66  ? 0.4265 0.2707 0.2013 0.1083  -0.0421 0.0461  88  PRO A CB  
+528  C  CG  . PRO A 66  ? 0.4096 0.3066 0.2166 0.1010  -0.0403 0.0412  88  PRO A CG  
+529  C  CD  . PRO A 66  ? 0.3661 0.2392 0.2099 0.1062  -0.0245 0.0433  88  PRO A CD  
+530  N  N   . THR A 67  ? 0.4358 0.1864 0.1868 0.1074  -0.0437 -0.0169 89  THR A N   
+531  C  CA  . THR A 67  ? 0.4517 0.2451 0.1831 0.1175  -0.0326 -0.0008 89  THR A CA  
+532  C  C   . THR A 67  ? 0.4118 0.2478 0.1681 0.0519  -0.0332 0.0017  89  THR A C   
+533  O  O   . THR A 67  ? 0.4804 0.2656 0.1755 0.0854  -0.0362 0.0102  89  THR A O   
+534  C  CB  . THR A 67  ? 0.4438 0.2988 0.1985 0.0879  -0.0179 -0.0074 89  THR A CB  
+535  O  OG1 . THR A 67  ? 0.4050 0.2030 0.1903 0.0640  0.0032  0.0074  89  THR A OG1 
+536  C  CG2 . THR A 67  ? 0.4091 0.2934 0.2073 0.0650  -0.0125 0.0076  89  THR A CG2 
+537  N  N   . ILE A 68  ? 0.3817 0.2285 0.1553 0.0296  -0.0265 0.0200  90  ILE A N   
+538  C  CA  . ILE A 68  ? 0.3968 0.2586 0.1370 0.0380  -0.0020 0.0263  90  ILE A CA  
+539  C  C   . ILE A 68  ? 0.4043 0.2710 0.1393 -0.0032 -0.0018 0.0415  90  ILE A C   
+540  O  O   . ILE A 68  ? 0.4454 0.3339 0.1346 0.0068  0.0270  0.0603  90  ILE A O   
+541  C  CB  . ILE A 68  ? 0.3548 0.2082 0.1150 0.0870  0.0010  0.0065  90  ILE A CB  
+542  C  CG1 . ILE A 68  ? 0.3749 0.1969 0.1169 0.0851  0.0202  0.0350  90  ILE A CG1 
+543  C  CG2 . ILE A 68  ? 0.3550 0.2356 0.1079 0.0513  0.0133  0.0013  90  ILE A CG2 
+544  C  CD1 . ILE A 68  ? 0.3502 0.2339 0.1251 0.1135  0.0162  0.0135  90  ILE A CD1 
+545  N  N   . ALA A 69  ? 0.4372 0.2593 0.1386 0.0062  -0.0195 0.0404  91  ALA A N   
+546  C  CA  . ALA A 69  ? 0.4747 0.2732 0.1464 -0.0387 0.0072  0.0611  91  ALA A CA  
+547  C  C   . ALA A 69  ? 0.4319 0.2522 0.1445 -0.0060 0.0117  0.0717  91  ALA A C   
+548  O  O   . ALA A 69  ? 0.4681 0.4349 0.1401 -0.0150 0.0016  0.0807  91  ALA A O   
+549  C  CB  . ALA A 69  ? 0.5711 0.3271 0.1685 -0.0092 0.0094  0.0682  91  ALA A CB  
+550  N  N   . LEU A 70  ? 0.4178 0.2018 0.1291 0.0269  -0.0189 0.0304  92  LEU A N   
+551  C  CA  . LEU A 70  ? 0.3665 0.2849 0.1280 0.0573  -0.0267 0.0128  92  LEU A CA  
+552  C  C   . LEU A 70  ? 0.3596 0.2042 0.1165 0.0618  -0.0236 0.0111  92  LEU A C   
+553  O  O   . LEU A 70  ? 0.3624 0.2806 0.1258 0.1237  -0.0001 0.0224  92  LEU A O   
+554  C  CB  . LEU A 70  ? 0.3646 0.3222 0.1523 0.0629  -0.0300 -0.0246 92  LEU A CB  
+555  C  CG  . LEU A 70  ? 0.3878 0.3677 0.1650 0.0357  -0.0216 0.0121  92  LEU A CG  
+556  C  CD1 . LEU A 70  ? 0.4300 0.3426 0.1882 0.0933  -0.0336 0.0036  92  LEU A CD1 
+557  C  CD2 . LEU A 70  ? 0.4323 0.5045 0.1727 0.1055  -0.0180 -0.0341 92  LEU A CD2 
+558  N  N   . SER A 71  ? 0.3687 0.2235 0.1098 0.0497  -0.0443 0.0168  93  SER A N   
+559  C  CA  . SER A 71  ? 0.3618 0.2175 0.1158 0.0810  -0.0415 0.0157  93  SER A CA  
+560  C  C   . SER A 71  ? 0.3480 0.2315 0.1106 0.0757  -0.0068 0.0377  93  SER A C   
+561  O  O   . SER A 71  ? 0.3256 0.2838 0.1190 0.1212  0.0016  0.0364  93  SER A O   
+562  C  CB  . SER A 71  ? 0.3906 0.2277 0.1249 0.0409  -0.0345 0.0447  93  SER A CB  
+563  O  OG  . SER A 71  ? 0.4192 0.2299 0.1311 0.1040  -0.0320 0.0182  93  SER A OG  
+564  N  N   . GLU A 72  ? 0.3403 0.3055 0.1166 0.0996  0.0004  0.0397  94  GLU A N   
+565  C  CA  . GLU A 72  ? 0.3397 0.3020 0.1282 0.1311  0.0157  0.0463  94  GLU A CA  
+566  C  C   . GLU A 72  ? 0.3255 0.2698 0.1240 0.1154  0.0053  0.0471  94  GLU A C   
+567  O  O   . GLU A 72  ? 0.3297 0.2328 0.1162 0.0811  -0.0114 0.0449  94  GLU A O   
+568  C  CB  . GLU A 72  ? 0.3768 0.3475 0.1338 0.1266  0.0346  0.0443  94  GLU A CB  
+569  C  CG  . GLU A 72  ? 0.3725 0.3503 0.1283 0.1120  0.0217  0.0421  94  GLU A CG  
+570  C  CD  . GLU A 72  ? 0.4458 0.3953 0.1461 0.1139  0.0331  0.0490  94  GLU A CD  
+571  O  OE1 . GLU A 72  ? 0.4812 0.4468 0.1587 0.1170  0.0272  0.0576  94  GLU A OE1 
+572  O  OE2 . GLU A 72  ? 0.4836 0.4262 0.1530 0.1208  0.0098  0.0450  94  GLU A OE2 
+573  N  N   . ALA A 73  ? 0.3473 0.2843 0.1233 0.0752  0.0143  0.0626  95  ALA A N   
+574  C  CA  . ALA A 73  ? 0.3253 0.2658 0.1101 0.0856  -0.0011 0.0419  95  ALA A CA  
+575  C  C   . ALA A 73  ? 0.2906 0.2239 0.0922 0.0651  0.0050  0.0145  95  ALA A C   
+576  O  O   . ALA A 73  ? 0.3158 0.2034 0.0921 0.0728  -0.0058 0.0104  95  ALA A O   
+577  C  CB  . ALA A 73  ? 0.3304 0.2857 0.1089 0.0700  0.0119  0.0478  95  ALA A CB  
+578  N  N   . GLU A 74  ? 0.2852 0.2279 0.0974 0.0656  0.0114  0.0318  96  GLU A N   
+579  C  CA  . GLU A 74  ? 0.2868 0.1880 0.1000 0.0666  -0.0014 0.0301  96  GLU A CA  
+580  C  C   . GLU A 74  ? 0.3108 0.2195 0.1006 0.0650  -0.0125 0.0307  96  GLU A C   
+581  O  O   . GLU A 74  ? 0.2984 0.2221 0.1008 0.0598  -0.0191 0.0394  96  GLU A O   
+582  C  CB  . GLU A 74  ? 0.3392 0.2037 0.1278 0.0880  -0.0169 0.0425  96  GLU A CB  
+583  C  CG  . GLU A 74  ? 0.3558 0.2087 0.1188 0.0609  -0.0068 0.0475  96  GLU A CG  
+584  C  CD  . GLU A 74  ? 0.3577 0.2582 0.1165 0.0121  -0.0181 0.0644  96  GLU A CD  
+585  O  OE1 . GLU A 74  ? 0.3356 0.3034 0.1084 0.0325  -0.0351 0.0505  96  GLU A OE1 
+586  O  OE2 . GLU A 74  ? 0.3482 0.3112 0.1342 0.0771  -0.0121 0.0706  96  GLU A OE2 
+587  N  N   . PHE A 75  ? 0.3176 0.2082 0.1057 0.0508  -0.0231 0.0412  97  PHE A N   
+588  C  CA  . PHE A 75  ? 0.3041 0.2272 0.1072 0.0487  -0.0262 0.0489  97  PHE A CA  
+589  C  C   . PHE A 75  ? 0.2713 0.2076 0.0977 0.0456  -0.0262 0.0442  97  PHE A C   
+590  O  O   . PHE A 75  ? 0.3007 0.2372 0.0953 0.0570  -0.0110 0.0363  97  PHE A O   
+591  C  CB  . PHE A 75  ? 0.3015 0.2329 0.0954 0.0274  -0.0156 0.0466  97  PHE A CB  
+592  C  CG  . PHE A 75  ? 0.3139 0.2146 0.0965 0.0447  0.0072  0.0331  97  PHE A CG  
+593  C  CD1 . PHE A 75  ? 0.3499 0.2292 0.0987 0.0794  0.0078  0.0126  97  PHE A CD1 
+594  C  CD2 . PHE A 75  ? 0.3402 0.2322 0.1024 0.0566  0.0076  0.0315  97  PHE A CD2 
+595  C  CE1 . PHE A 75  ? 0.3606 0.2249 0.1123 0.0906  -0.0025 0.0304  97  PHE A CE1 
+596  C  CE2 . PHE A 75  ? 0.4132 0.2582 0.1206 0.0583  0.0265  0.0403  97  PHE A CE2 
+597  C  CZ  . PHE A 75  ? 0.4059 0.2183 0.1314 0.0868  0.0075  0.0436  97  PHE A CZ  
+598  N  N   . ILE A 76  ? 0.2980 0.2549 0.1081 0.0891  -0.0036 0.0422  98  ILE A N   
+599  C  CA  . ILE A 76  ? 0.2439 0.2614 0.1087 0.0399  -0.0176 0.0297  98  ILE A CA  
+600  C  C   . ILE A 76  ? 0.2904 0.2539 0.0981 0.0467  -0.0238 0.0203  98  ILE A C   
+601  O  O   . ILE A 76  ? 0.3074 0.2090 0.0969 0.0768  -0.0122 0.0247  98  ILE A O   
+602  C  CB  . ILE A 76  ? 0.2592 0.3063 0.1246 0.0509  -0.0269 0.0246  98  ILE A CB  
+603  C  CG1 . ILE A 76  ? 0.2972 0.2452 0.1483 0.0405  -0.0073 0.0455  98  ILE A CG1 
+604  C  CG2 . ILE A 76  ? 0.1897 0.2875 0.1194 0.0349  -0.0562 0.0401  98  ILE A CG2 
+605  C  CD1 . ILE A 76  ? 0.3114 0.3189 0.1716 0.1218  0.0063  0.0512  98  ILE A CD1 
+606  N  N   . ALA A 77  ? 0.2080 0.2727 0.0931 0.0435  -0.0139 0.0399  99  ALA A N   
+607  C  CA  . ALA A 77  ? 0.2570 0.1913 0.0913 0.0144  -0.0132 0.0504  99  ALA A CA  
+608  C  C   . ALA A 77  ? 0.2995 0.1877 0.1003 0.0429  -0.0248 0.0388  99  ALA A C   
+609  O  O   . ALA A 77  ? 0.3228 0.1982 0.1143 0.0932  -0.0254 0.0246  99  ALA A O   
+610  C  CB  . ALA A 77  ? 0.3031 0.2345 0.1055 0.0949  0.0039  0.0367  99  ALA A CB  
+611  N  N   . GLN A 78  ? 0.3152 0.1814 0.0993 0.0724  -0.0203 0.0213  100 GLN A N   
+612  C  CA  . GLN A 78  ? 0.2882 0.2064 0.1053 0.0776  -0.0186 0.0360  100 GLN A CA  
+613  C  C   . GLN A 78  ? 0.2938 0.1895 0.1051 0.0784  -0.0160 0.0329  100 GLN A C   
+614  O  O   . GLN A 78  ? 0.2660 0.2065 0.1061 0.0442  -0.0145 0.0416  100 GLN A O   
+615  C  CB  . GLN A 78  ? 0.2909 0.1904 0.1097 0.0843  -0.0166 0.0343  100 GLN A CB  
+616  C  CG  . GLN A 78  ? 0.2933 0.2042 0.1010 0.0417  -0.0356 0.0208  100 GLN A CG  
+617  C  CD  . GLN A 78  ? 0.3202 0.2439 0.1050 0.0547  -0.0289 0.0356  100 GLN A CD  
+618  O  OE1 . GLN A 78  ? 0.3506 0.1867 0.1178 0.0524  -0.0283 0.0383  100 GLN A OE1 
+619  N  NE2 . GLN A 78  ? 0.3260 0.2175 0.1198 0.0596  -0.0302 0.0488  100 GLN A NE2 
+620  N  N   . ILE A 79  ? 0.2718 0.1633 0.1102 0.0655  -0.0344 0.0313  101 ILE A N   
+621  C  CA  . ILE A 79  ? 0.2347 0.1862 0.1041 0.0517  -0.0215 0.0293  101 ILE A CA  
+622  C  C   . ILE A 79  ? 0.3208 0.2280 0.1073 0.0512  -0.0432 0.0257  101 ILE A C   
+623  O  O   . ILE A 79  ? 0.2780 0.2389 0.1093 0.0516  -0.0338 0.0519  101 ILE A O   
+624  C  CB  . ILE A 79  ? 0.2122 0.2024 0.1119 0.0267  -0.0456 0.0024  101 ILE A CB  
+625  C  CG1 . ILE A 79  ? 0.2475 0.1847 0.1205 0.0613  -0.0217 -0.0044 101 ILE A CG1 
+626  C  CG2 . ILE A 79  ? 0.2415 0.1913 0.0951 0.0396  -0.0316 -0.0237 101 ILE A CG2 
+627  C  CD1 . ILE A 79  ? 0.2756 0.2177 0.1281 0.0730  -0.0208 -0.0168 101 ILE A CD1 
+628  N  N   . ASP A 80  ? 0.3185 0.2439 0.0962 0.0603  -0.0292 0.0166  102 ASP A N   
+629  C  CA  . ASP A 80  ? 0.3114 0.2193 0.1031 0.0685  -0.0489 0.0051  102 ASP A CA  
+630  C  C   . ASP A 80  ? 0.3179 0.2356 0.1052 0.0980  -0.0218 0.0168  102 ASP A C   
+631  O  O   . ASP A 80  ? 0.2897 0.2492 0.1058 0.1206  0.0107  0.0289  102 ASP A O   
+632  C  CB  . ASP A 80  ? 0.3484 0.2666 0.1235 0.0819  -0.0529 0.0222  102 ASP A CB  
+633  C  CG  . ASP A 80  ? 0.3901 0.2999 0.1303 0.0842  -0.0421 0.0344  102 ASP A CG  
+634  O  OD1 . ASP A 80  ? 0.4723 0.3498 0.1367 0.0464  -0.0424 0.0390  102 ASP A OD1 
+635  O  OD2 . ASP A 80  ? 0.4108 0.2988 0.1235 0.0971  0.0102  0.0331  102 ASP A OD2 
+636  N  N   . THR A 81  ? 0.2990 0.2385 0.1104 0.0693  -0.0139 0.0502  103 THR A N   
+637  C  CA  . THR A 81  ? 0.2703 0.2628 0.1203 0.0396  0.0001  0.0582  103 THR A CA  
+638  C  C   . THR A 81  ? 0.2845 0.2933 0.1134 0.0563  0.0030  0.0446  103 THR A C   
+639  O  O   . THR A 81  ? 0.2392 0.3258 0.1187 0.0591  0.0054  0.0360  103 THR A O   
+640  C  CB  . THR A 81  ? 0.3235 0.3467 0.1532 0.0592  0.0089  0.0945  103 THR A CB  
+641  O  OG1 . THR A 81  ? 0.2998 0.3585 0.1642 0.0463  0.0243  0.1071  103 THR A OG1 
+642  C  CG2 . THR A 81  ? 0.4050 0.3310 0.1767 0.0813  0.0114  0.1066  103 THR A CG2 
+643  N  N   . LEU A 82  ? 0.2884 0.2329 0.1064 0.1128  -0.0078 0.0249  104 LEU A N   
+644  C  CA  . LEU A 82  ? 0.2644 0.1792 0.0957 0.0581  -0.0078 0.0413  104 LEU A CA  
+645  C  C   . LEU A 82  ? 0.2424 0.1657 0.0882 0.0508  -0.0030 0.0395  104 LEU A C   
+646  O  O   . LEU A 82  ? 0.2764 0.2397 0.0925 0.0792  0.0023  0.0305  104 LEU A O   
+647  C  CB  . LEU A 82  ? 0.3332 0.2203 0.1030 0.0679  -0.0170 0.0293  104 LEU A CB  
+648  C  CG  . LEU A 82  ? 0.3156 0.2257 0.0918 0.0428  -0.0058 0.0290  104 LEU A CG  
+649  C  CD1 . LEU A 82  ? 0.3287 0.2841 0.1003 0.0551  0.0183  0.0351  104 LEU A CD1 
+650  C  CD2 . LEU A 82  ? 0.3692 0.3132 0.1006 0.0229  -0.0169 0.0322  104 LEU A CD2 
+651  N  N   . ASN A 83  ? 0.2599 0.2019 0.0883 0.0440  -0.0074 0.0249  105 ASN A N   
+652  C  CA  . ASN A 83  ? 0.2577 0.2053 0.0867 0.0480  -0.0123 0.0126  105 ASN A CA  
+653  C  C   . ASN A 83  ? 0.3035 0.2249 0.0980 0.0530  -0.0245 -0.0092 105 ASN A C   
+654  O  O   . ASN A 83  ? 0.3614 0.2367 0.1112 0.0647  -0.0251 -0.0112 105 ASN A O   
+655  C  CB  . ASN A 83  ? 0.2614 0.2232 0.0855 0.0694  -0.0285 0.0047  105 ASN A CB  
+656  C  CG  . ASN A 83  ? 0.3144 0.1612 0.0936 0.0606  -0.0283 0.0088  105 ASN A CG  
+657  O  OD1 . ASN A 83  ? 0.2911 0.2168 0.1149 0.0239  0.0083  0.0273  105 ASN A OD1 
+658  N  ND2 . ASN A 83  ? 0.2650 0.2397 0.0854 0.0577  -0.0339 -0.0021 105 ASN A ND2 
+659  N  N   A SER A 84  ? 0.3768 0.2447 0.1123 0.1212  -0.0044 -0.0031 106 SER A N   
+660  N  N   B SER A 84  ? 0.3517 0.2355 0.1006 0.0662  -0.0100 -0.0059 106 SER A N   
+661  C  CA  . SER A 84  ? 0.3846 0.2308 0.1015 0.0411  -0.0004 -0.0050 106 SER A CA  
+662  C  C   . SER A 84  ? 0.3447 0.2637 0.1118 0.0951  0.0185  -0.0023 106 SER A C   
+663  O  O   . SER A 84  ? 0.3954 0.3097 0.1469 0.1772  -0.0039 -0.0293 106 SER A O   
+664  C  CB  A SER A 84  ? 0.4205 0.2808 0.1155 0.0834  -0.0114 -0.0062 106 SER A CB  
+665  C  CB  B SER A 84  ? 0.3972 0.2186 0.1050 0.0635  -0.0067 -0.0077 106 SER A CB  
+666  O  OG  A SER A 84  ? 0.4420 0.4152 0.1371 0.0948  -0.0149 0.0321  106 SER A OG  
+667  O  OG  B SER A 84  ? 0.4091 0.2369 0.1098 0.0726  -0.0105 0.0050  106 SER A OG  
+668  N  N   . GLN A 85  ? 0.2782 0.2480 0.0993 0.0807  -0.0103 0.0065  107 GLN A N   
+669  C  CA  . GLN A 85  ? 0.2988 0.2481 0.1109 0.0935  -0.0133 -0.0008 107 GLN A CA  
+670  C  C   . GLN A 85  ? 0.2808 0.2737 0.1122 0.1025  -0.0161 0.0004  107 GLN A C   
+671  O  O   . GLN A 85  ? 0.3663 0.2984 0.1349 0.1278  0.0036  0.0280  107 GLN A O   
+672  C  CB  . GLN A 85  ? 0.2910 0.2374 0.1182 0.0348  -0.0125 0.0187  107 GLN A CB  
+673  C  CG  . GLN A 85  ? 0.3579 0.2139 0.1186 0.0420  -0.0143 0.0275  107 GLN A CG  
+674  C  CD  . GLN A 85  ? 0.4203 0.2869 0.1112 0.0586  -0.0096 0.0044  107 GLN A CD  
+675  O  OE1 . GLN A 85  ? 0.4687 0.2342 0.1174 -0.0087 -0.0056 0.0030  107 GLN A OE1 
+676  N  NE2 . GLN A 85  ? 0.4118 0.2782 0.1359 0.1800  0.0183  0.0136  107 GLN A NE2 
+677  N  N   . GLY A 86  ? 0.2489 0.2310 0.0945 0.0267  -0.0144 0.0058  108 GLY A N   
+678  C  CA  . GLY A 86  ? 0.2692 0.1616 0.1115 0.0549  -0.0074 -0.0207 108 GLY A CA  
+679  C  C   . GLY A 86  ? 0.3230 0.1391 0.1060 0.0524  -0.0169 -0.0117 108 GLY A C   
+680  O  O   . GLY A 86  ? 0.4043 0.1685 0.1142 0.0670  -0.0093 -0.0151 108 GLY A O   
+681  N  N   . ARG A 87  ? 0.2988 0.1435 0.0936 0.0467  -0.0355 -0.0259 109 ARG A N   
+682  C  CA  . ARG A 87  ? 0.3102 0.1584 0.0999 0.0745  -0.0393 -0.0291 109 ARG A CA  
+683  C  C   . ARG A 87  ? 0.2708 0.2093 0.0962 0.0463  -0.0576 -0.0229 109 ARG A C   
+684  O  O   . ARG A 87  ? 0.2725 0.2182 0.0954 0.0474  -0.0386 -0.0021 109 ARG A O   
+685  C  CB  . ARG A 87  ? 0.3046 0.1572 0.0908 0.0957  -0.0221 -0.0082 109 ARG A CB  
+686  C  CG  . ARG A 87  ? 0.2699 0.1641 0.0867 0.0183  -0.0329 -0.0349 109 ARG A CG  
+687  C  CD  . ARG A 87  ? 0.3043 0.2240 0.0956 0.0433  -0.0206 -0.0350 109 ARG A CD  
+688  N  NE  . ARG A 87  ? 0.2937 0.2455 0.1136 0.0366  -0.0213 -0.0316 109 ARG A NE  
+689  C  CZ  . ARG A 87  ? 0.2719 0.2036 0.1124 0.0058  -0.0105 -0.0330 109 ARG A CZ  
+690  N  NH1 . ARG A 87  ? 0.2973 0.1365 0.0934 0.0495  -0.0177 -0.0156 109 ARG A NH1 
+691  N  NH2 . ARG A 87  ? 0.3001 0.2173 0.1087 0.0406  -0.0117 -0.0302 109 ARG A NH2 
+692  N  N   . SER A 88  ? 0.2275 0.1847 0.0757 0.0458  -0.0315 -0.0225 110 SER A N   
+693  C  CA  . SER A 88  ? 0.1984 0.2108 0.0894 0.0540  -0.0350 -0.0225 110 SER A CA  
+694  C  C   . SER A 88  ? 0.2522 0.1932 0.0854 0.0638  -0.0044 -0.0194 110 SER A C   
+695  O  O   . SER A 88  ? 0.2558 0.1811 0.0874 0.0434  0.0131  -0.0145 110 SER A O   
+696  C  CB  . SER A 88  ? 0.2514 0.1770 0.1040 0.0621  -0.0233 -0.0158 110 SER A CB  
+697  O  OG  . SER A 88  ? 0.3110 0.1602 0.1220 0.0681  -0.0190 -0.0086 110 SER A OG  
+698  N  N   . VAL A 89  ? 0.2458 0.1330 0.0810 0.0523  -0.0306 -0.0105 111 VAL A N   
+699  C  CA  . VAL A 89  ? 0.2382 0.1650 0.0804 0.0229  -0.0145 -0.0015 111 VAL A CA  
+700  C  C   . VAL A 89  ? 0.2330 0.1695 0.0838 0.0731  -0.0290 0.0097  111 VAL A C   
+701  O  O   . VAL A 89  ? 0.2580 0.2178 0.0791 0.0636  -0.0213 -0.0047 111 VAL A O   
+702  C  CB  . VAL A 89  ? 0.2482 0.2024 0.0775 0.0314  -0.0240 0.0027  111 VAL A CB  
+703  C  CG1 . VAL A 89  ? 0.2710 0.1894 0.0798 0.0512  -0.0298 -0.0122 111 VAL A CG1 
+704  C  CG2 . VAL A 89  ? 0.3259 0.1796 0.0955 0.0695  -0.0271 0.0078  111 VAL A CG2 
+705  N  N   . LEU A 90  ? 0.2271 0.1499 0.0759 0.0402  -0.0382 -0.0117 112 LEU A N   
+706  C  CA  . LEU A 90  ? 0.2088 0.1405 0.0858 0.0261  -0.0171 0.0064  112 LEU A CA  
+707  C  C   . LEU A 90  ? 0.1977 0.1681 0.0880 0.0113  -0.0225 0.0038  112 LEU A C   
+708  O  O   . LEU A 90  ? 0.2665 0.1701 0.0962 0.0343  -0.0086 -0.0121 112 LEU A O   
+709  C  CB  . LEU A 90  ? 0.2026 0.1951 0.0834 0.0418  -0.0394 -0.0043 112 LEU A CB  
+710  C  CG  . LEU A 90  ? 0.2277 0.1731 0.0966 0.0738  -0.0403 0.0135  112 LEU A CG  
+711  C  CD1 . LEU A 90  ? 0.1919 0.2132 0.0980 0.0829  -0.0421 0.0004  112 LEU A CD1 
+712  C  CD2 . LEU A 90  ? 0.2776 0.1688 0.1000 0.0733  -0.0375 0.0049  112 LEU A CD2 
+713  N  N   . ILE A 91  ? 0.1931 0.1888 0.0826 -0.0170 -0.0286 0.0099  113 ILE A N   
+714  C  CA  . ILE A 91  ? 0.2211 0.1806 0.0979 0.0101  -0.0260 0.0120  113 ILE A CA  
+715  C  C   . ILE A 91  ? 0.2181 0.1760 0.0816 0.0418  -0.0022 0.0082  113 ILE A C   
+716  O  O   . ILE A 91  ? 0.2990 0.2066 0.0821 0.0225  -0.0106 0.0256  113 ILE A O   
+717  C  CB  . ILE A 91  ? 0.2535 0.1676 0.1134 0.0380  0.0106  0.0345  113 ILE A CB  
+718  C  CG1 . ILE A 91  ? 0.2619 0.1905 0.1328 0.0895  0.0083  0.0145  113 ILE A CG1 
+719  C  CG2 . ILE A 91  ? 0.2816 0.1645 0.1285 0.0484  0.0060  0.0307  113 ILE A CG2 
+720  C  CD1 . ILE A 91  ? 0.3082 0.1829 0.1229 0.0882  0.0121  0.0142  113 ILE A CD1 
+721  N  N   . ALA A 92  ? 0.2387 0.1426 0.0797 0.0168  -0.0103 0.0072  114 ALA A N   
+722  C  CA  . ALA A 92  ? 0.2205 0.1472 0.0798 0.0176  -0.0164 0.0075  114 ALA A CA  
+723  C  C   . ALA A 92  ? 0.2651 0.1698 0.0954 0.0295  -0.0103 0.0112  114 ALA A C   
+724  O  O   . ALA A 92  ? 0.2655 0.1768 0.1131 0.0381  -0.0129 -0.0050 114 ALA A O   
+725  C  CB  . ALA A 92  ? 0.2868 0.2029 0.0834 0.0596  0.0115  -0.0155 114 ALA A CB  
+726  N  N   . LEU A 93  ? 0.2398 0.1756 0.1088 0.0520  0.0040  0.0059  115 LEU A N   
+727  C  CA  . LEU A 93  ? 0.2512 0.1954 0.1160 0.0906  0.0038  0.0154  115 LEU A CA  
+728  C  C   . LEU A 93  ? 0.2451 0.2108 0.1116 0.0645  -0.0081 0.0103  115 LEU A C   
+729  O  O   . LEU A 93  ? 0.2522 0.1939 0.1134 0.0796  -0.0004 0.0250  115 LEU A O   
+730  C  CB  . LEU A 93  ? 0.2489 0.2651 0.1235 0.0369  -0.0279 0.0167  115 LEU A CB  
+731  C  CG  . LEU A 93  ? 0.2395 0.2303 0.1584 0.0434  -0.0106 0.0195  115 LEU A CG  
+732  C  CD1 . LEU A 93  ? 0.2437 0.2551 0.1669 0.0383  -0.0026 0.0044  115 LEU A CD1 
+733  C  CD2 . LEU A 93  ? 0.2782 0.2731 0.1802 0.0915  0.0186  0.0155  115 LEU A CD2 
+734  N  N   . GLY A 94  ? 0.2389 0.2055 0.0992 0.0318  0.0165  0.0229  116 GLY A N   
+735  C  CA  . GLY A 94  ? 0.2644 0.2598 0.0993 0.0548  0.0046  0.0003  116 GLY A CA  
+736  C  C   . GLY A 94  ? 0.2660 0.2077 0.1108 0.0793  0.0064  0.0063  116 GLY A C   
+737  O  O   . GLY A 94  ? 0.2752 0.1655 0.1262 0.0636  -0.0136 -0.0003 116 GLY A O   
+738  N  N   . GLY A 95  ? 0.2671 0.1307 0.1219 0.0518  -0.0012 0.0061  117 GLY A N   
+739  C  CA  . GLY A 95  ? 0.3118 0.1620 0.1329 0.0843  -0.0079 -0.0044 117 GLY A CA  
+740  C  C   . GLY A 95  ? 0.3023 0.1770 0.1457 0.0522  0.0293  0.0061  117 GLY A C   
+741  O  O   . GLY A 95  ? 0.2879 0.1991 0.1488 0.0337  0.0297  -0.0185 117 GLY A O   
+742  N  N   . ALA A 96  ? 0.2995 0.1806 0.1573 0.0889  0.0377  -0.0205 118 ALA A N   
+743  C  CA  . ALA A 96  ? 0.3432 0.1735 0.1603 0.0432  0.0277  -0.0258 118 ALA A CA  
+744  C  C   . ALA A 96  ? 0.3527 0.2199 0.2055 0.0620  0.0422  -0.0287 118 ALA A C   
+745  O  O   . ALA A 96  ? 0.3371 0.2145 0.2101 0.1212  0.0309  -0.0210 118 ALA A O   
+746  C  CB  . ALA A 96  ? 0.3701 0.2202 0.1556 0.1089  0.0141  -0.0351 118 ALA A CB  
+747  N  N   . ASP A 97  ? 0.3612 0.2359 0.2449 0.1074  0.0773  -0.0216 119 ASP A N   
+748  C  CA  . ASP A 97  ? 0.4139 0.1973 0.3018 0.0860  0.0585  -0.0464 119 ASP A CA  
+749  C  C   . ASP A 97  ? 0.3882 0.1983 0.3156 0.1412  0.0481  -0.0093 119 ASP A C   
+750  O  O   . ASP A 97  ? 0.5267 0.3176 0.3490 0.1733  -0.0064 -0.0331 119 ASP A O   
+751  C  CB  . ASP A 97  ? 0.5037 0.2933 0.3478 0.1588  0.0526  -0.0646 119 ASP A CB  
+752  C  CG  . ASP A 97  ? 0.6464 0.4112 0.3923 0.1354  0.0385  -0.1075 119 ASP A CG  
+753  O  OD1 . ASP A 97  ? 0.6985 0.4836 0.4071 0.0916  0.0013  -0.1002 119 ASP A OD1 
+754  O  OD2 . ASP A 97  ? 0.7094 0.4135 0.4199 0.1707  0.0420  -0.1200 119 ASP A OD2 
+755  N  N   . ALA A 98  ? 0.3708 0.2249 0.3038 0.1164  0.0743  0.0129  120 ALA A N   
+756  C  CA  . ALA A 98  ? 0.3699 0.2352 0.2921 0.0886  0.0433  0.0308  120 ALA A CA  
+757  C  C   . ALA A 98  ? 0.4272 0.2952 0.3118 0.1252  0.0374  0.0162  120 ALA A C   
+758  O  O   . ALA A 98  ? 0.4871 0.3585 0.3297 0.1038  0.0241  0.0404  120 ALA A O   
+759  C  CB  . ALA A 98  ? 0.3964 0.3364 0.2764 0.1503  0.0367  0.0461  120 ALA A CB  
+760  N  N   . HIS A 99  ? 0.3783 0.2925 0.3058 0.0815  0.0676  -0.0288 121 HIS A N   
+761  C  CA  . HIS A 99  ? 0.4119 0.3678 0.3069 0.0844  0.0323  -0.0574 121 HIS A CA  
+762  C  C   . HIS A 99  ? 0.3416 0.4334 0.2964 0.0347  0.0283  0.0016  121 HIS A C   
+763  O  O   . HIS A 99  ? 0.3357 0.4547 0.2924 0.0787  0.0362  0.0652  121 HIS A O   
+764  C  CB  . HIS A 99  ? 0.5217 0.5125 0.3195 0.1409  0.0123  -0.0908 121 HIS A CB  
+765  C  CG  . HIS A 99  ? 0.6315 0.6351 0.3293 0.1473  -0.0035 -0.1089 121 HIS A CG  
+766  N  ND1 . HIS A 99  ? 0.6741 0.6714 0.3329 0.1417  -0.0116 -0.1150 121 HIS A ND1 
+767  C  CD2 . HIS A 99  ? 0.6618 0.6668 0.3316 0.1405  -0.0074 -0.1152 121 HIS A CD2 
+768  C  CE1 . HIS A 99  ? 0.6885 0.6645 0.3320 0.1402  -0.0158 -0.1317 121 HIS A CE1 
+769  N  NE2 . HIS A 99  ? 0.6816 0.6521 0.3296 0.1475  -0.0116 -0.1291 121 HIS A NE2 
+770  N  N   . ILE A 100 ? 0.3333 0.4275 0.2789 0.0637  0.0165  -0.0133 122 ILE A N   
+771  C  CA  . ILE A 100 ? 0.2777 0.3989 0.2431 0.0552  0.0050  -0.0107 122 ILE A CA  
+772  C  C   . ILE A 100 ? 0.3005 0.4522 0.2386 0.0693  0.0158  -0.0143 122 ILE A C   
+773  O  O   . ILE A 100 ? 0.3214 0.3949 0.2274 0.0953  0.0048  -0.0256 122 ILE A O   
+774  C  CB  . ILE A 100 ? 0.2576 0.3790 0.2317 0.0144  0.0274  0.0161  122 ILE A CB  
+775  C  CG1 . ILE A 100 ? 0.2743 0.3697 0.2263 0.1107  0.0360  0.0136  122 ILE A CG1 
+776  C  CG2 . ILE A 100 ? 0.2889 0.3833 0.2132 0.0146  0.0376  0.0262  122 ILE A CG2 
+777  C  CD1 . ILE A 100 ? 0.3290 0.4321 0.2282 0.0548  0.0337  0.0194  122 ILE A CD1 
+778  N  N   . GLU A 101 ? 0.2689 0.4460 0.2397 0.0123  0.0114  -0.0212 123 GLU A N   
+779  C  CA  . GLU A 101 ? 0.3176 0.4668 0.2569 0.0229  0.0327  -0.0292 123 GLU A CA  
+780  C  C   . GLU A 101 ? 0.3024 0.4322 0.2535 0.0318  0.0272  -0.0008 123 GLU A C   
+781  O  O   . GLU A 101 ? 0.3546 0.4569 0.2736 0.0894  0.0192  -0.0063 123 GLU A O   
+782  C  CB  . GLU A 101 ? 0.3930 0.5547 0.2734 0.0184  0.0731  -0.0478 123 GLU A CB  
+783  C  CG  . GLU A 101 ? 0.4739 0.7172 0.2907 0.0591  0.0947  -0.0767 123 GLU A CG  
+784  C  CD  . GLU A 101 ? 0.5601 0.8631 0.3081 0.1005  0.1378  -0.0764 123 GLU A CD  
+785  O  OE1 . GLU A 101 ? 0.5679 0.9051 0.3191 0.0784  0.1568  -0.0565 123 GLU A OE1 
+786  O  OE2 . GLU A 101 ? 0.6208 0.8849 0.3248 0.1379  0.1512  -0.0786 123 GLU A OE2 
+787  N  N   . LEU A 102 ? 0.2782 0.4726 0.2396 0.0439  0.0365  0.0068  124 LEU A N   
+788  C  CA  . LEU A 102 ? 0.2397 0.5155 0.2411 0.0092  0.0238  -0.0023 124 LEU A CA  
+789  C  C   . LEU A 102 ? 0.2405 0.6254 0.2436 0.0145  0.0155  -0.0164 124 LEU A C   
+790  O  O   . LEU A 102 ? 0.3008 0.5990 0.2295 0.0054  0.0130  -0.0158 124 LEU A O   
+791  C  CB  . LEU A 102 ? 0.2430 0.4898 0.2392 0.0135  0.0156  0.0031  124 LEU A CB  
+792  C  CG  . LEU A 102 ? 0.2291 0.4879 0.2405 -0.0369 -0.0005 0.0434  124 LEU A CG  
+793  C  CD1 . LEU A 102 ? 0.2791 0.4807 0.2302 0.0101  0.0246  0.0526  124 LEU A CD1 
+794  C  CD2 . LEU A 102 ? 0.3271 0.5555 0.2671 0.0443  -0.0013 0.0786  124 LEU A CD2 
+795  N  N   . THR A 103 ? 0.2643 0.6772 0.2601 -0.0309 0.0008  -0.0325 125 THR A N   
+796  C  CA  . THR A 103 ? 0.2655 0.7642 0.2757 -0.0477 0.0269  -0.0146 125 THR A CA  
+797  C  C   . THR A 103 ? 0.2714 0.7900 0.2775 -0.0852 0.0143  0.0028  125 THR A C   
+798  O  O   . THR A 103 ? 0.2280 0.8011 0.2792 -0.1139 -0.0015 0.0052  125 THR A O   
+799  C  CB  . THR A 103 ? 0.3173 0.8189 0.2979 -0.0122 0.0472  -0.0230 125 THR A CB  
+800  O  OG1 . THR A 103 ? 0.3804 0.8530 0.3115 0.0335  0.0292  -0.0542 125 THR A OG1 
+801  C  CG2 . THR A 103 ? 0.3486 0.8444 0.3032 0.0502  0.0687  -0.0008 125 THR A CG2 
+802  N  N   . ARG A 104 ? 0.3140 0.7792 0.2747 -0.1216 0.0205  0.0336  126 ARG A N   
+803  C  CA  . ARG A 104 ? 0.3325 0.7978 0.2829 -0.1467 0.0200  0.0489  126 ARG A CA  
+804  C  C   . ARG A 104 ? 0.3273 0.8254 0.2925 -0.1444 0.0265  0.0442  126 ARG A C   
+805  O  O   . ARG A 104 ? 0.3605 0.8359 0.3090 -0.1145 0.0268  0.0451  126 ARG A O   
+806  C  CB  . ARG A 104 ? 0.3523 0.8342 0.2983 -0.1736 0.0263  0.0561  126 ARG A CB  
+807  C  CG  . ARG A 104 ? 0.4738 0.9069 0.3048 -0.0306 0.0074  0.0648  126 ARG A CG  
+808  C  CD  . ARG A 104 ? 0.5430 0.9491 0.3207 0.0040  0.0068  0.0792  126 ARG A CD  
+809  N  NE  . ARG A 104 ? 0.5720 0.8965 0.3192 -0.0388 -0.0129 0.0931  126 ARG A NE  
+810  C  CZ  . ARG A 104 ? 0.6041 0.9104 0.3229 -0.0319 0.0067  0.0984  126 ARG A CZ  
+811  N  NH1 . ARG A 104 ? 0.6299 0.9677 0.3235 0.0389  0.0252  0.0947  126 ARG A NH1 
+812  N  NH2 . ARG A 104 ? 0.5597 0.8510 0.3249 -0.1408 0.0095  0.1044  126 ARG A NH2 
+813  N  N   . GLY A 105 ? 0.3431 0.8413 0.2784 -0.1349 0.0033  0.0357  127 GLY A N   
+814  C  CA  . GLY A 105 ? 0.3303 0.7926 0.2774 -0.1393 -0.0197 0.0281  127 GLY A CA  
+815  C  C   . GLY A 105 ? 0.3535 0.6796 0.2739 -0.1593 -0.0398 0.0106  127 GLY A C   
+816  O  O   . GLY A 105 ? 0.4248 0.6964 0.2831 -0.1323 -0.0605 -0.0130 127 GLY A O   
+817  N  N   . ASP A 106 ? 0.3030 0.6761 0.2677 -0.0960 -0.0218 0.0124  128 ASP A N   
+818  C  CA  . ASP A 106 ? 0.2634 0.6038 0.2550 -0.0666 -0.0171 0.0155  128 ASP A CA  
+819  C  C   . ASP A 106 ? 0.2838 0.5426 0.2273 -0.0502 0.0059  0.0054  128 ASP A C   
+820  O  O   . ASP A 106 ? 0.2589 0.6009 0.2131 -0.0338 0.0167  0.0059  128 ASP A O   
+821  C  CB  . ASP A 106 ? 0.2649 0.6043 0.2645 0.0035  -0.0193 -0.0053 128 ASP A CB  
+822  C  CG  . ASP A 106 ? 0.2597 0.6443 0.2779 0.0403  -0.0211 -0.0184 128 ASP A CG  
+823  O  OD1 . ASP A 106 ? 0.2860 0.6857 0.2931 0.0553  -0.0079 -0.0346 128 ASP A OD1 
+824  O  OD2 . ASP A 106 ? 0.2282 0.6518 0.2761 0.0926  -0.0037 -0.0301 128 ASP A OD2 
+825  N  N   . GLU A 107 ? 0.2895 0.5445 0.2190 -0.0423 0.0061  0.0208  129 GLU A N   
+826  C  CA  . GLU A 107 ? 0.2938 0.5170 0.2214 -0.0651 -0.0087 0.0130  129 GLU A CA  
+827  C  C   . GLU A 107 ? 0.2970 0.4889 0.2213 -0.0413 -0.0102 0.0186  129 GLU A C   
+828  O  O   . GLU A 107 ? 0.3000 0.4823 0.2184 -0.0275 -0.0128 0.0141  129 GLU A O   
+829  C  CB  . GLU A 107 ? 0.3633 0.5515 0.2379 -0.0672 -0.0253 -0.0096 129 GLU A CB  
+830  C  CG  . GLU A 107 ? 0.3908 0.5135 0.2461 -0.0980 -0.0427 -0.0249 129 GLU A CG  
+831  C  CD  . GLU A 107 ? 0.4254 0.5518 0.2561 -0.0975 -0.0172 0.0056  129 GLU A CD  
+832  O  OE1 . GLU A 107 ? 0.4063 0.5936 0.2357 -0.0853 0.0260  0.0148  129 GLU A OE1 
+833  O  OE2 . GLU A 107 ? 0.4763 0.6296 0.2749 -0.0434 -0.0475 -0.0158 129 GLU A OE2 
+834  N  N   . ASP A 108 ? 0.3148 0.5423 0.2247 -0.0301 -0.0263 0.0096  130 ASP A N   
+835  C  CA  . ASP A 108 ? 0.3166 0.5729 0.2395 -0.0453 -0.0362 0.0042  130 ASP A CA  
+836  C  C   . ASP A 108 ? 0.3135 0.5230 0.2257 -0.0059 -0.0394 -0.0015 130 ASP A C   
+837  O  O   . ASP A 108 ? 0.3005 0.5094 0.2133 0.0078  -0.0421 0.0121  130 ASP A O   
+838  C  CB  . ASP A 108 ? 0.3274 0.6306 0.2770 -0.0800 -0.0428 -0.0069 130 ASP A CB  
+839  C  CG  . ASP A 108 ? 0.3977 0.6865 0.3172 -0.0419 -0.0390 -0.0169 130 ASP A CG  
+840  O  OD1 . ASP A 108 ? 0.4408 0.6869 0.3320 -0.0438 -0.0558 -0.0164 130 ASP A OD1 
+841  O  OD2 . ASP A 108 ? 0.4687 0.6760 0.3296 -0.0069 -0.0067 -0.0179 130 ASP A OD2 
+842  N  N   . ALA A 109 ? 0.2927 0.5687 0.2250 0.0305  -0.0351 0.0077  131 ALA A N   
+843  C  CA  . ALA A 109 ? 0.2504 0.5581 0.2190 0.0271  -0.0395 -0.0231 131 ALA A CA  
+844  C  C   . ALA A 109 ? 0.2146 0.5278 0.2106 0.0426  -0.0142 -0.0074 131 ALA A C   
+845  O  O   . ALA A 109 ? 0.2123 0.5424 0.2135 0.0354  -0.0141 -0.0001 131 ALA A O   
+846  C  CB  . ALA A 109 ? 0.2810 0.6200 0.2228 0.0371  -0.0182 0.0071  131 ALA A CB  
+847  N  N   . LEU A 110 ? 0.2502 0.4981 0.1970 0.0393  -0.0264 0.0151  132 LEU A N   
+848  C  CA  . LEU A 110 ? 0.2348 0.4342 0.1898 0.0940  -0.0364 -0.0027 132 LEU A CA  
+849  C  C   . LEU A 110 ? 0.2260 0.4210 0.1871 0.0407  -0.0362 -0.0058 132 LEU A C   
+850  O  O   . LEU A 110 ? 0.2152 0.4062 0.1825 0.0153  -0.0423 0.0028  132 LEU A O   
+851  C  CB  . LEU A 110 ? 0.2922 0.3637 0.1930 0.0820  -0.0308 0.0040  132 LEU A CB  
+852  C  CG  . LEU A 110 ? 0.2674 0.3366 0.1905 0.0736  -0.0185 0.0085  132 LEU A CG  
+853  C  CD1 . LEU A 110 ? 0.2631 0.3450 0.1865 0.0269  0.0018  0.0318  132 LEU A CD1 
+854  C  CD2 . LEU A 110 ? 0.2788 0.3272 0.1971 0.0670  -0.0391 -0.0201 132 LEU A CD2 
+855  N  N   . ALA A 111 ? 0.2643 0.4183 0.1904 0.0597  -0.0208 0.0128  133 ALA A N   
+856  C  CA  . ALA A 111 ? 0.3273 0.3762 0.1884 0.0247  -0.0427 0.0231  133 ALA A CA  
+857  C  C   . ALA A 111 ? 0.2809 0.3876 0.1861 0.0079  -0.0716 0.0005  133 ALA A C   
+858  O  O   . ALA A 111 ? 0.2871 0.4162 0.2019 0.0396  -0.0745 -0.0080 133 ALA A O   
+859  C  CB  . ALA A 111 ? 0.3124 0.3603 0.1905 -0.0259 -0.0452 0.0215  133 ALA A CB  
+860  N  N   . ALA A 112 ? 0.2914 0.4159 0.1830 0.0556  -0.0638 0.0085  134 ALA A N   
+861  C  CA  . ALA A 112 ? 0.3034 0.3946 0.1938 0.0380  -0.0654 0.0051  134 ALA A CA  
+862  C  C   . ALA A 112 ? 0.2671 0.3657 0.1813 0.0190  -0.0536 -0.0033 134 ALA A C   
+863  O  O   . ALA A 112 ? 0.2975 0.4120 0.1705 0.0629  -0.0438 -0.0011 134 ALA A O   
+864  C  CB  . ALA A 112 ? 0.3223 0.4293 0.2055 0.0173  -0.0781 0.0131  134 ALA A CB  
+865  N  N   . GLU A 113 ? 0.3184 0.3992 0.1799 0.0732  -0.0389 0.0094  135 GLU A N   
+866  C  CA  . GLU A 113 ? 0.3139 0.3602 0.1744 0.0538  -0.0397 0.0037  135 GLU A CA  
+867  C  C   . GLU A 113 ? 0.2811 0.3067 0.1582 0.0564  -0.0205 0.0288  135 GLU A C   
+868  O  O   . GLU A 113 ? 0.3006 0.3410 0.1648 0.0758  -0.0358 0.0351  135 GLU A O   
+869  C  CB  . GLU A 113 ? 0.3075 0.3651 0.1779 0.1082  -0.0683 0.0065  135 GLU A CB  
+870  C  CG  . GLU A 113 ? 0.3160 0.4167 0.1861 0.0782  -0.0495 0.0088  135 GLU A CG  
+871  C  CD  . GLU A 113 ? 0.3264 0.4389 0.1958 0.0279  -0.0302 0.0273  135 GLU A CD  
+872  O  OE1 . GLU A 113 ? 0.3550 0.5110 0.1893 0.1235  -0.0250 0.0418  135 GLU A OE1 
+873  O  OE2 . GLU A 113 ? 0.3671 0.4521 0.2057 0.0292  -0.0228 0.0447  135 GLU A OE2 
+874  N  N   . ILE A 114 ? 0.2339 0.3535 0.1416 0.0416  -0.0179 0.0167  136 ILE A N   
+875  C  CA  . ILE A 114 ? 0.2440 0.2898 0.1313 0.0079  -0.0255 0.0032  136 ILE A CA  
+876  C  C   . ILE A 114 ? 0.2451 0.3228 0.1304 0.0113  -0.0275 0.0334  136 ILE A C   
+877  O  O   . ILE A 114 ? 0.2965 0.3040 0.1403 -0.0028 -0.0320 0.0246  136 ILE A O   
+878  C  CB  . ILE A 114 ? 0.2628 0.2518 0.1359 0.0296  -0.0319 -0.0072 136 ILE A CB  
+879  C  CG1 . ILE A 114 ? 0.2136 0.2778 0.1402 0.0633  -0.0185 0.0252  136 ILE A CG1 
+880  C  CG2 . ILE A 114 ? 0.2736 0.2656 0.1303 0.0483  -0.0328 0.0041  136 ILE A CG2 
+881  C  CD1 . ILE A 114 ? 0.2274 0.3324 0.1495 0.0112  -0.0302 0.0133  136 ILE A CD1 
+882  N  N   . ILE A 115 ? 0.2828 0.4002 0.1332 0.0327  -0.0488 0.0408  137 ILE A N   
+883  C  CA  . ILE A 115 ? 0.2825 0.3851 0.1403 0.0071  -0.0569 0.0335  137 ILE A CA  
+884  C  C   . ILE A 115 ? 0.2678 0.3470 0.1426 -0.0192 -0.0583 0.0227  137 ILE A C   
+885  O  O   . ILE A 115 ? 0.2703 0.3845 0.1513 0.0210  -0.0485 0.0138  137 ILE A O   
+886  C  CB  . ILE A 115 ? 0.3180 0.4269 0.1493 0.0130  -0.0551 0.0257  137 ILE A CB  
+887  C  CG1 . ILE A 115 ? 0.2801 0.4017 0.1650 -0.0412 -0.0307 0.0261  137 ILE A CG1 
+888  C  CG2 . ILE A 115 ? 0.3265 0.4565 0.1521 0.0168  -0.0661 -0.0056 137 ILE A CG2 
+889  C  CD1 . ILE A 115 ? 0.2817 0.3799 0.1715 -0.0452 -0.0248 0.0472  137 ILE A CD1 
+890  N  N   . ARG A 116 ? 0.3112 0.4022 0.1407 0.0553  -0.0560 0.0282  138 ARG A N   
+891  C  CA  . ARG A 116 ? 0.2890 0.4228 0.1505 0.0705  -0.0515 0.0223  138 ARG A CA  
+892  C  C   . ARG A 116 ? 0.2996 0.3442 0.1446 0.0359  -0.0468 0.0278  138 ARG A C   
+893  O  O   . ARG A 116 ? 0.3233 0.3009 0.1452 0.0514  -0.0247 0.0243  138 ARG A O   
+894  C  CB  . ARG A 116 ? 0.2648 0.4126 0.1715 0.0457  -0.0689 0.0153  138 ARG A CB  
+895  C  CG  . ARG A 116 ? 0.3081 0.4169 0.1813 0.0823  -0.0445 0.0401  138 ARG A CG  
+896  C  CD  . ARG A 116 ? 0.3199 0.4352 0.1946 0.0946  -0.0363 0.0660  138 ARG A CD  
+897  N  NE  . ARG A 116 ? 0.3714 0.4101 0.2047 0.1446  -0.0647 0.0603  138 ARG A NE  
+898  C  CZ  . ARG A 116 ? 0.4654 0.3876 0.2184 0.1670  -0.0722 0.0497  138 ARG A CZ  
+899  N  NH1 . ARG A 116 ? 0.5438 0.4292 0.2335 0.1934  -0.0698 0.0501  138 ARG A NH1 
+900  N  NH2 . ARG A 116 ? 0.5205 0.3548 0.2287 0.1749  -0.0607 0.0491  138 ARG A NH2 
+901  N  N   . LEU A 117 ? 0.2679 0.3280 0.1248 -0.0135 -0.0773 0.0282  139 LEU A N   
+902  C  CA  . LEU A 117 ? 0.2562 0.2808 0.1134 0.0178  -0.0565 0.0182  139 LEU A CA  
+903  C  C   . LEU A 117 ? 0.2947 0.3083 0.1068 0.0305  -0.0423 0.0125  139 LEU A C   
+904  O  O   . LEU A 117 ? 0.3090 0.2779 0.1009 0.0507  -0.0257 0.0392  139 LEU A O   
+905  C  CB  . LEU A 117 ? 0.2811 0.2850 0.1134 0.0264  -0.0337 0.0220  139 LEU A CB  
+906  C  CG  . LEU A 117 ? 0.3253 0.3181 0.1342 0.0929  -0.0313 0.0133  139 LEU A CG  
+907  C  CD1 . LEU A 117 ? 0.3274 0.3187 0.1455 0.0760  -0.0240 0.0327  139 LEU A CD1 
+908  C  CD2 . LEU A 117 ? 0.3887 0.4055 0.1427 0.1601  -0.0114 0.0142  139 LEU A CD2 
+909  N  N   . THR A 118 ? 0.3177 0.2925 0.1104 0.0219  -0.0568 -0.0178 140 THR A N   
+910  C  CA  . THR A 118 ? 0.3081 0.3064 0.1185 0.0377  -0.0541 0.0119  140 THR A CA  
+911  C  C   . THR A 118 ? 0.3203 0.2225 0.1194 0.0302  -0.0353 0.0268  140 THR A C   
+912  O  O   . THR A 118 ? 0.3581 0.2435 0.1307 0.0291  -0.0286 0.0020  140 THR A O   
+913  C  CB  . THR A 118 ? 0.3205 0.3160 0.1237 0.0279  -0.0401 0.0042  140 THR A CB  
+914  O  OG1 . THR A 118 ? 0.3321 0.3173 0.1177 0.0465  -0.0555 -0.0177 140 THR A OG1 
+915  C  CG2 . THR A 118 ? 0.3364 0.2919 0.1408 0.0372  -0.0171 0.0144  140 THR A CG2 
+916  N  N   . ASP A 119 ? 0.2692 0.3205 0.1074 -0.0130 -0.0585 0.0362  141 ASP A N   
+917  C  CA  . ASP A 119 ? 0.2842 0.3338 0.1226 0.0393  -0.0711 0.0284  141 ASP A CA  
+918  C  C   . ASP A 119 ? 0.3316 0.3423 0.1246 0.0808  -0.0486 0.0198  141 ASP A C   
+919  O  O   . ASP A 119 ? 0.3676 0.3631 0.1313 0.0604  -0.0010 0.0244  141 ASP A O   
+920  C  CB  . ASP A 119 ? 0.3146 0.3354 0.1313 -0.0204 -0.0937 0.0038  141 ASP A CB  
+921  C  CG  . ASP A 119 ? 0.3638 0.3950 0.1488 -0.0254 -0.0849 0.0070  141 ASP A CG  
+922  O  OD1 . ASP A 119 ? 0.4117 0.3468 0.1589 0.0226  -0.0684 0.0198  141 ASP A OD1 
+923  O  OD2 . ASP A 119 ? 0.3839 0.4599 0.1703 -0.0193 -0.0942 0.0093  141 ASP A OD2 
+924  N  N   . LEU A 120 ? 0.3374 0.3607 0.1351 0.0960  -0.0597 0.0128  142 LEU A N   
+925  C  CA  . LEU A 120 ? 0.3182 0.3036 0.1351 0.0774  -0.0513 0.0304  142 LEU A CA  
+926  C  C   . LEU A 120 ? 0.3253 0.2622 0.1269 0.0681  -0.0569 0.0219  142 LEU A C   
+927  O  O   . LEU A 120 ? 0.2926 0.3212 0.1395 0.0357  -0.0178 0.0228  142 LEU A O   
+928  C  CB  . LEU A 120 ? 0.2995 0.2683 0.1625 0.0215  -0.0451 0.0573  142 LEU A CB  
+929  C  CG  . LEU A 120 ? 0.3782 0.3213 0.1712 0.0821  -0.0306 0.0933  142 LEU A CG  
+930  C  CD1 . LEU A 120 ? 0.4236 0.3732 0.1772 0.0986  -0.0510 0.0728  142 LEU A CD1 
+931  C  CD2 . LEU A 120 ? 0.4013 0.4081 0.1868 0.0680  -0.0194 0.0786  142 LEU A CD2 
+932  N  N   . TYR A 121 ? 0.3116 0.2508 0.1214 0.0703  -0.0429 0.0435  143 TYR A N   
+933  C  CA  . TYR A 121 ? 0.3077 0.2848 0.1138 0.0863  -0.0106 0.0452  143 TYR A CA  
+934  C  C   . TYR A 121 ? 0.2632 0.2717 0.1110 0.0331  -0.0247 0.0213  143 TYR A C   
+935  O  O   . TYR A 121 ? 0.2806 0.2310 0.1286 0.0485  -0.0302 0.0023  143 TYR A O   
+936  C  CB  . TYR A 121 ? 0.2505 0.2405 0.1225 0.0554  -0.0070 0.0486  143 TYR A CB  
+937  C  CG  . TYR A 121 ? 0.2843 0.2913 0.1319 0.1187  -0.0214 0.0202  143 TYR A CG  
+938  C  CD1 . TYR A 121 ? 0.3002 0.3047 0.1495 0.1281  0.0120  0.0357  143 TYR A CD1 
+939  C  CD2 . TYR A 121 ? 0.2772 0.2690 0.1334 0.0870  -0.0269 0.0106  143 TYR A CD2 
+940  C  CE1 . TYR A 121 ? 0.3462 0.2768 0.1550 0.0966  0.0131  0.0038  143 TYR A CE1 
+941  C  CE2 . TYR A 121 ? 0.3133 0.3166 0.1430 0.1050  -0.0141 0.0207  143 TYR A CE2 
+942  C  CZ  . TYR A 121 ? 0.3428 0.2658 0.1437 0.1133  0.0058  0.0074  143 TYR A CZ  
+943  O  OH  . TYR A 121 ? 0.4246 0.3184 0.1573 0.1676  0.0022  0.0287  143 TYR A OH  
+944  N  N   . GLY A 122 ? 0.2518 0.2783 0.1028 0.0343  -0.0263 0.0228  144 GLY A N   
+945  C  CA  . GLY A 122 ? 0.2776 0.2278 0.1001 0.0509  -0.0170 0.0145  144 GLY A CA  
+946  C  C   . GLY A 122 ? 0.2618 0.1558 0.1061 0.0399  -0.0300 -0.0135 144 GLY A C   
+947  O  O   . GLY A 122 ? 0.3047 0.2026 0.1253 0.0744  -0.0171 -0.0059 144 GLY A O   
+948  N  N   . PHE A 123 ? 0.2952 0.2536 0.0980 0.0776  -0.0239 0.0207  145 PHE A N   
+949  C  CA  . PHE A 123 ? 0.2944 0.2058 0.0948 0.0776  -0.0331 0.0070  145 PHE A CA  
+950  C  C   . PHE A 123 ? 0.2493 0.2438 0.0966 0.0315  -0.0238 0.0156  145 PHE A C   
+951  O  O   . PHE A 123 ? 0.2802 0.2466 0.1264 0.0611  -0.0056 0.0196  145 PHE A O   
+952  C  CB  . PHE A 123 ? 0.2699 0.1997 0.0929 0.0665  -0.0485 -0.0091 145 PHE A CB  
+953  C  CG  . PHE A 123 ? 0.2446 0.1815 0.1026 0.0500  -0.0306 0.0180  145 PHE A CG  
+954  C  CD1 . PHE A 123 ? 0.2848 0.1858 0.1207 0.0707  -0.0220 0.0098  145 PHE A CD1 
+955  C  CD2 . PHE A 123 ? 0.2466 0.2107 0.1095 -0.0068 -0.0332 0.0335  145 PHE A CD2 
+956  C  CE1 . PHE A 123 ? 0.2558 0.2694 0.1207 0.1056  -0.0195 0.0143  145 PHE A CE1 
+957  C  CE2 . PHE A 123 ? 0.2575 0.2759 0.1159 0.0606  -0.0350 0.0520  145 PHE A CE2 
+958  C  CZ  . PHE A 123 ? 0.2594 0.2780 0.1215 0.1072  -0.0378 0.0218  145 PHE A CZ  
+959  N  N   . ASP A 124 ? 0.2175 0.1915 0.0913 0.0023  -0.0340 0.0003  146 ASP A N   
+960  C  CA  . ASP A 124 ? 0.2520 0.1522 0.0886 0.0313  -0.0338 0.0097  146 ASP A CA  
+961  C  C   . ASP A 124 ? 0.2618 0.1448 0.0883 0.0134  -0.0283 -0.0018 146 ASP A C   
+962  O  O   . ASP A 124 ? 0.3083 0.1771 0.0974 0.0123  -0.0045 0.0081  146 ASP A O   
+963  C  CB  . ASP A 124 ? 0.2672 0.1643 0.0778 0.0569  -0.0172 0.0020  146 ASP A CB  
+964  C  CG  . ASP A 124 ? 0.2139 0.2110 0.0866 0.0308  -0.0192 0.0154  146 ASP A CG  
+965  O  OD1 . ASP A 124 ? 0.2904 0.2504 0.0986 0.0111  -0.0348 -0.0069 146 ASP A OD1 
+966  O  OD2 . ASP A 124 ? 0.2751 0.2154 0.0842 -0.0021 -0.0350 0.0180  146 ASP A OD2 
+967  N  N   . GLY A 125 ? 0.2842 0.1615 0.0892 0.0193  -0.0435 0.0066  147 GLY A N   
+968  C  CA  . GLY A 125 ? 0.2981 0.1749 0.0908 0.0103  -0.0445 -0.0156 147 GLY A CA  
+969  C  C   . GLY A 125 ? 0.2595 0.2218 0.0872 0.0145  -0.0493 0.0074  147 GLY A C   
+970  O  O   . GLY A 125 ? 0.2357 0.2227 0.0911 -0.0011 -0.0304 0.0089  147 GLY A O   
+971  N  N   . LEU A 126 ? 0.2653 0.1839 0.0745 0.0218  -0.0325 0.0016  148 LEU A N   
+972  C  CA  . LEU A 126 ? 0.2069 0.1807 0.0854 0.0294  -0.0254 -0.0181 148 LEU A CA  
+973  C  C   . LEU A 126 ? 0.2318 0.1795 0.0791 0.0578  -0.0082 -0.0041 148 LEU A C   
+974  O  O   . LEU A 126 ? 0.2906 0.1974 0.0826 0.0196  -0.0378 -0.0102 148 LEU A O   
+975  C  CB  . LEU A 126 ? 0.2371 0.2046 0.1121 0.0515  -0.0328 -0.0022 148 LEU A CB  
+976  C  CG  . LEU A 126 ? 0.2133 0.2047 0.1221 0.0357  -0.0456 -0.0033 148 LEU A CG  
+977  C  CD1 . LEU A 126 ? 0.2588 0.1913 0.1266 0.0401  -0.0287 -0.0063 148 LEU A CD1 
+978  C  CD2 . LEU A 126 ? 0.1907 0.2329 0.1321 -0.0180 -0.0168 -0.0079 148 LEU A CD2 
+979  N  N   . ASP A 127 ? 0.2713 0.1873 0.0780 0.0607  -0.0180 -0.0087 149 ASP A N   
+980  C  CA  . ASP A 127 ? 0.2690 0.1448 0.0767 0.0504  -0.0240 0.0026  149 ASP A CA  
+981  C  C   . ASP A 127 ? 0.2537 0.2058 0.0780 0.0435  -0.0099 0.0065  149 ASP A C   
+982  O  O   . ASP A 127 ? 0.2543 0.2080 0.0783 0.0411  -0.0034 -0.0093 149 ASP A O   
+983  C  CB  . ASP A 127 ? 0.2598 0.1161 0.0815 0.0421  -0.0274 -0.0084 149 ASP A CB  
+984  C  CG  . ASP A 127 ? 0.2371 0.1032 0.0935 0.0422  -0.0115 -0.0047 149 ASP A CG  
+985  O  OD1 . ASP A 127 ? 0.2706 0.1439 0.1085 0.0448  -0.0141 0.0077  149 ASP A OD1 
+986  O  OD2 . ASP A 127 ? 0.2573 0.1482 0.1042 0.0377  -0.0191 -0.0094 149 ASP A OD2 
+987  N  N   . ILE A 128 ? 0.2410 0.1765 0.0774 0.0425  -0.0188 0.0103  150 ILE A N   
+988  C  CA  . ILE A 128 ? 0.2461 0.1203 0.0893 0.0255  -0.0032 0.0001  150 ILE A CA  
+989  C  C   . ILE A 128 ? 0.2156 0.1628 0.0817 0.0432  -0.0066 -0.0027 150 ILE A C   
+990  O  O   . ILE A 128 ? 0.2527 0.1689 0.0925 0.0536  -0.0165 -0.0027 150 ILE A O   
+991  C  CB  . ILE A 128 ? 0.2405 0.2084 0.0861 0.0007  -0.0109 0.0407  150 ILE A CB  
+992  C  CG1 . ILE A 128 ? 0.2385 0.2186 0.1013 0.0414  0.0164  0.0357  150 ILE A CG1 
+993  C  CG2 . ILE A 128 ? 0.2807 0.1888 0.0990 0.0078  -0.0109 0.0395  150 ILE A CG2 
+994  C  CD1 . ILE A 128 ? 0.3244 0.2701 0.1172 0.0487  0.0079  0.0122  150 ILE A CD1 
+995  N  N   . ASP A 129 ? 0.2601 0.1531 0.0854 0.0558  -0.0173 -0.0093 151 ASP A N   
+996  C  CA  . ASP A 129 ? 0.2254 0.1648 0.0846 0.0421  -0.0082 0.0179  151 ASP A CA  
+997  C  C   . ASP A 129 ? 0.2779 0.1824 0.0893 0.0874  0.0016  0.0008  151 ASP A C   
+998  O  O   . ASP A 129 ? 0.2564 0.1627 0.0892 0.0650  0.0018  0.0111  151 ASP A O   
+999  C  CB  . ASP A 129 ? 0.2426 0.2126 0.0947 0.0749  0.0052  0.0221  151 ASP A CB  
+1000 C  CG  . ASP A 129 ? 0.2349 0.1816 0.1070 -0.0033 0.0199  0.0299  151 ASP A CG  
+1001 O  OD1 . ASP A 129 ? 0.2904 0.1584 0.1065 0.0221  -0.0043 0.0240  151 ASP A OD1 
+1002 O  OD2 . ASP A 129 ? 0.2581 0.1750 0.1096 0.0176  0.0131  0.0051  151 ASP A OD2 
+1003 N  N   . LEU A 130 ? 0.2894 0.1661 0.0917 0.0221  -0.0017 -0.0189 152 LEU A N   
+1004 C  CA  . LEU A 130 ? 0.2737 0.1962 0.1058 0.0208  0.0053  -0.0190 152 LEU A CA  
+1005 C  C   . LEU A 130 ? 0.2613 0.1765 0.0987 0.0736  0.0161  -0.0058 152 LEU A C   
+1006 O  O   . LEU A 130 ? 0.2536 0.1674 0.1162 0.0335  0.0183  0.0014  152 LEU A O   
+1007 C  CB  . LEU A 130 ? 0.2736 0.2277 0.1187 0.0346  0.0265  -0.0014 152 LEU A CB  
+1008 C  CG  . LEU A 130 ? 0.2776 0.2556 0.1307 0.0087  0.0009  -0.0079 152 LEU A CG  
+1009 C  CD1 . LEU A 130 ? 0.3143 0.2760 0.1345 0.0198  0.0008  -0.0225 152 LEU A CD1 
+1010 C  CD2 . LEU A 130 ? 0.2673 0.2652 0.1387 0.0311  -0.0188 -0.0280 152 LEU A CD2 
+1011 N  N   . GLN A 131 ? 0.2465 0.1939 0.0877 0.0755  0.0175  -0.0169 153 GLN A N   
+1012 C  CA  . GLN A 131 ? 0.2523 0.2254 0.1014 0.0683  0.0071  -0.0217 153 GLN A CA  
+1013 C  C   . GLN A 131 ? 0.2367 0.2057 0.1145 0.0499  0.0083  0.0034  153 GLN A C   
+1014 O  O   . GLN A 131 ? 0.2981 0.2033 0.1214 0.0392  0.0230  0.0030  153 GLN A O   
+1015 C  CB  . GLN A 131 ? 0.2621 0.2368 0.1138 0.0636  -0.0007 -0.0191 153 GLN A CB  
+1016 C  CG  . GLN A 131 ? 0.2578 0.1496 0.1260 0.0448  0.0155  -0.0095 153 GLN A CG  
+1017 C  CD  . GLN A 131 ? 0.3014 0.1804 0.1356 0.0574  0.0153  -0.0135 153 GLN A CD  
+1018 O  OE1 . GLN A 131 ? 0.2513 0.1580 0.1346 0.0471  0.0212  -0.0257 153 GLN A OE1 
+1019 N  NE2 . GLN A 131 ? 0.3034 0.1766 0.1388 0.0249  0.0248  0.0004  153 GLN A NE2 
+1020 N  N   . GLN A 132 ? 0.2328 0.2332 0.1118 0.0495  0.0118  0.0065  154 GLN A N   
+1021 C  CA  . GLN A 132 ? 0.3056 0.2813 0.1376 0.0894  0.0558  0.0024  154 GLN A CA  
+1022 C  C   . GLN A 132 ? 0.2630 0.2854 0.1256 0.0732  0.0522  -0.0043 154 GLN A C   
+1023 O  O   . GLN A 132 ? 0.2811 0.2436 0.1299 0.0362  0.0467  -0.0134 154 GLN A O   
+1024 C  CB  . GLN A 132 ? 0.4557 0.3615 0.1898 0.1119  0.0991  -0.0313 154 GLN A CB  
+1025 C  CG  . GLN A 132 ? 0.5749 0.4396 0.2200 0.1591  0.0770  -0.0231 154 GLN A CG  
+1026 C  CD  . GLN A 132 ? 0.6130 0.4537 0.2334 0.1312  0.0641  -0.0173 154 GLN A CD  
+1027 O  OE1 . GLN A 132 ? 0.5093 0.3277 0.2251 0.0368  0.0485  0.0170  154 GLN A OE1 
+1028 N  NE2 . GLN A 132 ? 0.7184 0.4656 0.2499 0.1310  0.0624  -0.0519 154 GLN A NE2 
+1029 N  N   . ALA A 133 ? 0.2424 0.2738 0.1303 0.0662  0.0100  -0.0352 155 ALA A N   
+1030 C  CA  . ALA A 133 ? 0.2461 0.2244 0.1378 0.0403  0.0223  -0.0176 155 ALA A CA  
+1031 C  C   . ALA A 133 ? 0.2740 0.2896 0.1446 0.1024  0.0184  -0.0182 155 ALA A C   
+1032 O  O   . ALA A 133 ? 0.2798 0.3642 0.1451 0.0749  0.0247  -0.0164 155 ALA A O   
+1033 C  CB  . ALA A 133 ? 0.3240 0.2912 0.1513 0.0621  0.0043  -0.0412 155 ALA A CB  
+1034 N  N   . ALA A 134 ? 0.2463 0.2515 0.1378 0.0622  0.0190  -0.0147 156 ALA A N   
+1035 C  CA  . ALA A 134 ? 0.2762 0.2232 0.1314 0.0797  0.0150  0.0115  156 ALA A CA  
+1036 C  C   . ALA A 134 ? 0.2963 0.2244 0.1241 0.0820  0.0213  0.0086  156 ALA A C   
+1037 O  O   . ALA A 134 ? 0.3273 0.2701 0.1453 0.0471  0.0238  -0.0030 156 ALA A O   
+1038 C  CB  . ALA A 134 ? 0.3788 0.2487 0.1462 0.1067  0.0097  0.0236  156 ALA A CB  
+1039 N  N   . ILE A 135 ? 0.2996 0.1808 0.1141 0.0261  0.0171  0.0085  157 ILE A N   
+1040 C  CA  . ILE A 135 ? 0.2980 0.2204 0.1145 0.0397  -0.0009 0.0074  157 ILE A CA  
+1041 C  C   . ILE A 135 ? 0.2915 0.2514 0.1159 0.0216  0.0038  -0.0036 157 ILE A C   
+1042 O  O   . ILE A 135 ? 0.2988 0.2452 0.1241 -0.0203 0.0027  0.0027  157 ILE A O   
+1043 C  CB  . ILE A 135 ? 0.2542 0.2192 0.1175 0.0539  0.0105  -0.0056 157 ILE A CB  
+1044 C  CG1 . ILE A 135 ? 0.3113 0.2274 0.1055 0.0612  0.0017  -0.0030 157 ILE A CG1 
+1045 C  CG2 . ILE A 135 ? 0.2798 0.2190 0.1273 0.0543  0.0161  0.0127  157 ILE A CG2 
+1046 C  CD1 . ILE A 135 ? 0.3707 0.1596 0.0958 0.0251  0.0224  -0.0005 157 ILE A CD1 
+1047 N  N   . THR A 136 ? 0.2467 0.2918 0.1222 -0.0317 0.0266  0.0077  158 THR A N   
+1048 C  CA  . THR A 136 ? 0.2315 0.3160 0.1306 -0.0714 0.0226  0.0082  158 THR A CA  
+1049 C  C   . THR A 136 ? 0.2820 0.3860 0.1414 -0.0007 0.0263  0.0122  158 THR A C   
+1050 O  O   . THR A 136 ? 0.3045 0.4422 0.1569 0.0074  0.0174  0.0273  158 THR A O   
+1051 C  CB  . THR A 136 ? 0.2991 0.2823 0.1332 -0.0419 0.0111  -0.0158 158 THR A CB  
+1052 O  OG1 . THR A 136 ? 0.2870 0.3487 0.1419 -0.0249 0.0141  -0.0154 158 THR A OG1 
+1053 C  CG2 . THR A 136 ? 0.3045 0.2461 0.1313 -0.0304 -0.0098 -0.0331 158 THR A CG2 
+1054 N  N   . ALA A 137 ? 0.2713 0.3970 0.1446 0.0182  0.0243  -0.0036 159 ALA A N   
+1055 C  CA  . ALA A 137 ? 0.2428 0.4969 0.1591 -0.0069 0.0412  0.0077  159 ALA A CA  
+1056 C  C   . ALA A 137 ? 0.2356 0.5093 0.1690 -0.0436 0.0264  -0.0148 159 ALA A C   
+1057 O  O   . ALA A 137 ? 0.2683 0.5075 0.1648 -0.0056 0.0219  -0.0413 159 ALA A O   
+1058 C  CB  . ALA A 137 ? 0.2889 0.5435 0.1746 0.0800  0.0156  0.0203  159 ALA A CB  
+1059 N  N   . LYS A 138 ? 0.2810 0.5741 0.1868 0.0001  0.0237  -0.0011 160 LYS A N   
+1060 C  CA  . LYS A 138 ? 0.2830 0.6475 0.2045 -0.0393 0.0119  -0.0115 160 LYS A CA  
+1061 C  C   . LYS A 138 ? 0.2710 0.5840 0.1943 -0.0307 0.0130  -0.0278 160 LYS A C   
+1062 O  O   . LYS A 138 ? 0.3243 0.5506 0.1852 -0.0090 0.0080  -0.0385 160 LYS A O   
+1063 C  CB  . LYS A 138 ? 0.3174 0.7718 0.2362 -0.0878 -0.0263 -0.0387 160 LYS A CB  
+1064 C  CG  . LYS A 138 ? 0.4408 0.8970 0.2596 -0.0254 -0.0339 -0.0439 160 LYS A CG  
+1065 C  CD  . LYS A 138 ? 0.5336 1.0117 0.2761 0.0233  -0.0408 -0.0511 160 LYS A CD  
+1066 C  CE  . LYS A 138 ? 0.5836 1.0731 0.2846 0.0479  -0.0594 -0.0559 160 LYS A CE  
+1067 N  NZ  . LYS A 138 ? 0.6159 1.1095 0.2893 0.0635  -0.0369 -0.0479 160 LYS A NZ  
+1068 N  N   . ASP A 139 ? 0.2296 0.5702 0.2016 -0.0762 0.0212  -0.0503 161 ASP A N   
+1069 C  CA  . ASP A 139 ? 0.2695 0.5277 0.2042 -0.0615 0.0277  -0.0232 161 ASP A CA  
+1070 C  C   . ASP A 139 ? 0.2398 0.4511 0.1924 -0.0838 0.0081  -0.0231 161 ASP A C   
+1071 O  O   . ASP A 139 ? 0.3204 0.4755 0.1892 -0.0726 -0.0008 -0.0388 161 ASP A O   
+1072 C  CB  . ASP A 139 ? 0.2997 0.6107 0.2198 -0.0249 0.0466  -0.0045 161 ASP A CB  
+1073 C  CG  . ASP A 139 ? 0.3485 0.6591 0.2343 -0.0659 0.0284  -0.0154 161 ASP A CG  
+1074 O  OD1 . ASP A 139 ? 0.3776 0.6404 0.2231 -0.1268 0.0306  -0.0400 161 ASP A OD1 
+1075 O  OD2 . ASP A 139 ? 0.3150 0.7215 0.2514 -0.0977 0.0111  -0.0309 161 ASP A OD2 
+1076 N  N   . ASN A 140 ? 0.2104 0.4307 0.1833 -0.0591 0.0194  -0.0182 162 ASN A N   
+1077 C  CA  . ASN A 140 ? 0.2120 0.4338 0.1702 -0.0220 0.0230  -0.0127 162 ASN A CA  
+1078 C  C   . ASN A 140 ? 0.2750 0.3648 0.1623 -0.0770 0.0077  0.0020  162 ASN A C   
+1079 O  O   . ASN A 140 ? 0.2872 0.3623 0.1579 -0.0302 0.0181  0.0194  162 ASN A O   
+1080 C  CB  . ASN A 140 ? 0.2475 0.4064 0.1651 0.0149  0.0512  0.0049  162 ASN A CB  
+1081 C  CG  . ASN A 140 ? 0.2797 0.4123 0.1809 0.0468  0.0219  -0.0085 162 ASN A CG  
+1082 O  OD1 . ASN A 140 ? 0.2858 0.4630 0.2050 0.0444  -0.0021 -0.0241 162 ASN A OD1 
+1083 N  ND2 . ASN A 140 ? 0.2800 0.3433 0.1772 0.0886  0.0224  0.0021  162 ASN A ND2 
+1084 N  N   . GLN A 141 ? 0.2852 0.4064 0.1668 -0.0938 -0.0064 0.0033  163 GLN A N   
+1085 C  CA  . GLN A 141 ? 0.3462 0.3738 0.1624 -0.0688 0.0067  0.0085  163 GLN A CA  
+1086 C  C   . GLN A 141 ? 0.3459 0.3965 0.1645 -0.0896 -0.0037 -0.0065 163 GLN A C   
+1087 O  O   . GLN A 141 ? 0.3755 0.4028 0.1674 -0.1065 0.0030  -0.0143 163 GLN A O   
+1088 C  CB  . GLN A 141 ? 0.3448 0.3653 0.1540 -0.0390 0.0114  0.0176  163 GLN A CB  
+1089 C  CG  . GLN A 141 ? 0.3607 0.4101 0.1404 -0.0221 -0.0088 -0.0058 163 GLN A CG  
+1090 C  CD  . GLN A 141 ? 0.3842 0.4068 0.1382 -0.0148 0.0012  -0.0171 163 GLN A CD  
+1091 O  OE1 . GLN A 141 ? 0.3627 0.4333 0.1214 -0.0608 0.0307  -0.0085 163 GLN A OE1 
+1092 N  NE2 . GLN A 141 ? 0.3858 0.3255 0.1477 -0.0368 -0.0067 -0.0221 163 GLN A NE2 
+1093 N  N   . PHE A 142 ? 0.3633 0.4182 0.1786 -0.1252 0.0057  -0.0323 164 PHE A N   
+1094 C  CA  . PHE A 142 ? 0.3549 0.4337 0.1924 -0.1487 0.0173  -0.0202 164 PHE A CA  
+1095 C  C   . PHE A 142 ? 0.3471 0.4560 0.1972 -0.0695 0.0154  -0.0150 164 PHE A C   
+1096 O  O   . PHE A 142 ? 0.3372 0.4248 0.1984 -0.0715 0.0003  -0.0132 164 PHE A O   
+1097 C  CB  . PHE A 142 ? 0.4170 0.5090 0.2114 -0.1763 0.0042  -0.0276 164 PHE A CB  
+1098 C  CG  . PHE A 142 ? 0.5121 0.5453 0.2208 -0.1189 0.0087  -0.0493 164 PHE A CG  
+1099 C  CD1 . PHE A 142 ? 0.5283 0.4841 0.2314 -0.1732 0.0023  -0.0379 164 PHE A CD1 
+1100 C  CD2 . PHE A 142 ? 0.5229 0.5224 0.2186 -0.1825 0.0171  -0.0256 164 PHE A CD2 
+1101 C  CE1 . PHE A 142 ? 0.5389 0.4955 0.2358 -0.1629 -0.0133 -0.0418 164 PHE A CE1 
+1102 C  CE2 . PHE A 142 ? 0.5383 0.4833 0.2291 -0.2124 0.0211  -0.0217 164 PHE A CE2 
+1103 C  CZ  . PHE A 142 ? 0.5462 0.4820 0.2346 -0.2219 0.0024  -0.0279 164 PHE A CZ  
+1104 N  N   . VAL A 143 ? 0.2981 0.4654 0.1919 -0.0591 0.0193  -0.0228 165 VAL A N   
+1105 C  CA  . VAL A 143 ? 0.2928 0.4914 0.1940 -0.0634 0.0115  -0.0266 165 VAL A CA  
+1106 C  C   . VAL A 143 ? 0.2820 0.3996 0.1735 -0.1020 -0.0035 -0.0319 165 VAL A C   
+1107 O  O   . VAL A 143 ? 0.3241 0.3789 0.1659 -0.0486 -0.0073 -0.0276 165 VAL A O   
+1108 C  CB  . VAL A 143 ? 0.2980 0.5410 0.2030 -0.0492 0.0162  -0.0024 165 VAL A CB  
+1109 C  CG1 . VAL A 143 ? 0.2336 0.5939 0.2020 -0.0723 0.0300  0.0256  165 VAL A CG1 
+1110 C  CG2 . VAL A 143 ? 0.3404 0.5446 0.2032 -0.0364 0.0335  0.0147  165 VAL A CG2 
+1111 N  N   . ILE A 144 ? 0.2744 0.4038 0.1635 -0.0230 -0.0319 -0.0303 166 ILE A N   
+1112 C  CA  . ILE A 144 ? 0.2839 0.3221 0.1514 -0.0525 -0.0300 -0.0121 166 ILE A CA  
+1113 C  C   . ILE A 144 ? 0.3238 0.3324 0.1558 -0.0393 -0.0270 0.0026  166 ILE A C   
+1114 O  O   . ILE A 144 ? 0.3812 0.3291 0.1513 -0.0126 -0.0403 -0.0161 166 ILE A O   
+1115 C  CB  . ILE A 144 ? 0.2696 0.3141 0.1382 0.0070  -0.0200 0.0072  166 ILE A CB  
+1116 C  CG1 . ILE A 144 ? 0.3342 0.3570 0.1414 0.0863  -0.0100 0.0004  166 ILE A CG1 
+1117 C  CG2 . ILE A 144 ? 0.3165 0.3607 0.1144 0.0264  -0.0212 -0.0052 166 ILE A CG2 
+1118 C  CD1 . ILE A 144 ? 0.3407 0.3615 0.1335 0.0640  0.0146  -0.0167 166 ILE A CD1 
+1119 N  N   . PRO A 145 ? 0.3347 0.2975 0.1616 -0.0797 -0.0178 0.0230  167 PRO A N   
+1120 C  CA  . PRO A 145 ? 0.3646 0.2725 0.1691 -0.0271 -0.0176 0.0191  167 PRO A CA  
+1121 C  C   . PRO A 145 ? 0.3186 0.2738 0.1808 -0.0704 -0.0105 0.0170  167 PRO A C   
+1122 O  O   . PRO A 145 ? 0.2808 0.2987 0.2031 -0.0549 -0.0141 0.0024  167 PRO A O   
+1123 C  CB  . PRO A 145 ? 0.3636 0.2145 0.1713 -0.0685 -0.0053 0.0268  167 PRO A CB  
+1124 C  CG  . PRO A 145 ? 0.3532 0.2839 0.1686 -0.0562 -0.0368 0.0178  167 PRO A CG  
+1125 C  CD  . PRO A 145 ? 0.3670 0.2724 0.1647 -0.0674 -0.0338 0.0155  167 PRO A CD  
+1126 N  N   . ALA A 146 ? 0.3143 0.3325 0.1744 -0.0467 -0.0163 0.0097  168 ALA A N   
+1127 C  CA  . ALA A 146 ? 0.3559 0.4140 0.1704 -0.0573 -0.0199 -0.0050 168 ALA A CA  
+1128 C  C   . ALA A 146 ? 0.3345 0.4130 0.1719 -0.0914 -0.0199 0.0028  168 ALA A C   
+1129 O  O   . ALA A 146 ? 0.3688 0.4215 0.1668 -0.1008 -0.0156 0.0012  168 ALA A O   
+1130 C  CB  . ALA A 146 ? 0.3431 0.4561 0.1697 -0.0612 -0.0410 -0.0202 168 ALA A CB  
+1131 N  N   . ALA A 147 ? 0.3005 0.4104 0.1722 -0.0722 -0.0216 -0.0204 169 ALA A N   
+1132 C  CA  . ALA A 147 ? 0.2775 0.3937 0.1784 -0.0607 -0.0359 -0.0336 169 ALA A CA  
+1133 C  C   . ALA A 147 ? 0.3032 0.3615 0.1706 -0.0287 -0.0401 -0.0239 169 ALA A C   
+1134 O  O   . ALA A 147 ? 0.3020 0.3440 0.1664 -0.0034 -0.0529 -0.0330 169 ALA A O   
+1135 C  CB  . ALA A 147 ? 0.2608 0.3900 0.1897 -0.0111 -0.0211 -0.0080 169 ALA A CB  
+1136 N  N   . LEU A 148 ? 0.3050 0.2903 0.1594 -0.0600 -0.0403 -0.0101 170 LEU A N   
+1137 C  CA  . LEU A 148 ? 0.3586 0.2420 0.1549 -0.0613 -0.0453 0.0017  170 LEU A CA  
+1138 C  C   . LEU A 148 ? 0.3843 0.2873 0.1612 -0.0918 -0.0444 0.0063  170 LEU A C   
+1139 O  O   . LEU A 148 ? 0.3815 0.2541 0.1554 -0.0904 -0.0318 0.0338  170 LEU A O   
+1140 C  CB  . LEU A 148 ? 0.3402 0.2912 0.1472 -0.0052 -0.0502 0.0128  170 LEU A CB  
+1141 C  CG  . LEU A 148 ? 0.3068 0.3252 0.1343 0.0059  -0.0308 0.0226  170 LEU A CG  
+1142 C  CD1 . LEU A 148 ? 0.3455 0.2813 0.1106 -0.0020 -0.0343 0.0120  170 LEU A CD1 
+1143 C  CD2 . LEU A 148 ? 0.2788 0.2788 0.1381 -0.0011 -0.0404 0.0462  170 LEU A CD2 
+1144 N  N   . LYS A 149 ? 0.3745 0.3170 0.1675 -0.1051 -0.0325 0.0065  171 LYS A N   
+1145 C  CA  . LYS A 149 ? 0.4179 0.3499 0.1785 -0.0830 -0.0433 -0.0168 171 LYS A CA  
+1146 C  C   . LYS A 149 ? 0.4178 0.3578 0.1827 -0.0818 -0.0365 -0.0081 171 LYS A C   
+1147 O  O   . LYS A 149 ? 0.4426 0.3369 0.1697 -0.0943 -0.0294 -0.0231 171 LYS A O   
+1148 C  CB  . LYS A 149 ? 0.3802 0.3925 0.1799 -0.1592 -0.0463 -0.0001 171 LYS A CB  
+1149 C  CG  . LYS A 149 ? 0.4631 0.4017 0.1831 -0.1576 -0.0499 0.0371  171 LYS A CG  
+1150 C  CD  . LYS A 149 ? 0.5434 0.4551 0.2002 -0.1656 -0.0739 0.0414  171 LYS A CD  
+1151 C  CE  . LYS A 149 ? 0.6274 0.4797 0.2244 -0.1972 -0.0522 0.0635  171 LYS A CE  
+1152 N  NZ  . LYS A 149 ? 0.6826 0.5506 0.2347 -0.2307 -0.0176 0.0720  171 LYS A NZ  
+1153 N  N   . MET A 150 ? 0.4147 0.3376 0.1928 -0.0865 -0.0410 0.0087  172 MET A N   
+1154 C  CA  . MET A 150 ? 0.3651 0.3796 0.1953 -0.0915 -0.0372 0.0021  172 MET A CA  
+1155 C  C   . MET A 150 ? 0.3261 0.3328 0.1834 -0.0718 -0.0530 0.0167  172 MET A C   
+1156 O  O   . MET A 150 ? 0.3606 0.3576 0.1549 -0.0335 -0.0457 0.0119  172 MET A O   
+1157 C  CB  . MET A 150 ? 0.3409 0.4128 0.2270 -0.1806 -0.0126 -0.0016 172 MET A CB  
+1158 C  CG  . MET A 150 ? 0.3371 0.4348 0.2720 -0.1754 0.0094  -0.0063 172 MET A CG  
+1159 S  SD  . MET A 150 ? 0.3880 0.6187 0.3077 -0.0569 0.0118  -0.0099 172 MET A SD  
+1160 C  CE  . MET A 150 ? 0.2916 0.5648 0.2952 -0.1808 -0.0583 -0.0409 172 MET A CE  
+1161 N  N   . VAL A 151 ? 0.2878 0.3454 0.1819 -0.1172 -0.0562 0.0191  173 VAL A N   
+1162 C  CA  . VAL A 151 ? 0.2729 0.3437 0.1749 -0.0815 -0.0443 0.0161  173 VAL A CA  
+1163 C  C   . VAL A 151 ? 0.3376 0.3059 0.1686 -0.0263 -0.0555 0.0206  173 VAL A C   
+1164 O  O   . VAL A 151 ? 0.3545 0.2927 0.1568 -0.0230 -0.0704 0.0067  173 VAL A O   
+1165 C  CB  . VAL A 151 ? 0.2435 0.3301 0.1776 -0.0824 -0.0337 0.0213  173 VAL A CB  
+1166 C  CG1 . VAL A 151 ? 0.2663 0.3233 0.1730 -0.0897 -0.0213 0.0297  173 VAL A CG1 
+1167 C  CG2 . VAL A 151 ? 0.2898 0.3763 0.1748 -0.0572 -0.0383 -0.0180 173 VAL A CG2 
+1168 N  N   . LYS A 152 ? 0.3805 0.2981 0.1647 -0.0552 -0.0560 0.0094  174 LYS A N   
+1169 C  CA  . LYS A 152 ? 0.3924 0.2342 0.1689 -0.0979 -0.0446 -0.0058 174 LYS A CA  
+1170 C  C   . LYS A 152 ? 0.4531 0.2514 0.1792 -0.1152 -0.0505 0.0037  174 LYS A C   
+1171 O  O   . LYS A 152 ? 0.4978 0.2963 0.1593 -0.0472 -0.0316 0.0032  174 LYS A O   
+1172 C  CB  . LYS A 152 ? 0.3891 0.2616 0.1757 -0.0443 -0.0345 -0.0046 174 LYS A CB  
+1173 C  CG  . LYS A 152 ? 0.4131 0.2389 0.1722 -0.0321 -0.0093 -0.0111 174 LYS A CG  
+1174 C  CD  . LYS A 152 ? 0.4559 0.2173 0.1710 0.0570  -0.0062 -0.0434 174 LYS A CD  
+1175 C  CE  . LYS A 152 ? 0.4573 0.1833 0.1651 0.0497  -0.0234 -0.0339 174 LYS A CE  
+1176 N  NZ  . LYS A 152 ? 0.4535 0.2263 0.1557 0.0500  -0.0542 -0.0358 174 LYS A NZ  
+1177 N  N   . GLU A 153 ? 0.4622 0.3348 0.1962 -0.0974 -0.0667 0.0189  175 GLU A N   
+1178 C  CA  . GLU A 153 ? 0.4641 0.3707 0.2063 -0.1391 -0.1004 -0.0152 175 GLU A CA  
+1179 C  C   . GLU A 153 ? 0.4675 0.3761 0.1991 -0.1471 -0.0855 -0.0318 175 GLU A C   
+1180 O  O   . GLU A 153 ? 0.5118 0.3855 0.2021 -0.1335 -0.0854 -0.0446 175 GLU A O   
+1181 C  CB  . GLU A 153 ? 0.5394 0.4298 0.2459 -0.1859 -0.1226 -0.0068 175 GLU A CB  
+1182 C  CG  . GLU A 153 ? 0.6463 0.6255 0.2751 -0.1329 -0.1154 -0.0171 175 GLU A CG  
+1183 C  CD  . GLU A 153 ? 0.7478 0.7881 0.2991 -0.0851 -0.1145 -0.0133 175 GLU A CD  
+1184 O  OE1 . GLU A 153 ? 0.7433 0.8118 0.3085 -0.1049 -0.1372 -0.0338 175 GLU A OE1 
+1185 O  OE2 . GLU A 153 ? 0.8067 0.8251 0.3053 -0.1174 -0.0903 0.0040  175 GLU A OE2 
+1186 N  N   . HIS A 154 ? 0.4654 0.4065 0.1884 -0.1485 -0.0681 -0.0191 176 HIS A N   
+1187 C  CA  . HIS A 154 ? 0.4521 0.4029 0.1848 -0.1233 -0.0676 -0.0084 176 HIS A CA  
+1188 C  C   . HIS A 154 ? 0.4285 0.3512 0.1738 -0.1192 -0.0743 -0.0198 176 HIS A C   
+1189 O  O   . HIS A 154 ? 0.4282 0.4087 0.1686 -0.0930 -0.0583 -0.0333 176 HIS A O   
+1190 C  CB  . HIS A 154 ? 0.4194 0.4269 0.1855 -0.1211 -0.0659 0.0016  176 HIS A CB  
+1191 C  CG  . HIS A 154 ? 0.4005 0.4657 0.1875 -0.1402 -0.0871 -0.0054 176 HIS A CG  
+1192 N  ND1 . HIS A 154 ? 0.4461 0.5373 0.1853 -0.1057 -0.0918 0.0111  176 HIS A ND1 
+1193 C  CD2 . HIS A 154 ? 0.4184 0.4696 0.1926 -0.1260 -0.0963 -0.0166 176 HIS A CD2 
+1194 C  CE1 . HIS A 154 ? 0.4605 0.5805 0.1941 -0.0937 -0.0901 0.0133  176 HIS A CE1 
+1195 N  NE2 . HIS A 154 ? 0.4548 0.5445 0.1936 -0.0977 -0.0819 0.0121  176 HIS A NE2 
+1196 N  N   . TYR A 155 ? 0.4299 0.3426 0.1674 -0.0803 -0.0618 -0.0082 177 TYR A N   
+1197 C  CA  . TYR A 155 ? 0.4151 0.2548 0.1561 -0.1003 -0.0778 -0.0147 177 TYR A CA  
+1198 C  C   . TYR A 155 ? 0.4224 0.2472 0.1682 -0.1124 -0.0718 -0.0226 177 TYR A C   
+1199 O  O   . TYR A 155 ? 0.4504 0.3070 0.1598 -0.0792 -0.0534 -0.0530 177 TYR A O   
+1200 C  CB  . TYR A 155 ? 0.3980 0.2678 0.1453 -0.0655 -0.0738 -0.0078 177 TYR A CB  
+1201 C  CG  . TYR A 155 ? 0.3755 0.2650 0.1364 -0.0260 -0.0532 -0.0148 177 TYR A CG  
+1202 C  CD1 . TYR A 155 ? 0.3565 0.2855 0.1405 -0.0370 -0.0680 -0.0476 177 TYR A CD1 
+1203 C  CD2 . TYR A 155 ? 0.3518 0.2775 0.1402 -0.0272 -0.0531 -0.0028 177 TYR A CD2 
+1204 C  CE1 . TYR A 155 ? 0.4084 0.3224 0.1411 -0.0109 -0.0624 -0.0052 177 TYR A CE1 
+1205 C  CE2 . TYR A 155 ? 0.3405 0.2745 0.1389 -0.0559 -0.0551 0.0005  177 TYR A CE2 
+1206 C  CZ  . TYR A 155 ? 0.3628 0.3004 0.1390 -0.0042 -0.0618 0.0060  177 TYR A CZ  
+1207 O  OH  . TYR A 155 ? 0.3170 0.3239 0.1446 -0.0001 -0.0666 0.0048  177 TYR A OH  
+1208 N  N   . ARG A 156 ? 0.4386 0.2880 0.1892 -0.1328 -0.0587 -0.0001 178 ARG A N   
+1209 C  CA  . ARG A 156 ? 0.4827 0.3079 0.2225 -0.1423 -0.0585 -0.0316 178 ARG A CA  
+1210 C  C   . ARG A 156 ? 0.5397 0.3213 0.2393 -0.1407 -0.0543 -0.0618 178 ARG A C   
+1211 O  O   . ARG A 156 ? 0.6020 0.3187 0.2357 -0.0835 -0.0432 -0.0655 178 ARG A O   
+1212 C  CB  . ARG A 156 ? 0.5463 0.3188 0.2428 -0.1041 -0.0545 -0.0144 178 ARG A CB  
+1213 C  CG  . ARG A 156 ? 0.6515 0.3758 0.2673 -0.0186 -0.0585 -0.0097 178 ARG A CG  
+1214 C  CD  . ARG A 156 ? 0.7149 0.4194 0.2926 -0.0259 -0.0755 -0.0015 178 ARG A CD  
+1215 N  NE  . ARG A 156 ? 0.7540 0.3748 0.3073 -0.0955 -0.0945 -0.0007 178 ARG A NE  
+1216 C  CZ  . ARG A 156 ? 0.7913 0.3910 0.3255 -0.0893 -0.1045 0.0216  178 ARG A CZ  
+1217 N  NH1 . ARG A 156 ? 0.8279 0.3381 0.3275 -0.0263 -0.1177 0.0125  178 ARG A NH1 
+1218 N  NH2 . ARG A 156 ? 0.7468 0.4495 0.3365 -0.1586 -0.0917 0.0436  178 ARG A NH2 
+1219 N  N   . LYS A 157 ? 0.5473 0.3704 0.2510 -0.1293 -0.0709 -0.0761 179 LYS A N   
+1220 C  CA  . LYS A 157 ? 0.5691 0.4680 0.2613 -0.1439 -0.0871 -0.0910 179 LYS A CA  
+1221 C  C   . LYS A 157 ? 0.5503 0.5034 0.2784 -0.1692 -0.1069 -0.0877 179 LYS A C   
+1222 O  O   . LYS A 157 ? 0.6302 0.5121 0.2792 -0.1575 -0.1137 -0.0914 179 LYS A O   
+1223 C  CB  . LYS A 157 ? 0.6306 0.5533 0.2727 -0.0886 -0.0880 -0.1094 179 LYS A CB  
+1224 C  CG  . LYS A 157 ? 0.6818 0.6204 0.2853 -0.0395 -0.0758 -0.1293 179 LYS A CG  
+1225 C  CD  . LYS A 157 ? 0.7262 0.7089 0.2987 -0.0090 -0.0797 -0.1292 179 LYS A CD  
+1226 C  CE  . LYS A 157 ? 0.7462 0.7284 0.3041 0.0165  -0.0644 -0.1191 179 LYS A CE  
+1227 N  NZ  . LYS A 157 ? 0.7524 0.7246 0.3100 0.0082  -0.0606 -0.1128 179 LYS A NZ  
+1228 N  N   . THR A 158 ? 0.5362 0.5210 0.2681 -0.1937 -0.1034 -0.0588 180 THR A N   
+1229 C  CA  . THR A 158 ? 0.5535 0.5146 0.2773 -0.1991 -0.1074 -0.0592 180 THR A CA  
+1230 C  C   . THR A 158 ? 0.5950 0.4772 0.2612 -0.1716 -0.0837 -0.0866 180 THR A C   
+1231 O  O   . THR A 158 ? 0.6358 0.4827 0.2685 -0.1495 -0.0619 -0.0586 180 THR A O   
+1232 C  CB  . THR A 158 ? 0.5645 0.5797 0.2792 -0.1629 -0.1379 -0.0133 180 THR A CB  
+1233 O  OG1 . THR A 158 ? 0.5535 0.6403 0.2759 -0.1186 -0.1655 -0.0092 180 THR A OG1 
+1234 C  CG2 . THR A 158 ? 0.5886 0.6278 0.2892 -0.1156 -0.1122 0.0227  180 THR A CG2 
+1235 N  N   . GLY A 159 ? 0.6002 0.4341 0.2465 -0.1286 -0.0709 -0.1028 181 GLY A N   
+1236 C  CA  . GLY A 159 ? 0.5759 0.3785 0.2447 -0.0966 -0.0676 -0.1115 181 GLY A CA  
+1237 C  C   . GLY A 159 ? 0.5965 0.3712 0.2272 -0.0921 -0.0399 -0.0844 181 GLY A C   
+1238 O  O   . GLY A 159 ? 0.6276 0.3430 0.2455 -0.1107 -0.0174 -0.0847 181 GLY A O   
+1239 N  N   . ASP A 160 ? 0.5423 0.3308 0.1900 -0.0936 -0.0418 -0.0722 182 ASP A N   
+1240 C  CA  . ASP A 160 ? 0.5148 0.3341 0.1685 -0.0973 -0.0462 -0.0507 182 ASP A CA  
+1241 C  C   . ASP A 160 ? 0.4670 0.3569 0.1621 -0.0424 -0.0388 -0.0678 182 ASP A C   
+1242 O  O   . ASP A 160 ? 0.4189 0.4186 0.1659 -0.1036 -0.0192 -0.0590 182 ASP A O   
+1243 C  CB  . ASP A 160 ? 0.5327 0.4042 0.1827 -0.1436 -0.0573 -0.0353 182 ASP A CB  
+1244 C  CG  . ASP A 160 ? 0.5876 0.4697 0.1763 -0.1346 -0.0506 0.0093  182 ASP A CG  
+1245 O  OD1 . ASP A 160 ? 0.6519 0.5033 0.1725 -0.0693 -0.0041 0.0294  182 ASP A OD1 
+1246 O  OD2 . ASP A 160 ? 0.6100 0.5274 0.1853 -0.0812 -0.0846 0.0262  182 ASP A OD2 
+1247 N  N   . ASN A 161 ? 0.4113 0.3008 0.1528 -0.0269 -0.0061 -0.0578 183 ASN A N   
+1248 C  CA  . ASN A 161 ? 0.4167 0.2737 0.1451 0.0078  -0.0365 -0.0299 183 ASN A CA  
+1249 C  C   . ASN A 161 ? 0.3643 0.2347 0.1369 -0.0129 -0.0301 -0.0177 183 ASN A C   
+1250 O  O   . ASN A 161 ? 0.4061 0.2357 0.1374 -0.0219 -0.0222 -0.0242 183 ASN A O   
+1251 C  CB  . ASN A 161 ? 0.3824 0.2454 0.1468 -0.0404 -0.0415 -0.0413 183 ASN A CB  
+1252 C  CG  . ASN A 161 ? 0.4447 0.2798 0.1534 -0.0526 -0.0369 -0.0084 183 ASN A CG  
+1253 O  OD1 . ASN A 161 ? 0.5008 0.3699 0.1545 -0.0432 -0.0118 -0.0440 183 ASN A OD1 
+1254 N  ND2 . ASN A 161 ? 0.4694 0.2490 0.1577 -0.0998 -0.0453 0.0217  183 ASN A ND2 
+1255 N  N   . PHE A 162 ? 0.2922 0.2472 0.1309 -0.0370 -0.0465 -0.0125 184 PHE A N   
+1256 C  CA  . PHE A 162 ? 0.3092 0.2203 0.1217 -0.0097 -0.0610 0.0085  184 PHE A CA  
+1257 C  C   . PHE A 162 ? 0.2980 0.2265 0.1189 -0.0373 -0.0412 -0.0106 184 PHE A C   
+1258 O  O   . PHE A 162 ? 0.3385 0.2171 0.1302 -0.0361 -0.0423 0.0097  184 PHE A O   
+1259 C  CB  . PHE A 162 ? 0.2996 0.2391 0.1126 0.0272  -0.0500 -0.0205 184 PHE A CB  
+1260 C  CG  . PHE A 162 ? 0.3404 0.2557 0.1039 0.0265  -0.0334 -0.0184 184 PHE A CG  
+1261 C  CD1 . PHE A 162 ? 0.3512 0.2701 0.1131 0.0045  -0.0409 -0.0298 184 PHE A CD1 
+1262 C  CD2 . PHE A 162 ? 0.3792 0.2118 0.1016 -0.0224 -0.0298 -0.0121 184 PHE A CD2 
+1263 C  CE1 . PHE A 162 ? 0.3230 0.2312 0.1174 0.0121  -0.0565 0.0111  184 PHE A CE1 
+1264 C  CE2 . PHE A 162 ? 0.3140 0.1944 0.1107 -0.0092 -0.0364 0.0198  184 PHE A CE2 
+1265 C  CZ  . PHE A 162 ? 0.3173 0.1687 0.1105 0.0029  -0.0475 0.0057  184 PHE A CZ  
+1266 N  N   . MET A 163 ? 0.3152 0.1734 0.1089 -0.0055 -0.0312 0.0138  185 MET A N   
+1267 C  CA  . MET A 163 ? 0.2861 0.1938 0.1036 0.0324  -0.0403 -0.0016 185 MET A CA  
+1268 C  C   . MET A 163 ? 0.2871 0.1840 0.1054 0.0431  -0.0378 -0.0006 185 MET A C   
+1269 O  O   . MET A 163 ? 0.3013 0.2133 0.1097 0.0473  -0.0373 0.0067  185 MET A O   
+1270 C  CB  . MET A 163 ? 0.3089 0.1984 0.1061 0.0453  -0.0259 0.0075  185 MET A CB  
+1271 C  CG  . MET A 163 ? 0.3131 0.2058 0.1082 0.0151  -0.0189 -0.0313 185 MET A CG  
+1272 S  SD  . MET A 163 ? 0.3663 0.2209 0.1231 0.0098  0.0152  -0.0234 185 MET A SD  
+1273 C  CE  . MET A 163 ? 0.3854 0.3002 0.1344 0.0269  -0.0320 -0.0158 185 MET A CE  
+1274 N  N   . ILE A 164 ? 0.3048 0.1392 0.0908 0.0309  -0.0234 -0.0024 186 ILE A N   
+1275 C  CA  . ILE A 164 ? 0.2647 0.1819 0.0859 -0.0119 -0.0208 0.0089  186 ILE A CA  
+1276 C  C   . ILE A 164 ? 0.2651 0.1946 0.0888 0.0062  -0.0167 -0.0162 186 ILE A C   
+1277 O  O   . ILE A 164 ? 0.2653 0.1912 0.0860 0.0233  -0.0002 -0.0176 186 ILE A O   
+1278 C  CB  . ILE A 164 ? 0.2464 0.2102 0.1068 -0.0086 -0.0060 -0.0069 186 ILE A CB  
+1279 C  CG1 . ILE A 164 ? 0.2807 0.2255 0.1125 -0.0319 -0.0316 -0.0212 186 ILE A CG1 
+1280 C  CG2 . ILE A 164 ? 0.2637 0.2400 0.1149 -0.0048 -0.0116 0.0003  186 ILE A CG2 
+1281 C  CD1 . ILE A 164 ? 0.3090 0.2640 0.1217 -0.0292 -0.0701 -0.0104 186 ILE A CD1 
+1282 N  N   . THR A 165 ? 0.2586 0.1546 0.0874 0.0109  -0.0172 -0.0016 187 THR A N   
+1283 C  CA  . THR A 165 ? 0.2775 0.1517 0.0782 0.0536  -0.0026 0.0037  187 THR A CA  
+1284 C  C   . THR A 165 ? 0.2289 0.1124 0.0787 0.0028  -0.0083 0.0095  187 THR A C   
+1285 O  O   . THR A 165 ? 0.2495 0.1809 0.0866 0.0451  -0.0130 0.0255  187 THR A O   
+1286 C  CB  . THR A 165 ? 0.2487 0.1578 0.0806 0.0858  -0.0265 -0.0080 187 THR A CB  
+1287 O  OG1 . THR A 165 ? 0.2161 0.1839 0.0796 0.0884  -0.0176 -0.0062 187 THR A OG1 
+1288 C  CG2 . THR A 165 ? 0.2660 0.1656 0.0888 0.0492  0.0024  -0.0019 187 THR A CG2 
+1289 N  N   . MET A 166 ? 0.2503 0.1457 0.0706 0.0175  -0.0183 -0.0177 188 MET A N   
+1290 C  CA  . MET A 166 ? 0.2490 0.1432 0.0787 -0.0077 0.0037  -0.0081 188 MET A CA  
+1291 C  C   . MET A 166 ? 0.2392 0.0878 0.0850 -0.0044 -0.0133 0.0006  188 MET A C   
+1292 O  O   . MET A 166 ? 0.2659 0.1687 0.0929 0.0491  -0.0070 -0.0192 188 MET A O   
+1293 C  CB  . MET A 166 ? 0.2742 0.1410 0.0778 0.0549  0.0072  -0.0030 188 MET A CB  
+1294 C  CG  . MET A 166 ? 0.3281 0.1756 0.0918 0.0384  0.0198  -0.0149 188 MET A CG  
+1295 S  SD  . MET A 166 ? 0.3129 0.1574 0.1078 0.0145  0.0106  0.0070  188 MET A SD  
+1296 C  CE  . MET A 166 ? 0.3431 0.1713 0.1263 0.0169  0.0094  0.0049  188 MET A CE  
+1297 N  N   . ALA A 167 ? 0.2630 0.1076 0.0853 0.0167  -0.0096 -0.0188 189 ALA A N   
+1298 C  CA  . ALA A 167 ? 0.2533 0.0801 0.0862 0.0218  -0.0142 -0.0182 189 ALA A CA  
+1299 C  C   . ALA A 167 ? 0.2480 0.1209 0.0804 0.0266  -0.0184 -0.0270 189 ALA A C   
+1300 O  O   . ALA A 167 ? 0.2658 0.1330 0.0863 0.0668  -0.0063 -0.0176 189 ALA A O   
+1301 C  CB  . ALA A 167 ? 0.2914 0.1314 0.0963 0.0474  -0.0321 -0.0312 189 ALA A CB  
+1302 N  N   . PRO A 168 ? 0.2424 0.1124 0.0786 0.0202  -0.0004 0.0099  190 PRO A N   
+1303 C  CA  . PRO A 168 ? 0.2420 0.1516 0.0721 0.0421  0.0079  0.0128  190 PRO A CA  
+1304 C  C   . PRO A 168 ? 0.2648 0.1990 0.0791 0.0437  0.0266  0.0227  190 PRO A C   
+1305 O  O   . PRO A 168 ? 0.2262 0.1602 0.0823 0.0268  0.0051  -0.0099 190 PRO A O   
+1306 C  CB  . PRO A 168 ? 0.2670 0.1381 0.0739 0.0083  -0.0055 0.0046  190 PRO A CB  
+1307 C  CG  . PRO A 168 ? 0.2853 0.1470 0.0791 0.0322  0.0033  0.0079  190 PRO A CG  
+1308 C  CD  . PRO A 168 ? 0.2798 0.1113 0.0872 0.0184  -0.0076 0.0040  190 PRO A CD  
+1309 N  N   . GLU A 169 ? 0.2536 0.1777 0.0878 0.0837  0.0083  -0.0149 191 GLU A N   
+1310 C  CA  . GLU A 169 ? 0.2612 0.1354 0.0930 0.0271  0.0109  -0.0179 191 GLU A CA  
+1311 C  C   . GLU A 169 ? 0.2738 0.1277 0.1017 0.0517  0.0060  -0.0216 191 GLU A C   
+1312 O  O   . GLU A 169 ? 0.2775 0.1548 0.0960 0.0306  0.0164  0.0068  191 GLU A O   
+1313 C  CB  . GLU A 169 ? 0.2377 0.1498 0.0904 0.0287  0.0116  0.0032  191 GLU A CB  
+1314 C  CG  . GLU A 169 ? 0.2278 0.1761 0.0951 -0.0119 0.0034  -0.0058 191 GLU A CG  
+1315 C  CD  . GLU A 169 ? 0.2409 0.1527 0.1085 0.0421  -0.0020 -0.0107 191 GLU A CD  
+1316 O  OE1 . GLU A 169 ? 0.2923 0.1781 0.1058 0.0436  0.0006  -0.0332 191 GLU A OE1 
+1317 O  OE2 . GLU A 169 ? 0.2452 0.1856 0.1154 0.0618  -0.0155 -0.0209 191 GLU A OE2 
+1318 N  N   . PHE A 170 ? 0.2270 0.1785 0.0998 0.0167  0.0062  -0.0173 192 PHE A N   
+1319 C  CA  . PHE A 170 ? 0.2748 0.1777 0.1002 0.0603  0.0120  -0.0066 192 PHE A CA  
+1320 C  C   . PHE A 170 ? 0.2948 0.1788 0.1089 0.0665  -0.0079 0.0086  192 PHE A C   
+1321 O  O   . PHE A 170 ? 0.3399 0.1488 0.1301 0.0398  0.0064  0.0096  192 PHE A O   
+1322 C  CB  . PHE A 170 ? 0.3352 0.1543 0.1081 0.0791  0.0219  0.0118  192 PHE A CB  
+1323 C  CG  . PHE A 170 ? 0.3002 0.1689 0.0954 0.0507  -0.0033 -0.0141 192 PHE A CG  
+1324 C  CD1 . PHE A 170 ? 0.3311 0.2188 0.1086 0.0417  -0.0196 -0.0053 192 PHE A CD1 
+1325 C  CD2 . PHE A 170 ? 0.2802 0.1925 0.0861 0.0317  0.0094  -0.0298 192 PHE A CD2 
+1326 C  CE1 . PHE A 170 ? 0.3106 0.2695 0.1131 0.0959  -0.0346 0.0086  192 PHE A CE1 
+1327 C  CE2 . PHE A 170 ? 0.2592 0.2097 0.0901 0.0282  -0.0010 -0.0213 192 PHE A CE2 
+1328 C  CZ  . PHE A 170 ? 0.2709 0.2838 0.1152 0.0483  -0.0148 -0.0149 192 PHE A CZ  
+1329 N  N   . PRO A 171 ? 0.3017 0.2004 0.1010 0.0362  0.0117  0.0202  193 PRO A N   
+1330 C  CA  . PRO A 171 ? 0.3738 0.1808 0.1057 0.0704  0.0090  0.0218  193 PRO A CA  
+1331 C  C   . PRO A 171 ? 0.3266 0.2342 0.1148 0.0969  0.0139  0.0447  193 PRO A C   
+1332 O  O   . PRO A 171 ? 0.3481 0.2468 0.1223 0.0945  0.0260  0.0518  193 PRO A O   
+1333 C  CB  . PRO A 171 ? 0.4333 0.1908 0.1095 0.0264  0.0039  -0.0054 193 PRO A CB  
+1334 C  CG  . PRO A 171 ? 0.4155 0.2002 0.1090 0.0311  -0.0059 -0.0193 193 PRO A CG  
+1335 C  CD  . PRO A 171 ? 0.3042 0.1908 0.0940 0.0573  -0.0232 -0.0273 193 PRO A CD  
+1336 N  N   . TYR A 172 ? 0.2716 0.1930 0.1190 0.0828  0.0299  0.0205  194 TYR A N   
+1337 C  CA  . TYR A 172 ? 0.3005 0.1683 0.1429 0.1219  0.0381  0.0166  194 TYR A CA  
+1338 C  C   . TYR A 172 ? 0.3595 0.1731 0.1907 0.0940  0.0394  0.0150  194 TYR A C   
+1339 O  O   . TYR A 172 ? 0.4012 0.1604 0.2376 0.0566  0.0608  -0.0023 194 TYR A O   
+1340 C  CB  . TYR A 172 ? 0.3287 0.1581 0.1405 0.0543  0.0210  0.0164  194 TYR A CB  
+1341 C  CG  . TYR A 172 ? 0.2934 0.1758 0.1341 0.0686  0.0075  -0.0005 194 TYR A CG  
+1342 C  CD1 . TYR A 172 ? 0.3049 0.1237 0.1391 0.0336  0.0160  0.0117  194 TYR A CD1 
+1343 C  CD2 . TYR A 172 ? 0.2778 0.1418 0.1326 0.0496  -0.0010 0.0005  194 TYR A CD2 
+1344 C  CE1 . TYR A 172 ? 0.3001 0.1245 0.1458 0.0384  0.0213  0.0081  194 TYR A CE1 
+1345 C  CE2 . TYR A 172 ? 0.2808 0.1411 0.1353 0.0528  0.0144  0.0121  194 TYR A CE2 
+1346 C  CZ  . TYR A 172 ? 0.3015 0.1141 0.1460 0.0286  0.0005  -0.0086 194 TYR A CZ  
+1347 O  OH  . TYR A 172 ? 0.3172 0.1968 0.1503 0.0689  0.0038  0.0036  194 TYR A OH  
+1348 N  N   . LEU A 173 ? 0.2987 0.1779 0.1550 0.0835  0.0613  0.0190  195 LEU A N   
+1349 C  CA  . LEU A 173 ? 0.3527 0.1333 0.1305 0.0516  0.0250  0.0176  195 LEU A CA  
+1350 C  C   . LEU A 173 ? 0.3384 0.1213 0.1247 0.0800  0.0345  0.0060  195 LEU A C   
+1351 O  O   . LEU A 173 ? 0.4050 0.1632 0.1270 0.1115  0.0520  0.0242  195 LEU A O   
+1352 C  CB  . LEU A 173 ? 0.3327 0.1412 0.1215 0.0746  0.0338  0.0345  195 LEU A CB  
+1353 C  CG  . LEU A 173 ? 0.3157 0.1509 0.1156 0.0498  0.0324  0.0412  195 LEU A CG  
+1354 C  CD1 . LEU A 173 ? 0.3497 0.1981 0.1196 0.0857  0.0277  0.0211  195 LEU A CD1 
+1355 C  CD2 . LEU A 173 ? 0.2986 0.2670 0.1179 0.0640  0.0113  0.0472  195 LEU A CD2 
+1356 N  N   . THR A 174 ? 0.3154 0.1476 0.1150 0.0354  0.0094  -0.0176 196 THR A N   
+1357 C  CA  . THR A 174 ? 0.3250 0.1547 0.1127 0.0121  0.0030  0.0120  196 THR A CA  
+1358 C  C   . THR A 174 ? 0.4126 0.1866 0.1165 0.0544  -0.0174 0.0223  196 THR A C   
+1359 O  O   . THR A 174 ? 0.4419 0.2276 0.1303 0.0758  -0.0262 0.0266  196 THR A O   
+1360 C  CB  . THR A 174 ? 0.3569 0.2030 0.1135 0.0398  -0.0099 -0.0244 196 THR A CB  
+1361 O  OG1 . THR A 174 ? 0.4046 0.2502 0.1210 0.1164  0.0193  -0.0076 196 THR A OG1 
+1362 C  CG2 . THR A 174 ? 0.4044 0.2738 0.1243 0.0405  -0.0001 -0.0270 196 THR A CG2 
+1363 N  N   . ALA A 175 ? 0.4987 0.1917 0.1336 0.0781  -0.0066 0.0123  197 ALA A N   
+1364 C  CA  . ALA A 175 ? 0.5407 0.2056 0.1571 -0.0045 -0.0125 0.0389  197 ALA A CA  
+1365 C  C   . ALA A 175 ? 0.6080 0.2464 0.1906 -0.0017 -0.0750 0.0459  197 ALA A C   
+1366 O  O   . ALA A 175 ? 0.7173 0.2483 0.2162 -0.0237 -0.1242 0.0090  197 ALA A O   
+1367 C  CB  . ALA A 175 ? 0.5842 0.2577 0.1536 0.0459  -0.0223 -0.0091 197 ALA A CB  
+1368 N  N   . ASN A 176 ? 0.4995 0.2272 0.1952 -0.0443 -0.0278 0.0815  198 ASN A N   
+1369 C  CA  . ASN A 176 ? 0.4628 0.2728 0.2027 -0.0532 -0.0891 0.0589  198 ASN A CA  
+1370 C  C   . ASN A 176 ? 0.4280 0.2467 0.1762 -0.0527 -0.0584 0.0493  198 ASN A C   
+1371 O  O   . ASN A 176 ? 0.3916 0.3421 0.1945 -0.0907 -0.0562 0.0801  198 ASN A O   
+1372 C  CB  . ASN A 176 ? 0.4958 0.2546 0.2378 -0.0647 -0.0778 0.0568  198 ASN A CB  
+1373 C  CG  . ASN A 176 ? 0.5344 0.3423 0.2480 -0.0294 -0.0757 0.0312  198 ASN A CG  
+1374 O  OD1 . ASN A 176 ? 0.5875 0.4121 0.2484 -0.0076 -0.0618 0.0215  198 ASN A OD1 
+1375 N  ND2 . ASN A 176 ? 0.4530 0.3167 0.2378 -0.0484 -0.0799 0.0505  198 ASN A ND2 
+1376 N  N   . GLY A 177 ? 0.4254 0.1958 0.1384 -0.0084 -0.0647 0.0376  199 GLY A N   
+1377 C  CA  . GLY A 177 ? 0.3820 0.2028 0.1294 0.0244  -0.0328 0.0289  199 GLY A CA  
+1378 C  C   . GLY A 177 ? 0.3731 0.1902 0.1309 -0.0243 -0.0143 0.0447  199 GLY A C   
+1379 O  O   . GLY A 177 ? 0.3701 0.2182 0.1323 -0.0375 -0.0625 0.0436  199 GLY A O   
+1380 N  N   . ALA A 178 ? 0.3647 0.1711 0.1348 -0.0243 -0.0026 0.0361  200 ALA A N   
+1381 C  CA  . ALA A 178 ? 0.3064 0.1406 0.1127 -0.0471 0.0095  0.0171  200 ALA A CA  
+1382 C  C   . ALA A 178 ? 0.3281 0.1396 0.1029 0.0007  -0.0242 0.0081  200 ALA A C   
+1383 O  O   . ALA A 178 ? 0.3261 0.2033 0.0969 0.0070  -0.0287 -0.0031 200 ALA A O   
+1384 C  CB  . ALA A 178 ? 0.3132 0.1881 0.1018 0.0176  0.0089  -0.0380 200 ALA A CB  
+1385 N  N   . TYR A 179 ? 0.3789 0.1464 0.1075 0.0472  -0.0298 -0.0210 201 TYR A N   
+1386 C  CA  . TYR A 179 ? 0.4035 0.1311 0.1096 0.0795  -0.0279 -0.0078 201 TYR A CA  
+1387 C  C   . TYR A 179 ? 0.4822 0.1264 0.1281 0.0367  -0.0415 -0.0042 201 TYR A C   
+1388 O  O   . TYR A 179 ? 0.5086 0.1924 0.1336 0.0731  -0.0267 -0.0065 201 TYR A O   
+1389 C  CB  . TYR A 179 ? 0.3739 0.2055 0.0985 0.0334  -0.0198 -0.0153 201 TYR A CB  
+1390 C  CG  . TYR A 179 ? 0.2801 0.2269 0.0985 0.0175  -0.0052 -0.0056 201 TYR A CG  
+1391 C  CD1 . TYR A 179 ? 0.2586 0.1905 0.1084 -0.0406 0.0108  -0.0089 201 TYR A CD1 
+1392 C  CD2 . TYR A 179 ? 0.2519 0.2118 0.0994 0.0520  -0.0216 0.0035  201 TYR A CD2 
+1393 C  CE1 . TYR A 179 ? 0.2356 0.1658 0.1072 0.0171  0.0080  -0.0032 201 TYR A CE1 
+1394 C  CE2 . TYR A 179 ? 0.3116 0.1765 0.1017 0.0406  -0.0212 -0.0155 201 TYR A CE2 
+1395 C  CZ  . TYR A 179 ? 0.3097 0.1378 0.1125 0.0123  -0.0073 0.0051  201 TYR A CZ  
+1396 O  OH  . TYR A 179 ? 0.3168 0.1753 0.1318 -0.0034 0.0042  0.0230  201 TYR A OH  
+1397 N  N   . THR A 180 ? 0.5312 0.1505 0.1411 0.0314  -0.0488 -0.0051 202 THR A N   
+1398 C  CA  . THR A 180 ? 0.5560 0.1663 0.1480 -0.0180 -0.0237 -0.0126 202 THR A CA  
+1399 C  C   . THR A 180 ? 0.5430 0.1812 0.1451 -0.0896 0.0152  -0.0093 202 THR A C   
+1400 O  O   . THR A 180 ? 0.5497 0.1803 0.1475 -0.0673 0.0091  -0.0074 202 THR A O   
+1401 C  CB  . THR A 180 ? 0.5851 0.2819 0.1488 0.0473  -0.0159 -0.0006 202 THR A CB  
+1402 O  OG1 . THR A 180 ? 0.4860 0.1919 0.1467 -0.0343 0.0721  0.0130  202 THR A OG1 
+1403 C  CG2 . THR A 180 ? 0.4976 0.2410 0.1395 0.0288  -0.0607 -0.0185 202 THR A CG2 
+1404 N  N   . PRO A 181 ? 0.5319 0.2073 0.1696 -0.0918 0.0762  -0.0398 203 PRO A N   
+1405 C  CA  . PRO A 181 ? 0.4984 0.2364 0.1815 -0.1293 0.0943  -0.0423 203 PRO A CA  
+1406 C  C   . PRO A 181 ? 0.4342 0.1856 0.1641 -0.0983 0.0572  -0.0394 203 PRO A C   
+1407 O  O   . PRO A 181 ? 0.4453 0.2859 0.1669 -0.0589 0.0561  -0.0500 203 PRO A O   
+1408 C  CB  . PRO A 181 ? 0.5245 0.3602 0.2009 -0.0684 0.1382  -0.0084 203 PRO A CB  
+1409 C  CG  . PRO A 181 ? 0.5664 0.3472 0.2152 -0.0229 0.1135  -0.0738 203 PRO A CG  
+1410 C  CD  . PRO A 181 ? 0.5576 0.3358 0.1982 -0.0286 0.1108  -0.0660 203 PRO A CD  
+1411 N  N   . TYR A 182 ? 0.3659 0.1529 0.1411 -0.0848 0.0525  -0.0235 204 TYR A N   
+1412 C  CA  . TYR A 182 ? 0.3185 0.1796 0.1221 -0.0292 0.0102  -0.0137 204 TYR A CA  
+1413 C  C   . TYR A 182 ? 0.3509 0.1686 0.1103 -0.0288 -0.0270 -0.0182 204 TYR A C   
+1414 O  O   . TYR A 182 ? 0.3402 0.2021 0.1172 -0.0008 -0.0150 -0.0266 204 TYR A O   
+1415 C  CB  . TYR A 182 ? 0.3231 0.2235 0.1137 0.0061  0.0162  -0.0052 204 TYR A CB  
+1416 C  CG  . TYR A 182 ? 0.2978 0.2278 0.1059 -0.0132 -0.0028 0.0032  204 TYR A CG  
+1417 C  CD1 . TYR A 182 ? 0.3411 0.2009 0.1038 0.0101  -0.0242 0.0025  204 TYR A CD1 
+1418 C  CD2 . TYR A 182 ? 0.2960 0.1794 0.1023 0.0009  0.0011  0.0011  204 TYR A CD2 
+1419 C  CE1 . TYR A 182 ? 0.3514 0.2241 0.1024 0.0359  -0.0279 0.0013  204 TYR A CE1 
+1420 C  CE2 . TYR A 182 ? 0.3032 0.2157 0.1042 -0.0263 -0.0057 0.0084  204 TYR A CE2 
+1421 C  CZ  . TYR A 182 ? 0.3083 0.2005 0.1124 0.0076  0.0090  0.0185  204 TYR A CZ  
+1422 O  OH  . TYR A 182 ? 0.3188 0.2271 0.1280 0.0173  -0.0106 -0.0116 204 TYR A OH  
+1423 N  N   . LEU A 183 ? 0.3689 0.1757 0.1215 -0.0378 -0.0133 0.0466  205 LEU A N   
+1424 C  CA  . LEU A 183 ? 0.3533 0.1770 0.1260 -0.0315 0.0067  0.0542  205 LEU A CA  
+1425 C  C   . LEU A 183 ? 0.3385 0.1744 0.1242 -0.0637 0.0124  0.0207  205 LEU A C   
+1426 O  O   . LEU A 183 ? 0.4176 0.2131 0.1386 0.0128  0.0226  -0.0200 205 LEU A O   
+1427 C  CB  . LEU A 183 ? 0.3875 0.2410 0.1436 -0.0338 -0.0054 0.0606  205 LEU A CB  
+1428 C  CG  . LEU A 183 ? 0.4165 0.2867 0.1498 -0.0684 -0.0464 0.0547  205 LEU A CG  
+1429 C  CD1 . LEU A 183 ? 0.5133 0.3705 0.1647 -0.0571 -0.0602 0.0716  205 LEU A CD1 
+1430 C  CD2 . LEU A 183 ? 0.4153 0.2911 0.1449 -0.0371 -0.0546 0.0465  205 LEU A CD2 
+1431 N  N   . THR A 184 ? 0.3754 0.2241 0.1353 -0.0766 0.0244  0.0122  206 THR A N   
+1432 C  CA  . THR A 184 ? 0.4257 0.2283 0.1495 -0.0722 0.0318  0.0182  206 THR A CA  
+1433 C  C   . THR A 184 ? 0.4362 0.2572 0.1551 -0.0674 0.0269  -0.0135 206 THR A C   
+1434 O  O   . THR A 184 ? 0.4905 0.2455 0.1615 0.0051  -0.0121 -0.0512 206 THR A O   
+1435 C  CB  . THR A 184 ? 0.5030 0.3237 0.1627 -0.0148 0.0148  0.0007  206 THR A CB  
+1436 O  OG1 . THR A 184 ? 0.5480 0.3546 0.1819 -0.0810 0.0280  0.0037  206 THR A OG1 
+1437 C  CG2 . THR A 184 ? 0.5240 0.2266 0.1598 -0.1461 -0.0133 0.0096  206 THR A CG2 
+1438 N  N   . GLU A 185 ? 0.4748 0.1609 0.1560 -0.0753 0.0164  -0.0019 207 GLU A N   
+1439 C  CA  . GLU A 185 ? 0.4701 0.2684 0.1554 -0.0916 0.0311  -0.0169 207 GLU A CA  
+1440 C  C   . GLU A 185 ? 0.4503 0.2254 0.1391 -0.0825 0.0136  -0.0364 207 GLU A C   
+1441 O  O   . GLU A 185 ? 0.4573 0.2310 0.1493 -0.0653 0.0213  -0.0431 207 GLU A O   
+1442 C  CB  . GLU A 185 ? 0.4946 0.2559 0.1797 -0.1170 0.0466  -0.0260 207 GLU A CB  
+1443 C  CG  . GLU A 185 ? 0.5705 0.3216 0.2090 -0.1421 0.0517  -0.0249 207 GLU A CG  
+1444 C  CD  . GLU A 185 ? 0.6720 0.4616 0.2460 -0.1353 0.0682  -0.0415 207 GLU A CD  
+1445 O  OE1 . GLU A 185 ? 0.6568 0.5098 0.2680 -0.1734 0.0685  -0.0608 207 GLU A OE1 
+1446 O  OE2 . GLU A 185 ? 0.7676 0.4924 0.2767 -0.1440 0.0886  -0.0595 207 GLU A OE2 
+1447 N  N   . LEU A 186 ? 0.4144 0.2317 0.1295 -0.0752 0.0035  -0.0447 208 LEU A N   
+1448 C  CA  . LEU A 186 ? 0.3468 0.2229 0.1295 -0.1113 0.0144  -0.0450 208 LEU A CA  
+1449 C  C   . LEU A 186 ? 0.3972 0.2387 0.1368 -0.0849 -0.0043 -0.0435 208 LEU A C   
+1450 O  O   . LEU A 186 ? 0.3895 0.2125 0.1290 -0.0312 -0.0031 -0.0226 208 LEU A O   
+1451 C  CB  . LEU A 186 ? 0.3273 0.2103 0.1285 -0.0534 0.0229  -0.0371 208 LEU A CB  
+1452 C  CG  . LEU A 186 ? 0.3753 0.2040 0.1381 -0.0754 0.0233  -0.0282 208 LEU A CG  
+1453 C  CD1 . LEU A 186 ? 0.4050 0.2689 0.1403 -0.0732 0.0369  -0.0037 208 LEU A CD1 
+1454 C  CD2 . LEU A 186 ? 0.3867 0.2560 0.1642 -0.0804 -0.0266 -0.0424 208 LEU A CD2 
+1455 N  N   . ASP A 187 ? 0.4790 0.2619 0.1427 -0.0543 0.0073  -0.0281 209 ASP A N   
+1456 C  CA  A ASP A 187 ? 0.5151 0.1516 0.1534 -0.0580 0.0097  -0.0155 209 ASP A CA  
+1457 C  CA  B ASP A 187 ? 0.5340 0.2443 0.1574 -0.0313 0.0167  -0.0391 209 ASP A CA  
+1458 C  C   . ASP A 187 ? 0.5314 0.2041 0.1565 -0.0664 0.0134  -0.0246 209 ASP A C   
+1459 O  O   . ASP A 187 ? 0.5115 0.2084 0.1555 -0.1116 0.0160  -0.0304 209 ASP A O   
+1460 C  CB  A ASP A 187 ? 0.5267 0.1608 0.1634 -0.0699 0.0151  0.0166  209 ASP A CB  
+1461 C  CB  B ASP A 187 ? 0.5971 0.3308 0.1722 0.0179  0.0310  -0.0540 209 ASP A CB  
+1462 C  CG  A ASP A 187 ? 0.5483 0.1902 0.1812 -0.0510 0.0168  0.0118  209 ASP A CG  
+1463 C  CG  B ASP A 187 ? 0.6475 0.3841 0.1975 0.0400  0.0407  -0.0776 209 ASP A CG  
+1464 O  OD1 A ASP A 187 ? 0.5537 0.2108 0.1849 -0.0556 0.0242  0.0283  209 ASP A OD1 
+1465 O  OD1 B ASP A 187 ? 0.6468 0.4135 0.1967 0.0503  0.0448  -0.0776 209 ASP A OD1 
+1466 O  OD2 A ASP A 187 ? 0.5434 0.1637 0.1944 -0.0397 0.0009  0.0020  209 ASP A OD2 
+1467 O  OD2 B ASP A 187 ? 0.7032 0.4112 0.2173 0.0489  0.0427  -0.0862 209 ASP A OD2 
+1468 N  N   . GLY A 188 ? 0.5298 0.2322 0.1703 -0.1093 0.0051  -0.0379 210 GLY A N   
+1469 C  CA  . GLY A 188 ? 0.5518 0.2423 0.1635 -0.0533 0.0287  -0.0283 210 GLY A CA  
+1470 C  C   . GLY A 188 ? 0.5689 0.2111 0.1674 -0.0691 0.0322  -0.0368 210 GLY A C   
+1471 O  O   . GLY A 188 ? 0.6592 0.2586 0.1818 0.0147  0.0575  -0.0262 210 GLY A O   
+1472 N  N   . TYR A 189 ? 0.4735 0.2187 0.1655 -0.0834 -0.0091 -0.0527 211 TYR A N   
+1473 C  CA  . TYR A 189 ? 0.4327 0.1997 0.1487 -0.0591 -0.0119 -0.0268 211 TYR A CA  
+1474 C  C   . TYR A 189 ? 0.3995 0.2064 0.1285 -0.0203 -0.0268 -0.0207 211 TYR A C   
+1475 O  O   . TYR A 189 ? 0.4390 0.2245 0.1284 -0.0358 -0.0654 -0.0023 211 TYR A O   
+1476 C  CB  . TYR A 189 ? 0.3783 0.2453 0.1563 -0.1025 -0.0301 0.0104  211 TYR A CB  
+1477 C  CG  . TYR A 189 ? 0.3667 0.2664 0.1765 -0.1392 -0.0419 0.0213  211 TYR A CG  
+1478 C  CD1 . TYR A 189 ? 0.3390 0.3734 0.1891 -0.1076 -0.0544 0.0035  211 TYR A CD1 
+1479 C  CD2 . TYR A 189 ? 0.3776 0.3377 0.1919 -0.1591 -0.0451 0.0315  211 TYR A CD2 
+1480 C  CE1 . TYR A 189 ? 0.3599 0.4704 0.2044 -0.0773 -0.0688 0.0061  211 TYR A CE1 
+1481 C  CE2 . TYR A 189 ? 0.4159 0.4314 0.2124 -0.0649 -0.0605 0.0095  211 TYR A CE2 
+1482 C  CZ  . TYR A 189 ? 0.3933 0.4758 0.2358 -0.1224 -0.0688 -0.0173 211 TYR A CZ  
+1483 O  OH  . TYR A 189 ? 0.3980 0.5241 0.2713 -0.1544 -0.0592 -0.0092 211 TYR A OH  
+1484 N  N   . TYR A 190 ? 0.3637 0.1681 0.1197 -0.0274 -0.0350 -0.0135 212 TYR A N   
+1485 C  CA  . TYR A 190 ? 0.3221 0.1933 0.1233 -0.0478 -0.0257 -0.0341 212 TYR A CA  
+1486 C  C   . TYR A 190 ? 0.3284 0.1528 0.1329 -0.0251 -0.0187 -0.0229 212 TYR A C   
+1487 O  O   . TYR A 190 ? 0.3764 0.1458 0.1483 0.0254  0.0113  -0.0310 212 TYR A O   
+1488 C  CB  . TYR A 190 ? 0.3567 0.1728 0.1224 0.0059  -0.0058 0.0040  212 TYR A CB  
+1489 C  CG  . TYR A 190 ? 0.3736 0.1802 0.1228 0.0221  -0.0206 -0.0172 212 TYR A CG  
+1490 C  CD1 . TYR A 190 ? 0.3471 0.1740 0.1233 0.0103  -0.0257 -0.0095 212 TYR A CD1 
+1491 C  CD2 . TYR A 190 ? 0.3250 0.1461 0.1125 0.0312  -0.0107 -0.0049 212 TYR A CD2 
+1492 C  CE1 . TYR A 190 ? 0.3748 0.1472 0.1245 0.0352  -0.0083 -0.0006 212 TYR A CE1 
+1493 C  CE2 . TYR A 190 ? 0.3557 0.2011 0.1178 -0.0093 -0.0069 0.0165  212 TYR A CE2 
+1494 C  CZ  . TYR A 190 ? 0.3995 0.1737 0.1267 0.0145  -0.0097 0.0260  212 TYR A CZ  
+1495 O  OH  . TYR A 190 ? 0.4257 0.2059 0.1497 0.0391  -0.0190 0.0113  212 TYR A OH  
+1496 N  N   . ASP A 191 ? 0.2867 0.1051 0.1219 0.0206  -0.0167 -0.0094 213 ASP A N   
+1497 C  CA  . ASP A 191 ? 0.2971 0.1168 0.1140 0.0068  -0.0070 -0.0083 213 ASP A CA  
+1498 C  C   . ASP A 191 ? 0.2902 0.1073 0.1206 0.0155  -0.0008 -0.0056 213 ASP A C   
+1499 O  O   . ASP A 191 ? 0.3024 0.1624 0.1326 0.0666  -0.0197 -0.0258 213 ASP A O   
+1500 C  CB  . ASP A 191 ? 0.3330 0.1391 0.1065 0.0251  -0.0186 -0.0301 213 ASP A CB  
+1501 C  CG  . ASP A 191 ? 0.3702 0.1475 0.1146 -0.0088 -0.0214 -0.0321 213 ASP A CG  
+1502 O  OD1 . ASP A 191 ? 0.4227 0.3162 0.1360 0.0167  -0.0201 -0.0766 213 ASP A OD1 
+1503 O  OD2 . ASP A 191 ? 0.3299 0.1854 0.1127 0.0124  -0.0456 -0.0072 213 ASP A OD2 
+1504 N  N   . PHE A 192 ? 0.2858 0.1311 0.1011 0.0266  -0.0144 -0.0037 214 PHE A N   
+1505 C  CA  . PHE A 192 ? 0.3095 0.1301 0.0984 0.0694  -0.0085 -0.0173 214 PHE A CA  
+1506 C  C   . PHE A 192 ? 0.2579 0.0901 0.0941 0.0356  -0.0008 -0.0076 214 PHE A C   
+1507 O  O   . PHE A 192 ? 0.2676 0.1719 0.0964 0.0756  -0.0002 -0.0088 214 PHE A O   
+1508 C  CB  . PHE A 192 ? 0.2951 0.1194 0.1061 0.0464  -0.0002 -0.0127 214 PHE A CB  
+1509 C  CG  . PHE A 192 ? 0.2837 0.1415 0.1086 0.0845  -0.0090 0.0003  214 PHE A CG  
+1510 C  CD1 . PHE A 192 ? 0.2825 0.1697 0.1046 0.0875  -0.0328 -0.0037 214 PHE A CD1 
+1511 C  CD2 . PHE A 192 ? 0.3397 0.1135 0.1212 0.0593  -0.0132 -0.0102 214 PHE A CD2 
+1512 C  CE1 . PHE A 192 ? 0.2702 0.1770 0.1279 0.0260  -0.0227 -0.0141 214 PHE A CE1 
+1513 C  CE2 . PHE A 192 ? 0.3213 0.1961 0.1157 0.0447  -0.0169 -0.0075 214 PHE A CE2 
+1514 C  CZ  . PHE A 192 ? 0.2702 0.1820 0.1237 0.0260  -0.0117 0.0290  214 PHE A CZ  
+1515 N  N   . ILE A 193 ? 0.2788 0.1478 0.0920 0.0413  -0.0230 0.0051  215 ILE A N   
+1516 C  CA  . ILE A 193 ? 0.2368 0.1216 0.0843 0.0663  -0.0241 -0.0043 215 ILE A CA  
+1517 C  C   . ILE A 193 ? 0.2599 0.0988 0.0708 0.0539  -0.0001 0.0022  215 ILE A C   
+1518 O  O   . ILE A 193 ? 0.2722 0.1101 0.0828 0.0417  0.0068  0.0114  215 ILE A O   
+1519 C  CB  . ILE A 193 ? 0.2594 0.1566 0.0998 0.0172  -0.0096 -0.0230 215 ILE A CB  
+1520 C  CG1 . ILE A 193 ? 0.3219 0.1229 0.1165 0.0614  -0.0004 -0.0092 215 ILE A CG1 
+1521 C  CG2 . ILE A 193 ? 0.2624 0.1880 0.0921 0.0096  -0.0128 -0.0373 215 ILE A CG2 
+1522 C  CD1 . ILE A 193 ? 0.2923 0.1358 0.1173 -0.0145 0.0036  -0.0422 215 ILE A CD1 
+1523 N  N   . ASN A 194 ? 0.2111 0.1197 0.0726 0.0238  -0.0098 -0.0190 216 ASN A N   
+1524 C  CA  . ASN A 194 ? 0.2714 0.1306 0.0720 0.0392  -0.0151 0.0003  216 ASN A CA  
+1525 C  C   . ASN A 194 ? 0.2411 0.0921 0.0698 0.0647  -0.0219 -0.0084 216 ASN A C   
+1526 O  O   . ASN A 194 ? 0.2481 0.1109 0.0731 0.0589  -0.0159 -0.0146 216 ASN A O   
+1527 C  CB  . ASN A 194 ? 0.2559 0.1521 0.0750 0.0600  -0.0079 0.0128  216 ASN A CB  
+1528 C  CG  . ASN A 194 ? 0.2814 0.1060 0.0790 0.0756  0.0095  0.0042  216 ASN A CG  
+1529 O  OD1 . ASN A 194 ? 0.3099 0.2076 0.0937 0.0931  -0.0207 -0.0082 216 ASN A OD1 
+1530 N  ND2 . ASN A 194 ? 0.3094 0.1514 0.0919 0.1121  0.0028  0.0014  216 ASN A ND2 
+1531 N  N   . PRO A 195 ? 0.2602 0.0962 0.0741 0.0373  -0.0056 0.0111  217 PRO A N   
+1532 C  CA  . PRO A 195 ? 0.2605 0.1004 0.0687 0.0359  0.0030  -0.0059 217 PRO A CA  
+1533 C  C   . PRO A 195 ? 0.2480 0.1278 0.0656 0.0355  -0.0077 -0.0081 217 PRO A C   
+1534 O  O   . PRO A 195 ? 0.2391 0.1389 0.0775 0.0276  0.0025  -0.0045 217 PRO A O   
+1535 C  CB  . PRO A 195 ? 0.2296 0.1586 0.0667 0.0377  0.0051  0.0057  217 PRO A CB  
+1536 C  CG  . PRO A 195 ? 0.2698 0.1469 0.0769 0.0575  -0.0031 0.0136  217 PRO A CG  
+1537 C  CD  . PRO A 195 ? 0.2941 0.1017 0.0816 0.0559  -0.0126 0.0025  217 PRO A CD  
+1538 N  N   . GLN A 196 ? 0.2134 0.1295 0.0685 0.0288  0.0091  -0.0088 218 GLN A N   
+1539 C  CA  . GLN A 196 ? 0.2296 0.1398 0.0697 0.0353  -0.0119 0.0076  218 GLN A CA  
+1540 C  C   . GLN A 196 ? 0.2816 0.1238 0.0724 0.0304  -0.0059 0.0036  218 GLN A C   
+1541 O  O   . GLN A 196 ? 0.2968 0.1715 0.0816 0.0442  -0.0204 0.0076  218 GLN A O   
+1542 C  CB  . GLN A 196 ? 0.2231 0.1255 0.0822 0.0510  -0.0279 0.0123  218 GLN A CB  
+1543 C  CG  . GLN A 196 ? 0.2285 0.1614 0.0960 0.0783  0.0166  0.0185  218 GLN A CG  
+1544 C  CD  . GLN A 196 ? 0.2339 0.1546 0.1029 0.0302  0.0225  0.0088  218 GLN A CD  
+1545 O  OE1 . GLN A 196 ? 0.2502 0.1722 0.1102 0.0449  0.0054  -0.0153 218 GLN A OE1 
+1546 N  NE2 . GLN A 196 ? 0.2694 0.1510 0.1127 0.0270  0.0092  -0.0205 218 GLN A NE2 
+1547 N  N   . PHE A 197 ? 0.2433 0.2108 0.0738 0.0483  0.0019  0.0231  219 PHE A N   
+1548 C  CA  . PHE A 197 ? 0.2120 0.2000 0.0789 0.0174  -0.0062 0.0334  219 PHE A CA  
+1549 C  C   . PHE A 197 ? 0.2196 0.2112 0.0921 -0.0087 -0.0273 -0.0102 219 PHE A C   
+1550 O  O   . PHE A 197 ? 0.2627 0.1700 0.1010 0.0675  -0.0064 -0.0352 219 PHE A O   
+1551 C  CB  . PHE A 197 ? 0.2418 0.2077 0.0805 0.0612  -0.0071 0.0087  219 PHE A CB  
+1552 C  CG  . PHE A 197 ? 0.2214 0.1798 0.0790 0.0514  -0.0003 0.0127  219 PHE A CG  
+1553 C  CD1 . PHE A 197 ? 0.2584 0.1502 0.0819 0.0662  -0.0097 -0.0037 219 PHE A CD1 
+1554 C  CD2 . PHE A 197 ? 0.2254 0.1741 0.0819 0.0315  -0.0137 0.0027  219 PHE A CD2 
+1555 C  CE1 . PHE A 197 ? 0.2671 0.1308 0.0774 0.0660  -0.0088 0.0045  219 PHE A CE1 
+1556 C  CE2 . PHE A 197 ? 0.2705 0.1809 0.0751 0.0344  -0.0103 0.0029  219 PHE A CE2 
+1557 C  CZ  . PHE A 197 ? 0.3218 0.1941 0.0931 0.0933  -0.0076 -0.0031 219 PHE A CZ  
+1558 N  N   . TYR A 198 ? 0.2450 0.2164 0.0903 0.0506  -0.0297 -0.0425 220 TYR A N   
+1559 C  CA  . TYR A 198 ? 0.2136 0.1926 0.0888 0.0484  -0.0028 -0.0414 220 TYR A CA  
+1560 C  C   . TYR A 198 ? 0.2396 0.1887 0.0996 0.0496  -0.0231 -0.0154 220 TYR A C   
+1561 O  O   . TYR A 198 ? 0.2513 0.1363 0.1023 0.0282  -0.0165 -0.0234 220 TYR A O   
+1562 C  CB  . TYR A 198 ? 0.2444 0.1611 0.0869 0.0363  -0.0008 -0.0411 220 TYR A CB  
+1563 C  CG  . TYR A 198 ? 0.2447 0.1533 0.0883 0.0594  0.0009  -0.0352 220 TYR A CG  
+1564 C  CD1 . TYR A 198 ? 0.2606 0.1297 0.0913 0.0596  0.0063  -0.0264 220 TYR A CD1 
+1565 C  CD2 . TYR A 198 ? 0.2587 0.1624 0.0730 0.0430  0.0209  -0.0066 220 TYR A CD2 
+1566 C  CE1 . TYR A 198 ? 0.2281 0.1532 0.0854 0.0654  -0.0039 -0.0117 220 TYR A CE1 
+1567 C  CE2 . TYR A 198 ? 0.2778 0.1592 0.0786 0.0399  -0.0050 -0.0224 220 TYR A CE2 
+1568 C  CZ  . TYR A 198 ? 0.2288 0.1842 0.0653 0.0288  0.0097  -0.0201 220 TYR A CZ  
+1569 O  OH  . TYR A 198 ? 0.2811 0.1495 0.0737 0.0441  -0.0009 0.0015  220 TYR A OH  
+1570 N  N   . ASN A 199 ? 0.2300 0.1944 0.1003 0.0232  -0.0114 -0.0273 221 ASN A N   
+1571 C  CA  . ASN A 199 ? 0.2625 0.1870 0.0912 0.0430  -0.0159 -0.0171 221 ASN A CA  
+1572 C  C   . ASN A 199 ? 0.2815 0.1855 0.0904 0.0352  0.0114  -0.0161 221 ASN A C   
+1573 O  O   . ASN A 199 ? 0.2999 0.2366 0.0909 0.0599  0.0259  -0.0149 221 ASN A O   
+1574 C  CB  . ASN A 199 ? 0.2875 0.1778 0.0943 0.0947  0.0094  -0.0031 221 ASN A CB  
+1575 C  CG  . ASN A 199 ? 0.2951 0.1625 0.1124 0.0547  -0.0129 -0.0079 221 ASN A CG  
+1576 O  OD1 . ASN A 199 ? 0.2812 0.1918 0.1226 0.0315  -0.0288 -0.0074 221 ASN A OD1 
+1577 N  ND2 . ASN A 199 ? 0.3211 0.1581 0.1165 0.0766  -0.0020 -0.0006 221 ASN A ND2 
+1578 N  N   . GLN A 200 ? 0.2871 0.1695 0.1008 0.0611  0.0058  -0.0163 222 GLN A N   
+1579 C  CA  . GLN A 200 ? 0.2469 0.1843 0.1024 0.0024  0.0017  -0.0179 222 GLN A CA  
+1580 C  C   . GLN A 200 ? 0.2925 0.2025 0.0994 0.0540  -0.0118 0.0000  222 GLN A C   
+1581 O  O   . GLN A 200 ? 0.3256 0.2289 0.0933 0.0749  -0.0173 -0.0011 222 GLN A O   
+1582 C  CB  . GLN A 200 ? 0.2625 0.1672 0.1052 -0.0169 0.0070  -0.0247 222 GLN A CB  
+1583 C  CG  . GLN A 200 ? 0.2846 0.1799 0.1082 0.0292  0.0218  -0.0122 222 GLN A CG  
+1584 C  CD  . GLN A 200 ? 0.2650 0.2160 0.1061 0.0176  0.0095  -0.0252 222 GLN A CD  
+1585 O  OE1 . GLN A 200 ? 0.3065 0.2325 0.1223 0.0824  0.0113  0.0133  222 GLN A OE1 
+1586 N  NE2 . GLN A 200 ? 0.2759 0.1884 0.0969 0.0262  0.0274  -0.0232 222 GLN A NE2 
+1587 N  N   . GLY A 201 ? 0.3054 0.2537 0.1018 0.0220  -0.0389 0.0084  223 GLY A N   
+1588 C  CA  . GLY A 201 ? 0.3051 0.2167 0.0990 -0.0327 -0.0344 0.0221  223 GLY A CA  
+1589 C  C   . GLY A 201 ? 0.3317 0.2564 0.0924 0.0325  -0.0345 -0.0080 223 GLY A C   
+1590 O  O   . GLY A 201 ? 0.3221 0.2721 0.0956 0.0433  -0.0203 -0.0010 223 GLY A O   
+1591 N  N   . GLY A 202 ? 0.3203 0.2870 0.1087 0.0977  -0.0383 -0.0137 224 GLY A N   
+1592 C  CA  . GLY A 202 ? 0.2445 0.2989 0.0939 0.0663  -0.0328 -0.0188 224 GLY A CA  
+1593 C  C   . GLY A 202 ? 0.2717 0.2896 0.0998 0.0874  -0.0259 0.0118  224 GLY A C   
+1594 O  O   . GLY A 202 ? 0.3358 0.3422 0.1236 0.0957  -0.0272 0.0359  224 GLY A O   
+1595 N  N   . ASP A 203 ? 0.2520 0.2757 0.1087 0.0606  -0.0216 0.0140  225 ASP A N   
+1596 C  CA  . ASP A 203 ? 0.2854 0.2438 0.1224 0.0333  -0.0155 0.0190  225 ASP A CA  
+1597 C  C   . ASP A 203 ? 0.2627 0.2535 0.1111 0.0452  -0.0161 0.0088  225 ASP A C   
+1598 O  O   . ASP A 203 ? 0.2784 0.3077 0.1312 0.1213  0.0003  0.0140  225 ASP A O   
+1599 C  CB  . ASP A 203 ? 0.2724 0.2597 0.1413 0.0789  0.0016  0.0157  225 ASP A CB  
+1600 C  CG  . ASP A 203 ? 0.3471 0.3803 0.1515 0.1057  -0.0041 0.0203  225 ASP A CG  
+1601 O  OD1 . ASP A 203 ? 0.3651 0.3577 0.1734 0.0711  -0.0230 -0.0177 225 ASP A OD1 
+1602 O  OD2 . ASP A 203 ? 0.3775 0.4097 0.1514 0.0650  0.0141  0.0079  225 ASP A OD2 
+1603 N  N   . GLY A 204 ? 0.3074 0.2761 0.1028 0.0981  -0.0022 0.0059  226 GLY A N   
+1604 C  CA  . GLY A 204 ? 0.3520 0.2666 0.1270 0.1451  -0.0401 -0.0090 226 GLY A CA  
+1605 C  C   . GLY A 204 ? 0.4284 0.2636 0.1394 0.1375  -0.0303 -0.0067 226 GLY A C   
+1606 O  O   . GLY A 204 ? 0.4162 0.2694 0.1578 0.0926  -0.0409 0.0003  226 GLY A O   
+1607 N  N   . LEU A 205 ? 0.4268 0.2715 0.1415 0.1352  -0.0545 -0.0384 227 LEU A N   
+1608 C  CA  . LEU A 205 ? 0.4820 0.2534 0.1558 0.1541  -0.0571 -0.0379 227 LEU A CA  
+1609 C  C   . LEU A 205 ? 0.5291 0.2820 0.1642 0.1581  -0.0540 -0.0353 227 LEU A C   
+1610 O  O   . LEU A 205 ? 0.5320 0.3350 0.1688 0.1994  -0.0316 -0.0070 227 LEU A O   
+1611 C  CB  . LEU A 205 ? 0.5278 0.2292 0.1608 0.1505  -0.0514 -0.0296 227 LEU A CB  
+1612 C  CG  . LEU A 205 ? 0.5317 0.2317 0.1689 0.1642  -0.0461 -0.0291 227 LEU A CG  
+1613 C  CD1 . LEU A 205 ? 0.5738 0.2480 0.1791 0.1575  -0.0445 -0.0359 227 LEU A CD1 
+1614 C  CD2 . LEU A 205 ? 0.5290 0.3557 0.1717 0.1879  -0.0526 -0.0274 227 LEU A CD2 
+1615 N  N   . TRP A 206 ? 0.5602 0.3404 0.1777 0.1615  -0.0695 -0.0378 228 TRP A N   
+1616 C  CA  . TRP A 206 ? 0.5851 0.3408 0.1838 0.1610  -0.0765 -0.0319 228 TRP A CA  
+1617 C  C   . TRP A 206 ? 0.6597 0.3503 0.2046 0.2168  -0.0638 -0.0221 228 TRP A C   
+1618 O  O   . TRP A 206 ? 0.7409 0.3011 0.2085 0.2018  -0.0269 -0.0039 228 TRP A O   
+1619 C  CB  . TRP A 206 ? 0.5969 0.3222 0.1846 0.1320  -0.0868 -0.0180 228 TRP A CB  
+1620 C  CG  . TRP A 206 ? 0.6069 0.3805 0.1869 0.1394  -0.0782 -0.0076 228 TRP A CG  
+1621 C  CD1 . TRP A 206 ? 0.6624 0.4186 0.2027 0.1363  -0.0838 0.0062  228 TRP A CD1 
+1622 C  CD2 . TRP A 206 ? 0.5728 0.3687 0.1703 0.1388  -0.0563 -0.0130 228 TRP A CD2 
+1623 N  NE1 . TRP A 206 ? 0.6537 0.4329 0.1936 0.1289  -0.0699 0.0078  228 TRP A NE1 
+1624 C  CE2 . TRP A 206 ? 0.6075 0.3948 0.1750 0.1418  -0.0429 -0.0190 228 TRP A CE2 
+1625 C  CE3 . TRP A 206 ? 0.5504 0.3823 0.1559 0.0820  -0.0437 0.0227  228 TRP A CE3 
+1626 C  CZ2 . TRP A 206 ? 0.5737 0.4129 0.1740 0.1504  -0.0399 0.0118  228 TRP A CZ2 
+1627 C  CZ3 . TRP A 206 ? 0.5492 0.4131 0.1558 0.0470  -0.0122 0.0607  228 TRP A CZ3 
+1628 C  CH2 . TRP A 206 ? 0.5675 0.4200 0.1606 0.0842  -0.0360 0.0310  228 TRP A CH2 
+1629 N  N   . ILE A 207 ? 0.5991 0.3327 0.2006 0.2133  -0.0805 -0.0318 229 ILE A N   
+1630 C  CA  . ILE A 207 ? 0.6525 0.4045 0.2264 0.2496  -0.0896 -0.0373 229 ILE A CA  
+1631 C  C   . ILE A 207 ? 0.7426 0.4747 0.2730 0.2736  -0.1150 -0.0253 229 ILE A C   
+1632 O  O   . ILE A 207 ? 0.7136 0.4715 0.2923 0.2519  -0.1567 -0.0413 229 ILE A O   
+1633 C  CB  . ILE A 207 ? 0.6351 0.3986 0.2263 0.2726  -0.0680 -0.0560 229 ILE A CB  
+1634 C  CG1 . ILE A 207 ? 0.6210 0.3443 0.1946 0.1298  -0.0530 -0.0642 229 ILE A CG1 
+1635 C  CG2 . ILE A 207 ? 0.6739 0.4542 0.2556 0.2851  -0.0553 -0.0741 229 ILE A CG2 
+1636 C  CD1 . ILE A 207 ? 0.6332 0.3614 0.1763 0.1163  -0.0511 -0.0045 229 ILE A CD1 
+1637 N  N   . GLU A 208 ? 0.8009 0.4999 0.2876 0.2386  -0.1172 0.0162  230 GLU A N   
+1638 C  CA  . GLU A 208 ? 0.8310 0.5952 0.3304 0.2549  -0.0908 0.0386  230 GLU A CA  
+1639 C  C   . GLU A 208 ? 0.7968 0.6484 0.3691 0.3393  -0.0941 0.0121  230 GLU A C   
+1640 O  O   . GLU A 208 ? 0.7621 0.5945 0.3905 0.3711  -0.0735 0.0220  230 GLU A O   
+1641 C  CB  . GLU A 208 ? 0.8742 0.5864 0.3300 0.2256  -0.0612 0.0667  230 GLU A CB  
+1642 C  CG  . GLU A 208 ? 0.9253 0.5733 0.3258 0.2076  -0.0231 0.0698  230 GLU A CG  
+1643 C  CD  . GLU A 208 ? 0.9369 0.5705 0.3250 0.2464  -0.0065 0.0841  230 GLU A CD  
+1644 O  OE1 . GLU A 208 ? 0.9600 0.6540 0.3292 0.2120  -0.0214 0.0890  230 GLU A OE1 
+1645 O  OE2 . GLU A 208 ? 0.9039 0.4607 0.3435 0.2989  0.0202  0.0759  230 GLU A OE2 
+1646 N  N   . GLY A 209 ? 0.8193 0.7754 0.3984 0.3634  -0.0829 -0.0296 231 GLY A N   
+1647 C  CA  . GLY A 209 ? 0.8350 0.8312 0.4172 0.4066  -0.0585 -0.0383 231 GLY A CA  
+1648 C  C   . GLY A 209 ? 0.8190 0.8842 0.4264 0.4504  -0.0575 -0.0379 231 GLY A C   
+1649 O  O   . GLY A 209 ? 0.7770 0.9242 0.4354 0.4552  -0.0664 -0.0587 231 GLY A O   
+1650 N  N   . VAL A 210 ? 0.7960 0.8952 0.4178 0.4816  -0.0530 -0.0465 232 VAL A N   
+1651 C  CA  . VAL A 210 ? 0.7508 0.8621 0.3972 0.4620  -0.0477 -0.0567 232 VAL A CA  
+1652 C  C   . VAL A 210 ? 0.6875 0.8828 0.3650 0.3901  -0.0519 -0.0457 232 VAL A C   
+1653 O  O   . VAL A 210 ? 0.6858 0.9342 0.3747 0.3455  -0.0695 -0.0918 232 VAL A O   
+1654 C  CB  . VAL A 210 ? 0.7804 0.8535 0.4099 0.4032  -0.0539 -0.0717 232 VAL A CB  
+1655 C  CG1 . VAL A 210 ? 0.8194 0.8732 0.4175 0.3961  -0.0467 -0.0688 232 VAL A CG1 
+1656 C  CG2 . VAL A 210 ? 0.7545 0.8204 0.4089 0.3818  -0.0595 -0.0791 232 VAL A CG2 
+1657 N  N   . GLY A 211 ? 0.5507 0.8028 0.3090 0.3194  -0.0580 0.0123  233 GLY A N   
+1658 C  CA  . GLY A 211 ? 0.4420 0.6676 0.2447 0.2577  -0.0386 0.0285  233 GLY A CA  
+1659 C  C   . GLY A 211 ? 0.3805 0.5621 0.2035 0.2259  -0.0107 0.0434  233 GLY A C   
+1660 O  O   . GLY A 211 ? 0.4939 0.5274 0.2000 0.1987  0.0064  0.0721  233 GLY A O   
+1661 N  N   . TRP A 212 ? 0.3624 0.5023 0.1686 0.1821  -0.0099 0.0361  234 TRP A N   
+1662 C  CA  . TRP A 212 ? 0.3349 0.3855 0.1281 0.1401  -0.0201 -0.0064 234 TRP A CA  
+1663 C  C   . TRP A 212 ? 0.3538 0.4109 0.1318 0.1259  -0.0238 0.0032  234 TRP A C   
+1664 O  O   . TRP A 212 ? 0.3728 0.4233 0.1444 0.0856  -0.0696 -0.0026 234 TRP A O   
+1665 C  CB  . TRP A 212 ? 0.3078 0.4133 0.1271 0.1344  -0.0064 -0.0145 234 TRP A CB  
+1666 C  CG  . TRP A 212 ? 0.3432 0.3404 0.1215 0.1171  0.0011  -0.0320 234 TRP A CG  
+1667 C  CD1 . TRP A 212 ? 0.3792 0.3174 0.1138 0.0550  0.0186  -0.0366 234 TRP A CD1 
+1668 C  CD2 . TRP A 212 ? 0.3699 0.2650 0.1059 0.0609  0.0290  -0.0148 234 TRP A CD2 
+1669 N  NE1 . TRP A 212 ? 0.4249 0.2802 0.1231 0.0738  0.0426  -0.0084 234 TRP A NE1 
+1670 C  CE2 . TRP A 212 ? 0.3928 0.2768 0.1234 0.0893  0.0327  -0.0251 234 TRP A CE2 
+1671 C  CE3 . TRP A 212 ? 0.3852 0.2832 0.1142 0.0715  0.0394  -0.0094 234 TRP A CE3 
+1672 C  CZ2 . TRP A 212 ? 0.3694 0.2525 0.1146 0.0988  0.0359  0.0015  234 TRP A CZ2 
+1673 C  CZ3 . TRP A 212 ? 0.3981 0.2147 0.1165 0.0501  0.0568  0.0058  234 TRP A CZ3 
+1674 C  CH2 . TRP A 212 ? 0.3761 0.2541 0.1174 0.0548  0.0440  -0.0063 234 TRP A CH2 
+1675 N  N   . ILE A 213 ? 0.3362 0.4265 0.1401 0.1607  0.0048  0.0243  235 ILE A N   
+1676 C  CA  . ILE A 213 ? 0.3377 0.4103 0.1417 0.1883  0.0044  0.0004  235 ILE A CA  
+1677 C  C   . ILE A 213 ? 0.3253 0.4176 0.1382 0.1714  -0.0090 -0.0004 235 ILE A C   
+1678 O  O   . ILE A 213 ? 0.3531 0.4220 0.1617 0.2261  -0.0344 -0.0402 235 ILE A O   
+1679 C  CB  . ILE A 213 ? 0.3877 0.4030 0.1569 0.1883  -0.0006 -0.0346 235 ILE A CB  
+1680 C  CG1 . ILE A 213 ? 0.4192 0.4611 0.1687 0.2070  -0.0087 -0.0348 235 ILE A CG1 
+1681 C  CG2 . ILE A 213 ? 0.4098 0.4142 0.1672 0.1809  0.0310  -0.0249 235 ILE A CG2 
+1682 C  CD1 . ILE A 213 ? 0.4646 0.5643 0.1893 0.2138  -0.0299 -0.0408 235 ILE A CD1 
+1683 N  N   . ALA A 214 ? 0.3049 0.4041 0.1220 0.1140  -0.0049 0.0181  236 ALA A N   
+1684 C  CA  . ALA A 214 ? 0.2393 0.4005 0.1094 0.0711  -0.0173 -0.0020 236 ALA A CA  
+1685 C  C   . ALA A 214 ? 0.2936 0.3036 0.1002 0.0721  -0.0149 -0.0242 236 ALA A C   
+1686 O  O   . ALA A 214 ? 0.2866 0.3534 0.1042 0.0873  -0.0105 -0.0096 236 ALA A O   
+1687 C  CB  . ALA A 214 ? 0.2571 0.4564 0.1394 0.1519  -0.0217 -0.0188 236 ALA A CB  
+1688 N  N   . GLN A 215 ? 0.2651 0.2873 0.0895 0.0365  -0.0312 -0.0324 237 GLN A N   
+1689 C  CA  . GLN A 215 ? 0.2871 0.2633 0.0917 0.0537  -0.0332 -0.0264 237 GLN A CA  
+1690 C  C   . GLN A 215 ? 0.2959 0.2230 0.1018 0.0837  -0.0126 -0.0402 237 GLN A C   
+1691 O  O   . GLN A 215 ? 0.3367 0.2718 0.1135 0.0811  -0.0005 -0.0469 237 GLN A O   
+1692 C  CB  . GLN A 215 ? 0.2448 0.2611 0.0844 0.0478  -0.0281 -0.0288 237 GLN A CB  
+1693 C  CG  . GLN A 215 ? 0.2867 0.1926 0.0897 0.0632  -0.0306 -0.0282 237 GLN A CG  
+1694 C  CD  . GLN A 215 ? 0.2573 0.2088 0.0957 -0.0022 -0.0170 -0.0030 237 GLN A CD  
+1695 O  OE1 . GLN A 215 ? 0.2475 0.2189 0.1185 0.0479  -0.0084 -0.0265 237 GLN A OE1 
+1696 N  NE2 . GLN A 215 ? 0.2644 0.2263 0.1013 0.0463  -0.0177 -0.0311 237 GLN A NE2 
+1697 N  N   . ASN A 216 ? 0.2936 0.2904 0.1057 0.0718  -0.0353 -0.0436 238 ASN A N   
+1698 C  CA  . ASN A 216 ? 0.3102 0.2952 0.1237 0.0362  -0.0293 -0.0804 238 ASN A CA  
+1699 C  C   . ASN A 216 ? 0.3324 0.3380 0.1361 0.0439  -0.0395 -0.0858 238 ASN A C   
+1700 O  O   . ASN A 216 ? 0.3781 0.3553 0.1453 0.0380  -0.0359 -0.0931 238 ASN A O   
+1701 C  CB  . ASN A 216 ? 0.3248 0.3173 0.1309 0.0085  -0.0183 -0.0944 238 ASN A CB  
+1702 C  CG  . ASN A 216 ? 0.3335 0.3782 0.1523 0.0527  -0.0318 -0.1022 238 ASN A CG  
+1703 O  OD1 . ASN A 216 ? 0.3341 0.3607 0.1411 0.0338  -0.0266 -0.0960 238 ASN A OD1 
+1704 N  ND2 . ASN A 216 ? 0.3628 0.4216 0.1796 0.0934  -0.0569 -0.1126 238 ASN A ND2 
+1705 N  N   . ASN A 217 ? 0.2661 0.3334 0.1408 0.0506  -0.0289 -0.0618 239 ASN A N   
+1706 C  CA  . ASN A 217 ? 0.2350 0.3713 0.1437 0.0772  -0.0259 -0.0423 239 ASN A CA  
+1707 C  C   . ASN A 217 ? 0.2720 0.3839 0.1547 0.0706  -0.0455 -0.0539 239 ASN A C   
+1708 O  O   . ASN A 217 ? 0.2810 0.3529 0.1695 0.0398  -0.0449 -0.0449 239 ASN A O   
+1709 C  CB  . ASN A 217 ? 0.2516 0.4451 0.1490 0.0882  -0.0331 -0.0097 239 ASN A CB  
+1710 C  CG  . ASN A 217 ? 0.2621 0.5286 0.1634 0.0956  -0.0339 0.0126  239 ASN A CG  
+1711 O  OD1 . ASN A 217 ? 0.2229 0.6187 0.1935 0.0171  -0.0487 0.0266  239 ASN A OD1 
+1712 N  ND2 . ASN A 217 ? 0.3365 0.5939 0.1876 0.1808  -0.0462 -0.0332 239 ASN A ND2 
+1713 N  N   . ASP A 218 ? 0.3115 0.3647 0.1559 0.0278  -0.0424 -0.0552 240 ASP A N   
+1714 C  CA  . ASP A 218 ? 0.3079 0.3568 0.1690 0.0572  -0.0397 -0.0659 240 ASP A CA  
+1715 C  C   . ASP A 218 ? 0.3614 0.3773 0.1683 0.1340  -0.0340 -0.0753 240 ASP A C   
+1716 O  O   . ASP A 218 ? 0.4480 0.5735 0.1992 0.2529  -0.0336 -0.0202 240 ASP A O   
+1717 C  CB  . ASP A 218 ? 0.3408 0.4107 0.1867 0.0370  -0.0318 -0.0912 240 ASP A CB  
+1718 C  CG  . ASP A 218 ? 0.4085 0.4312 0.2119 0.0700  -0.0313 -0.0603 240 ASP A CG  
+1719 O  OD1 . ASP A 218 ? 0.4159 0.4813 0.1933 0.1016  -0.0698 -0.0719 240 ASP A OD1 
+1720 O  OD2 . ASP A 218 ? 0.5118 0.4544 0.2465 0.1012  -0.0328 -0.0486 240 ASP A OD2 
+1721 N  N   . ALA A 219 ? 0.3267 0.3491 0.1576 0.1131  -0.0594 -0.0719 241 ALA A N   
+1722 C  CA  . ALA A 219 ? 0.3187 0.3618 0.1573 0.0994  -0.0621 -0.0774 241 ALA A CA  
+1723 C  C   . ALA A 219 ? 0.3407 0.3903 0.1757 0.1134  -0.0449 -0.0572 241 ALA A C   
+1724 O  O   . ALA A 219 ? 0.4102 0.4296 0.2175 0.1086  -0.0421 -0.0545 241 ALA A O   
+1725 C  CB  . ALA A 219 ? 0.3582 0.4019 0.1668 0.1121  -0.0844 -0.0700 241 ALA A CB  
+1726 N  N   . LEU A 220 ? 0.3057 0.3463 0.1531 0.0606  -0.0429 -0.0535 242 LEU A N   
+1727 C  CA  . LEU A 220 ? 0.2743 0.3236 0.1355 0.0663  -0.0573 -0.0070 242 LEU A CA  
+1728 C  C   . LEU A 220 ? 0.2836 0.3267 0.1214 0.0728  -0.0428 -0.0099 242 LEU A C   
+1729 O  O   . LEU A 220 ? 0.2791 0.3650 0.1154 0.0804  -0.0266 -0.0223 242 LEU A O   
+1730 C  CB  . LEU A 220 ? 0.3282 0.3341 0.1446 0.0161  -0.0794 0.0153  242 LEU A CB  
+1731 C  CG  . LEU A 220 ? 0.3827 0.3778 0.1546 0.0117  -0.0904 0.0329  242 LEU A CG  
+1732 C  CD1 . LEU A 220 ? 0.4430 0.4711 0.1646 0.0299  -0.1048 0.0389  242 LEU A CD1 
+1733 C  CD2 . LEU A 220 ? 0.4032 0.4281 0.1611 0.0361  -0.0954 0.0334  242 LEU A CD2 
+1734 N  N   . LYS A 221 ? 0.2763 0.3256 0.1129 0.0558  -0.0356 0.0121  243 LYS A N   
+1735 C  CA  . LYS A 221 ? 0.3083 0.2739 0.1145 0.0629  -0.0512 -0.0371 243 LYS A CA  
+1736 C  C   . LYS A 221 ? 0.3005 0.2732 0.1175 0.0793  -0.0313 -0.0361 243 LYS A C   
+1737 O  O   . LYS A 221 ? 0.2577 0.2882 0.1188 0.0920  -0.0275 -0.0192 243 LYS A O   
+1738 C  CB  . LYS A 221 ? 0.2765 0.2779 0.1209 0.0697  -0.0227 -0.0353 243 LYS A CB  
+1739 C  CG  . LYS A 221 ? 0.2519 0.3172 0.1091 0.0642  0.0024  -0.0335 243 LYS A CG  
+1740 C  CD  . LYS A 221 ? 0.2328 0.2658 0.0912 0.0340  0.0292  -0.0437 243 LYS A CD  
+1741 C  CE  . LYS A 221 ? 0.2943 0.2928 0.1105 0.0627  -0.0037 -0.0603 243 LYS A CE  
+1742 N  NZ  . LYS A 221 ? 0.2880 0.2761 0.0956 0.0702  0.0120  -0.0286 243 LYS A NZ  
+1743 N  N   . GLU A 222 ? 0.2914 0.3042 0.1168 0.0933  -0.0004 -0.0369 244 GLU A N   
+1744 C  CA  . GLU A 222 ? 0.2879 0.2746 0.1191 0.1345  -0.0073 -0.0317 244 GLU A CA  
+1745 C  C   . GLU A 222 ? 0.2809 0.2448 0.1144 0.0965  -0.0314 -0.0115 244 GLU A C   
+1746 O  O   . GLU A 222 ? 0.3278 0.2595 0.1171 0.1223  -0.0251 -0.0331 244 GLU A O   
+1747 C  CB  . GLU A 222 ? 0.3615 0.3044 0.1402 0.1931  -0.0145 -0.0202 244 GLU A CB  
+1748 C  CG  . GLU A 222 ? 0.3452 0.3154 0.1530 0.1892  -0.0297 -0.0428 244 GLU A CG  
+1749 C  CD  . GLU A 222 ? 0.3900 0.3397 0.1732 0.1785  -0.0335 -0.0524 244 GLU A CD  
+1750 O  OE1 . GLU A 222 ? 0.3893 0.3937 0.1944 0.2033  -0.0460 -0.0444 244 GLU A OE1 
+1751 O  OE2 . GLU A 222 ? 0.3952 0.3508 0.1841 0.1845  -0.0420 -0.0538 244 GLU A OE2 
+1752 N  N   . GLU A 223 ? 0.3178 0.2676 0.1055 0.0359  -0.0273 0.0002  245 GLU A N   
+1753 C  CA  . GLU A 223 ? 0.3563 0.2290 0.1164 0.0680  -0.0496 0.0020  245 GLU A CA  
+1754 C  C   . GLU A 223 ? 0.3415 0.2073 0.1096 0.0765  -0.0154 -0.0160 245 GLU A C   
+1755 O  O   . GLU A 223 ? 0.3442 0.2417 0.1061 0.0969  -0.0067 -0.0199 245 GLU A O   
+1756 C  CB  . GLU A 223 ? 0.3850 0.2790 0.1453 0.1096  -0.0802 -0.0128 245 GLU A CB  
+1757 C  CG  . GLU A 223 ? 0.3994 0.3627 0.1823 0.1124  -0.1129 -0.0225 245 GLU A CG  
+1758 C  CD  . GLU A 223 ? 0.4497 0.4772 0.2270 0.2047  -0.1081 -0.0366 245 GLU A CD  
+1759 O  OE1 . GLU A 223 ? 0.4604 0.5197 0.2441 0.2037  -0.1257 -0.0988 245 GLU A OE1 
+1760 O  OE2 . GLU A 223 ? 0.5225 0.5613 0.2328 0.1861  -0.1064 0.0049  245 GLU A OE2 
+1761 N  N   . PHE A 224 ? 0.3373 0.2207 0.1098 0.0691  -0.0011 -0.0255 246 PHE A N   
+1762 C  CA  . PHE A 224 ? 0.3388 0.2140 0.1123 0.0704  0.0033  -0.0298 246 PHE A CA  
+1763 C  C   . PHE A 224 ? 0.2998 0.2156 0.1016 0.0680  -0.0111 -0.0304 246 PHE A C   
+1764 O  O   . PHE A 224 ? 0.2835 0.2230 0.0967 0.0804  -0.0187 -0.0153 246 PHE A O   
+1765 C  CB  . PHE A 224 ? 0.3477 0.1913 0.1134 0.0793  0.0047  -0.0079 246 PHE A CB  
+1766 C  CG  . PHE A 224 ? 0.3444 0.1607 0.1152 0.0896  0.0242  0.0134  246 PHE A CG  
+1767 C  CD1 . PHE A 224 ? 0.3781 0.1348 0.1218 0.0769  0.0233  0.0219  246 PHE A CD1 
+1768 C  CD2 . PHE A 224 ? 0.3566 0.1975 0.1108 0.0776  0.0179  -0.0021 246 PHE A CD2 
+1769 C  CE1 . PHE A 224 ? 0.3490 0.1477 0.1194 0.0925  -0.0063 -0.0222 246 PHE A CE1 
+1770 C  CE2 . PHE A 224 ? 0.3115 0.2205 0.1078 0.0521  0.0341  -0.0159 246 PHE A CE2 
+1771 C  CZ  . PHE A 224 ? 0.2983 0.1954 0.1168 0.0451  -0.0042 -0.0236 246 PHE A CZ  
+1772 N  N   . ILE A 225 ? 0.2984 0.1845 0.0921 0.0661  -0.0016 -0.0225 247 ILE A N   
+1773 C  CA  . ILE A 225 ? 0.3229 0.1690 0.0978 0.1065  -0.0120 -0.0136 247 ILE A CA  
+1774 C  C   . ILE A 225 ? 0.2646 0.1909 0.0923 0.0888  -0.0033 -0.0202 247 ILE A C   
+1775 O  O   . ILE A 225 ? 0.3129 0.2071 0.0928 0.0881  0.0125  -0.0056 247 ILE A O   
+1776 C  CB  . ILE A 225 ? 0.2972 0.1705 0.1002 0.0901  -0.0155 -0.0302 247 ILE A CB  
+1777 C  CG1 . ILE A 225 ? 0.3061 0.1976 0.0998 0.0795  -0.0161 -0.0352 247 ILE A CG1 
+1778 C  CG2 . ILE A 225 ? 0.3183 0.2090 0.1062 0.1005  -0.0129 -0.0323 247 ILE A CG2 
+1779 C  CD1 . ILE A 225 ? 0.3384 0.2066 0.1074 0.0843  -0.0220 -0.0352 247 ILE A CD1 
+1780 N  N   . TYR A 226 ? 0.2479 0.2237 0.1060 0.1244  -0.0267 -0.0150 248 TYR A N   
+1781 C  CA  . TYR A 226 ? 0.2817 0.2187 0.1145 0.1016  -0.0209 0.0023  248 TYR A CA  
+1782 C  C   . TYR A 226 ? 0.2828 0.2034 0.1059 0.0935  -0.0409 -0.0207 248 TYR A C   
+1783 O  O   . TYR A 226 ? 0.3100 0.2195 0.1068 0.1024  -0.0259 -0.0081 248 TYR A O   
+1784 C  CB  . TYR A 226 ? 0.3283 0.2573 0.1312 0.1400  -0.0162 0.0244  248 TYR A CB  
+1785 C  CG  . TYR A 226 ? 0.3339 0.2626 0.1405 0.1352  -0.0132 -0.0080 248 TYR A CG  
+1786 C  CD1 . TYR A 226 ? 0.3168 0.2725 0.1347 0.1679  -0.0043 0.0045  248 TYR A CD1 
+1787 C  CD2 . TYR A 226 ? 0.3985 0.1892 0.1409 0.1221  -0.0332 -0.0140 248 TYR A CD2 
+1788 C  CE1 . TYR A 226 ? 0.3572 0.2355 0.1432 0.1661  0.0109  0.0014  248 TYR A CE1 
+1789 C  CE2 . TYR A 226 ? 0.4049 0.2312 0.1466 0.1584  -0.0398 -0.0071 248 TYR A CE2 
+1790 C  CZ  . TYR A 226 ? 0.3952 0.2262 0.1524 0.1659  -0.0127 -0.0052 248 TYR A CZ  
+1791 O  OH  . TYR A 226 ? 0.4506 0.2321 0.1680 0.1708  0.0081  -0.0059 248 TYR A OH  
+1792 N  N   . TYR A 227 ? 0.3148 0.2385 0.1021 0.0987  -0.0273 -0.0259 249 TYR A N   
+1793 C  CA  . TYR A 227 ? 0.2939 0.2140 0.1065 0.0935  -0.0539 -0.0214 249 TYR A CA  
+1794 C  C   . TYR A 227 ? 0.2977 0.2079 0.1059 0.0499  -0.0328 -0.0107 249 TYR A C   
+1795 O  O   . TYR A 227 ? 0.3061 0.1750 0.1034 0.0909  -0.0098 0.0228  249 TYR A O   
+1796 C  CB  . TYR A 227 ? 0.3290 0.2843 0.1328 0.1367  -0.0477 -0.0010 249 TYR A CB  
+1797 C  CG  . TYR A 227 ? 0.3660 0.2493 0.1769 0.1419  -0.0678 0.0066  249 TYR A CG  
+1798 C  CD1 . TYR A 227 ? 0.4073 0.2367 0.1959 0.1353  -0.0990 -0.0093 249 TYR A CD1 
+1799 C  CD2 . TYR A 227 ? 0.4186 0.2962 0.2088 0.1403  -0.0959 0.0189  249 TYR A CD2 
+1800 C  CE1 . TYR A 227 ? 0.4866 0.2835 0.2306 0.1589  -0.1144 -0.0055 249 TYR A CE1 
+1801 C  CE2 . TYR A 227 ? 0.4694 0.3151 0.2329 0.1376  -0.1243 0.0144  249 TYR A CE2 
+1802 C  CZ  . TYR A 227 ? 0.5061 0.2712 0.2593 0.1655  -0.1121 -0.0017 249 TYR A CZ  
+1803 O  OH  . TYR A 227 ? 0.6493 0.3616 0.3101 0.2438  -0.1010 -0.0062 249 TYR A OH  
+1804 N  N   . ILE A 228 ? 0.2777 0.2057 0.1038 0.0720  -0.0231 -0.0089 250 ILE A N   
+1805 C  CA  . ILE A 228 ? 0.2969 0.1658 0.1027 0.0647  -0.0078 0.0009  250 ILE A CA  
+1806 C  C   . ILE A 228 ? 0.2432 0.1833 0.0998 0.0677  -0.0154 0.0119  250 ILE A C   
+1807 O  O   . ILE A 228 ? 0.2553 0.1655 0.0997 0.0769  0.0044  0.0143  250 ILE A O   
+1808 C  CB  . ILE A 228 ? 0.3052 0.1819 0.1117 0.0729  0.0003  -0.0034 250 ILE A CB  
+1809 C  CG1 . ILE A 228 ? 0.3545 0.2012 0.1492 0.0740  0.0087  -0.0232 250 ILE A CG1 
+1810 C  CG2 . ILE A 228 ? 0.3113 0.2150 0.1028 0.0839  0.0082  0.0165  250 ILE A CG2 
+1811 C  CD1 . ILE A 228 ? 0.3846 0.2884 0.1743 0.0451  0.0006  -0.0170 250 ILE A CD1 
+1812 N  N   . ALA A 229 ? 0.2596 0.1763 0.0940 0.0666  -0.0035 0.0066  251 ALA A N   
+1813 C  CA  . ALA A 229 ? 0.3058 0.1678 0.0969 0.1095  -0.0070 -0.0136 251 ALA A CA  
+1814 C  C   . ALA A 229 ? 0.3148 0.1837 0.1005 0.1209  -0.0114 -0.0139 251 ALA A C   
+1815 O  O   . ALA A 229 ? 0.3368 0.1982 0.0999 0.1050  -0.0045 0.0070  251 ALA A O   
+1816 C  CB  . ALA A 229 ? 0.3090 0.1726 0.1005 0.0985  -0.0191 -0.0192 251 ALA A CB  
+1817 N  N   . ASP A 230 ? 0.3300 0.1440 0.1146 0.1055  -0.0147 -0.0104 252 ASP A N   
+1818 C  CA  . ASP A 230 ? 0.2737 0.1360 0.1209 0.1014  -0.0089 -0.0009 252 ASP A CA  
+1819 C  C   . ASP A 230 ? 0.3399 0.1943 0.1123 0.1085  -0.0064 0.0142  252 ASP A C   
+1820 O  O   . ASP A 230 ? 0.3476 0.1800 0.1128 0.1192  0.0004  0.0145  252 ASP A O   
+1821 C  CB  . ASP A 230 ? 0.3400 0.1598 0.1333 0.1162  -0.0075 0.0086  252 ASP A CB  
+1822 C  CG  . ASP A 230 ? 0.3628 0.2004 0.1224 0.1480  -0.0007 0.0009  252 ASP A CG  
+1823 O  OD1 . ASP A 230 ? 0.4480 0.2092 0.1347 0.1562  0.0286  0.0142  252 ASP A OD1 
+1824 O  OD2 . ASP A 230 ? 0.4349 0.1576 0.1274 0.1058  0.0211  0.0011  252 ASP A OD2 
+1825 N  N   . SER A 231 ? 0.3264 0.1653 0.1155 0.1223  0.0081  0.0096  253 SER A N   
+1826 C  CA  . SER A 231 ? 0.3302 0.1923 0.1095 0.0975  0.0218  0.0148  253 SER A CA  
+1827 C  C   . SER A 231 ? 0.2801 0.1747 0.1085 0.1019  0.0134  0.0341  253 SER A C   
+1828 O  O   . SER A 231 ? 0.3413 0.1841 0.1080 0.0681  0.0206  0.0372  253 SER A O   
+1829 C  CB  . SER A 231 ? 0.3299 0.1972 0.1180 0.1402  0.0114  0.0149  253 SER A CB  
+1830 O  OG  . SER A 231 ? 0.3415 0.2328 0.1114 0.1260  0.0002  0.0176  253 SER A OG  
+1831 N  N   . LEU A 232 ? 0.2893 0.1519 0.1042 0.0949  -0.0025 0.0203  254 LEU A N   
+1832 C  CA  . LEU A 232 ? 0.2589 0.1462 0.1121 0.1012  -0.0014 0.0166  254 LEU A CA  
+1833 C  C   . LEU A 232 ? 0.2874 0.1073 0.1095 0.0759  0.0038  0.0013  254 LEU A C   
+1834 O  O   . LEU A 232 ? 0.2738 0.1599 0.1113 0.0602  0.0135  0.0155  254 LEU A O   
+1835 C  CB  . LEU A 232 ? 0.2440 0.1505 0.1106 0.0740  -0.0243 0.0260  254 LEU A CB  
+1836 C  CG  . LEU A 232 ? 0.3007 0.1943 0.1039 0.0908  0.0105  0.0256  254 LEU A CG  
+1837 C  CD1 . LEU A 232 ? 0.3033 0.2159 0.0916 0.0929  -0.0128 -0.0016 254 LEU A CD1 
+1838 C  CD2 . LEU A 232 ? 0.3778 0.1403 0.1155 0.0739  0.0144  0.0197  254 LEU A CD2 
+1839 N  N   . ILE A 233 ? 0.3355 0.1307 0.1070 0.0947  0.0206  0.0069  255 ILE A N   
+1840 C  CA  . ILE A 233 ? 0.3452 0.1430 0.1081 0.0913  0.0199  -0.0028 255 ILE A CA  
+1841 C  C   . ILE A 233 ? 0.3499 0.1459 0.1075 0.0560  0.0136  0.0030  255 ILE A C   
+1842 O  O   . ILE A 233 ? 0.3902 0.1852 0.1120 0.0477  0.0268  0.0239  255 ILE A O   
+1843 C  CB  . ILE A 233 ? 0.3475 0.1327 0.1105 0.0934  0.0442  0.0174  255 ILE A CB  
+1844 C  CG1 . ILE A 233 ? 0.3755 0.1469 0.1163 0.0799  0.0471  0.0021  255 ILE A CG1 
+1845 C  CG2 . ILE A 233 ? 0.3530 0.1776 0.1282 0.0929  0.0186  0.0417  255 ILE A CG2 
+1846 C  CD1 . ILE A 233 ? 0.3880 0.1746 0.1325 0.1071  0.0191  -0.0168 255 ILE A CD1 
+1847 N  N   . ASN A 234 ? 0.3910 0.1410 0.1087 0.0989  0.0164  0.0060  256 ASN A N   
+1848 C  CA  . ASN A 234 ? 0.4126 0.2019 0.1147 0.0715  0.0277  0.0208  256 ASN A CA  
+1849 C  C   . ASN A 234 ? 0.3995 0.1559 0.1232 0.0881  0.0321  0.0046  256 ASN A C   
+1850 O  O   . ASN A 234 ? 0.3954 0.1717 0.1318 0.0669  0.0206  0.0331  256 ASN A O   
+1851 C  CB  . ASN A 234 ? 0.3725 0.1687 0.1129 0.0472  0.0337  0.0003  256 ASN A CB  
+1852 C  CG  . ASN A 234 ? 0.4004 0.1551 0.1267 0.1035  0.0418  0.0229  256 ASN A CG  
+1853 O  OD1 . ASN A 234 ? 0.3748 0.1697 0.1368 0.0876  0.0455  0.0022  256 ASN A OD1 
+1854 N  ND2 . ASN A 234 ? 0.3825 0.1787 0.1295 0.1216  0.0319  0.0281  256 ASN A ND2 
+1855 N  N   . GLY A 235 ? 0.3568 0.1517 0.1188 0.0897  0.0240  0.0114  257 GLY A N   
+1856 C  CA  . GLY A 235 ? 0.3579 0.1666 0.1070 0.0896  0.0296  0.0226  257 GLY A CA  
+1857 C  C   . GLY A 235 ? 0.3527 0.1836 0.1106 0.0940  0.0239  0.0199  257 GLY A C   
+1858 O  O   . GLY A 235 ? 0.4091 0.2416 0.1136 0.0386  0.0285  0.0307  257 GLY A O   
+1859 N  N   . THR A 236 ? 0.3411 0.1881 0.1029 0.0866  0.0128  0.0249  258 THR A N   
+1860 C  CA  . THR A 236 ? 0.3559 0.1519 0.1124 0.0766  0.0311  0.0289  258 THR A CA  
+1861 C  C   . THR A 236 ? 0.3696 0.1672 0.1122 0.0658  0.0250  0.0309  258 THR A C   
+1862 O  O   . THR A 236 ? 0.3584 0.1797 0.1160 0.0930  0.0216  0.0329  258 THR A O   
+1863 C  CB  . THR A 236 ? 0.3891 0.2283 0.1247 0.1273  0.0088  0.0265  258 THR A CB  
+1864 O  OG1 . THR A 236 ? 0.4306 0.1992 0.1359 0.1374  0.0232  0.0219  258 THR A OG1 
+1865 C  CG2 . THR A 236 ? 0.4107 0.2720 0.1342 0.1212  -0.0028 0.0361  258 THR A CG2 
+1866 N  N   . ARG A 237 ? 0.3945 0.2263 0.1122 0.0989  0.0192  0.0128  259 ARG A N   
+1867 C  CA  . ARG A 237 ? 0.4073 0.2476 0.1119 0.0828  0.0013  0.0124  259 ARG A CA  
+1868 C  C   . ARG A 237 ? 0.4169 0.2241 0.1281 0.1280  0.0055  0.0216  259 ARG A C   
+1869 O  O   . ARG A 237 ? 0.4726 0.2208 0.1523 0.1184  -0.0053 0.0063  259 ARG A O   
+1870 C  CB  . ARG A 237 ? 0.4350 0.2039 0.1164 0.0847  -0.0118 0.0005  259 ARG A CB  
+1871 C  CG  . ARG A 237 ? 0.4707 0.2210 0.1340 0.1301  -0.0258 -0.0104 259 ARG A CG  
+1872 C  CD  . ARG A 237 ? 0.3694 0.2116 0.1334 0.1308  -0.0497 -0.0301 259 ARG A CD  
+1873 N  NE  . ARG A 237 ? 0.3960 0.2584 0.1571 0.1593  -0.0415 -0.0275 259 ARG A NE  
+1874 C  CZ  . ARG A 237 ? 0.3729 0.2624 0.1785 0.1799  -0.0516 -0.0362 259 ARG A CZ  
+1875 N  NH1 . ARG A 237 ? 0.3816 0.2231 0.1641 0.1616  -0.0363 -0.0260 259 ARG A NH1 
+1876 N  NH2 . ARG A 237 ? 0.4496 0.3058 0.2143 0.2144  -0.0247 -0.0158 259 ARG A NH2 
+1877 N  N   . ASN A 238 ? 0.4237 0.2547 0.1384 0.1330  0.0167  0.0372  260 ASN A N   
+1878 C  CA  . ASN A 238 ? 0.4134 0.2711 0.1462 0.1147  0.0289  0.0592  260 ASN A CA  
+1879 C  C   . ASN A 238 ? 0.3861 0.2555 0.1438 0.1410  0.0407  0.0519  260 ASN A C   
+1880 O  O   . ASN A 238 ? 0.4065 0.2098 0.1464 0.1260  0.0739  0.0450  260 ASN A O   
+1881 C  CB  . ASN A 238 ? 0.4229 0.3350 0.1571 0.1014  0.0476  0.0782  260 ASN A CB  
+1882 C  CG  . ASN A 238 ? 0.4339 0.2746 0.1516 0.1033  0.0457  0.0564  260 ASN A CG  
+1883 O  OD1 . ASN A 238 ? 0.4213 0.2704 0.1653 0.1053  0.0198  0.0359  260 ASN A OD1 
+1884 N  ND2 . ASN A 238 ? 0.3931 0.1849 0.1546 0.0998  0.0712  0.0281  260 ASN A ND2 
+1885 N  N   . TYR A 239 ? 0.4032 0.2357 0.1429 0.0757  0.0425  0.0625  261 TYR A N   
+1886 C  CA  . TYR A 239 ? 0.3831 0.1640 0.1346 0.0844  0.0293  0.0358  261 TYR A CA  
+1887 C  C   . TYR A 239 ? 0.4132 0.1841 0.1479 0.0866  0.0337  0.0099  261 TYR A C   
+1888 O  O   . TYR A 239 ? 0.4200 0.1750 0.1531 0.1098  0.0366  0.0285  261 TYR A O   
+1889 C  CB  . TYR A 239 ? 0.3446 0.2408 0.1565 0.0662  0.0326  0.0338  261 TYR A CB  
+1890 C  CG  . TYR A 239 ? 0.3642 0.2077 0.1831 0.0766  0.0266  0.0220  261 TYR A CG  
+1891 C  CD1 . TYR A 239 ? 0.3790 0.2466 0.2013 0.0014  0.0331  0.0249  261 TYR A CD1 
+1892 C  CD2 . TYR A 239 ? 0.3639 0.2426 0.2055 0.0879  0.0356  0.0265  261 TYR A CD2 
+1893 C  CE1 . TYR A 239 ? 0.4401 0.2760 0.2202 0.0022  0.0398  0.0475  261 TYR A CE1 
+1894 C  CE2 . TYR A 239 ? 0.3974 0.3315 0.2167 -0.0314 0.0389  0.0374  261 TYR A CE2 
+1895 C  CZ  . TYR A 239 ? 0.4881 0.3698 0.2347 -0.0538 0.0510  0.0270  261 TYR A CZ  
+1896 O  OH  . TYR A 239 ? 0.5973 0.4740 0.2567 -0.0384 0.0645  0.0389  261 TYR A OH  
+1897 N  N   . HIS A 240 ? 0.4006 0.1955 0.1432 0.0734  0.0355  -0.0069 262 HIS A N   
+1898 C  CA  . HIS A 240 ? 0.4036 0.1527 0.1704 0.0445  0.0685  -0.0107 262 HIS A CA  
+1899 C  C   . HIS A 240 ? 0.4089 0.1429 0.1532 0.0851  0.0670  0.0143  262 HIS A C   
+1900 O  O   . HIS A 240 ? 0.4373 0.1795 0.1580 0.0208  0.0768  -0.0224 262 HIS A O   
+1901 C  CB  . HIS A 240 ? 0.4056 0.1829 0.2158 0.0635  0.0441  -0.0409 262 HIS A CB  
+1902 C  CG  . HIS A 240 ? 0.4581 0.3009 0.2797 0.0369  0.0494  -0.0378 262 HIS A CG  
+1903 N  ND1 . HIS A 240 ? 0.4923 0.4366 0.3070 0.0379  0.0227  -0.0822 262 HIS A ND1 
+1904 C  CD2 . HIS A 240 ? 0.4901 0.3504 0.3066 0.0593  0.0233  -0.0703 262 HIS A CD2 
+1905 C  CE1 . HIS A 240 ? 0.5153 0.4322 0.3134 0.0713  0.0159  -0.1046 262 HIS A CE1 
+1906 N  NE2 . HIS A 240 ? 0.5310 0.4117 0.3150 0.0913  0.0333  -0.0861 262 HIS A NE2 
+1907 N  N   . LYS A 241 ? 0.3573 0.1257 0.1263 0.0600  0.0416  0.0236  263 LYS A N   
+1908 C  CA  . LYS A 241 ? 0.3537 0.1566 0.1154 0.0847  0.0162  0.0031  263 LYS A CA  
+1909 C  C   . LYS A 241 ? 0.3251 0.1425 0.1095 0.0456  -0.0014 0.0219  263 LYS A C   
+1910 O  O   . LYS A 241 ? 0.3274 0.2499 0.1201 0.0498  0.0067  0.0350  263 LYS A O   
+1911 C  CB  . LYS A 241 ? 0.3440 0.1666 0.1253 0.0431  -0.0169 -0.0167 263 LYS A CB  
+1912 C  CG  . LYS A 241 ? 0.3765 0.1698 0.1586 0.0910  -0.0041 -0.0274 263 LYS A CG  
+1913 C  CD  . LYS A 241 ? 0.4786 0.2672 0.1870 0.0781  -0.0066 -0.0561 263 LYS A CD  
+1914 C  CE  . LYS A 241 ? 0.5001 0.2230 0.2141 0.0426  -0.0087 -0.0899 263 LYS A CE  
+1915 N  NZ  . LYS A 241 ? 0.5919 0.3303 0.2401 0.0790  0.0173  -0.0454 263 LYS A NZ  
+1916 N  N   . ILE A 242 ? 0.2893 0.1750 0.0890 0.0430  0.0046  0.0079  264 ILE A N   
+1917 C  CA  . ILE A 242 ? 0.3301 0.1688 0.0916 0.0829  0.0011  -0.0037 264 ILE A CA  
+1918 C  C   . ILE A 242 ? 0.3544 0.1972 0.1026 0.0425  0.0189  0.0203  264 ILE A C   
+1919 O  O   . ILE A 242 ? 0.3608 0.1726 0.0987 0.0449  0.0060  0.0214  264 ILE A O   
+1920 C  CB  . ILE A 242 ? 0.2944 0.1569 0.0978 0.0447  0.0150  -0.0017 264 ILE A CB  
+1921 C  CG1 . ILE A 242 ? 0.3565 0.1732 0.0940 0.0376  0.0202  0.0119  264 ILE A CG1 
+1922 C  CG2 . ILE A 242 ? 0.2911 0.2086 0.1083 0.0337  0.0008  -0.0056 264 ILE A CG2 
+1923 C  CD1 . ILE A 242 ? 0.3545 0.1503 0.1143 0.0744  0.0116  0.0286  264 ILE A CD1 
+1924 N  N   . PRO A 243 ? 0.3085 0.1719 0.1136 0.0251  0.0274  0.0080  265 PRO A N   
+1925 C  CA  . PRO A 243 ? 0.3478 0.1998 0.1270 0.0708  0.0437  0.0116  265 PRO A CA  
+1926 C  C   . PRO A 243 ? 0.3791 0.1395 0.1197 0.0521  0.0330  -0.0174 265 PRO A C   
+1927 O  O   . PRO A 243 ? 0.3405 0.1581 0.1031 0.0648  0.0343  0.0228  265 PRO A O   
+1928 C  CB  . PRO A 243 ? 0.3796 0.1976 0.1642 0.1148  0.0359  -0.0295 265 PRO A CB  
+1929 C  CG  . PRO A 243 ? 0.3770 0.2070 0.1587 0.0702  0.0070  -0.0696 265 PRO A CG  
+1930 C  CD  . PRO A 243 ? 0.2837 0.2171 0.1253 -0.0069 0.0176  -0.0280 265 PRO A CD  
+1931 N  N   . HIS A 244 ? 0.3536 0.1190 0.1223 0.0545  0.0088  -0.0026 266 HIS A N   
+1932 C  CA  . HIS A 244 ? 0.3641 0.0996 0.1044 0.0404  0.0319  0.0050  266 HIS A CA  
+1933 C  C   . HIS A 244 ? 0.3397 0.1125 0.1032 0.0704  0.0020  0.0066  266 HIS A C   
+1934 O  O   . HIS A 244 ? 0.3385 0.1144 0.0963 0.0556  -0.0043 -0.0003 266 HIS A O   
+1935 C  CB  . HIS A 244 ? 0.3579 0.1733 0.1136 0.1252  0.0399  0.0211  266 HIS A CB  
+1936 C  CG  . HIS A 244 ? 0.3549 0.1615 0.1128 0.1168  0.0455  0.0213  266 HIS A CG  
+1937 N  ND1 . HIS A 244 ? 0.3852 0.1617 0.1212 0.1001  0.0415  0.0029  266 HIS A ND1 
+1938 C  CD2 . HIS A 244 ? 0.3951 0.1537 0.1265 0.0489  0.0313  0.0069  266 HIS A CD2 
+1939 C  CE1 . HIS A 244 ? 0.3944 0.1627 0.1253 0.1128  0.0554  0.0194  266 HIS A CE1 
+1940 N  NE2 . HIS A 244 ? 0.3991 0.1626 0.1239 0.0927  0.0441  0.0244  266 HIS A NE2 
+1941 N  N   . ASP A 245 ? 0.3596 0.1211 0.0953 0.0741  0.0043  0.0016  267 ASP A N   
+1942 C  CA  . ASP A 245 ? 0.3301 0.0999 0.0973 0.0574  0.0165  0.0025  267 ASP A CA  
+1943 C  C   . ASP A 245 ? 0.3581 0.0916 0.0937 0.0207  0.0049  0.0008  267 ASP A C   
+1944 O  O   . ASP A 245 ? 0.3712 0.1250 0.0996 0.0579  0.0031  0.0083  267 ASP A O   
+1945 C  CB  . ASP A 245 ? 0.3838 0.1249 0.1205 0.0668  -0.0201 -0.0162 267 ASP A CB  
+1946 C  CG  . ASP A 245 ? 0.4018 0.1357 0.1446 0.0235  -0.0225 -0.0382 267 ASP A CG  
+1947 O  OD1 . ASP A 245 ? 0.4736 0.1879 0.1611 0.0127  0.0275  0.0170  267 ASP A OD1 
+1948 O  OD2 . ASP A 245 ? 0.4533 0.2508 0.1767 0.0305  -0.0219 -0.0731 267 ASP A OD2 
+1949 N  N   . LYS A 246 ? 0.3431 0.1263 0.0954 0.0535  0.0166  -0.0081 268 LYS A N   
+1950 C  CA  . LYS A 246 ? 0.2933 0.0975 0.1105 0.0349  0.0171  -0.0165 268 LYS A CA  
+1951 C  C   . LYS A 246 ? 0.2575 0.1042 0.0948 0.0571  0.0083  -0.0171 268 LYS A C   
+1952 O  O   . LYS A 246 ? 0.3157 0.1602 0.0974 0.0723  -0.0046 -0.0144 268 LYS A O   
+1953 C  CB  . LYS A 246 ? 0.3209 0.1893 0.1291 0.0676  0.0017  -0.0078 268 LYS A CB  
+1954 C  CG  . LYS A 246 ? 0.3462 0.1781 0.1415 -0.0112 -0.0008 0.0089  268 LYS A CG  
+1955 C  CD  . LYS A 246 ? 0.4257 0.2045 0.1712 -0.0213 -0.0104 -0.0120 268 LYS A CD  
+1956 C  CE  . LYS A 246 ? 0.5470 0.2631 0.2110 -0.0020 -0.0094 -0.0029 268 LYS A CE  
+1957 N  NZ  . LYS A 246 ? 0.6660 0.4648 0.2322 0.1106  -0.0228 0.0009  268 LYS A NZ  
+1958 N  N   . LEU A 247 ? 0.2327 0.1458 0.0959 0.0656  -0.0026 -0.0046 269 LEU A N   
+1959 C  CA  . LEU A 247 ? 0.2178 0.1777 0.0918 0.0372  0.0039  -0.0205 269 LEU A CA  
+1960 C  C   . LEU A 247 ? 0.2533 0.1861 0.0804 0.0617  0.0080  -0.0110 269 LEU A C   
+1961 O  O   . LEU A 247 ? 0.2495 0.1441 0.0975 0.0543  0.0114  0.0039  269 LEU A O   
+1962 C  CB  . LEU A 247 ? 0.3026 0.1635 0.0915 0.0768  0.0283  -0.0026 269 LEU A CB  
+1963 C  CG  . LEU A 247 ? 0.3128 0.1494 0.0891 0.0875  0.0102  0.0087  269 LEU A CG  
+1964 C  CD1 . LEU A 247 ? 0.3331 0.1953 0.1023 0.1221  -0.0095 -0.0096 269 LEU A CD1 
+1965 C  CD2 . LEU A 247 ? 0.2787 0.1819 0.0843 0.0688  0.0038  0.0221  269 LEU A CD2 
+1966 N  N   . VAL A 248 ? 0.2758 0.1245 0.0826 0.0723  0.0106  -0.0074 270 VAL A N   
+1967 C  CA  . VAL A 248 ? 0.2830 0.1041 0.0750 0.0564  0.0005  0.0014  270 VAL A CA  
+1968 C  C   . VAL A 248 ? 0.2939 0.1412 0.0803 0.0471  -0.0037 -0.0143 270 VAL A C   
+1969 O  O   . VAL A 248 ? 0.2334 0.1377 0.1013 0.0518  -0.0093 -0.0218 270 VAL A O   
+1970 C  CB  . VAL A 248 ? 0.2375 0.1357 0.0675 0.0622  0.0029  0.0066  270 VAL A CB  
+1971 C  CG1 . VAL A 248 ? 0.2781 0.1169 0.0808 0.0806  0.0029  -0.0032 270 VAL A CG1 
+1972 C  CG2 . VAL A 248 ? 0.2345 0.1491 0.0745 0.0442  -0.0108 -0.0218 270 VAL A CG2 
+1973 N  N   . PHE A 249 ? 0.2984 0.1419 0.0783 0.0493  -0.0041 -0.0024 271 PHE A N   
+1974 C  CA  . PHE A 249 ? 0.2298 0.1059 0.0713 0.0534  0.0143  0.0182  271 PHE A CA  
+1975 C  C   . PHE A 249 ? 0.2148 0.1497 0.0668 0.0359  0.0190  0.0034  271 PHE A C   
+1976 O  O   . PHE A 249 ? 0.2198 0.1635 0.0711 0.0513  0.0022  -0.0246 271 PHE A O   
+1977 C  CB  . PHE A 249 ? 0.2549 0.1379 0.0774 0.0841  -0.0084 0.0034  271 PHE A CB  
+1978 C  CG  . PHE A 249 ? 0.2723 0.1387 0.0796 0.0485  -0.0028 0.0070  271 PHE A CG  
+1979 C  CD1 . PHE A 249 ? 0.2760 0.1483 0.0883 0.0281  -0.0186 0.0081  271 PHE A CD1 
+1980 C  CD2 . PHE A 249 ? 0.2834 0.1740 0.0906 0.0736  -0.0128 -0.0128 271 PHE A CD2 
+1981 C  CE1 . PHE A 249 ? 0.2579 0.1592 0.0810 0.0761  -0.0141 -0.0058 271 PHE A CE1 
+1982 C  CE2 . PHE A 249 ? 0.2989 0.1579 0.0935 0.0745  -0.0414 -0.0196 271 PHE A CE2 
+1983 C  CZ  . PHE A 249 ? 0.2897 0.2191 0.0978 0.0790  -0.0291 -0.0368 271 PHE A CZ  
+1984 N  N   . GLY A 250 ? 0.2152 0.1701 0.0730 0.0626  0.0122  0.0273  272 GLY A N   
+1985 C  CA  . GLY A 250 ? 0.2369 0.1576 0.0681 0.0562  0.0073  0.0112  272 GLY A CA  
+1986 C  C   . GLY A 250 ? 0.2632 0.1258 0.0804 0.0848  0.0143  0.0005  272 GLY A C   
+1987 O  O   . GLY A 250 ? 0.2650 0.1371 0.0762 0.0352  0.0116  -0.0187 272 GLY A O   
+1988 N  N   . LEU A 251 ? 0.2529 0.1401 0.0671 0.0217  -0.0167 0.0070  273 LEU A N   
+1989 C  CA  . LEU A 251 ? 0.2569 0.1633 0.0791 0.0121  -0.0334 -0.0038 273 LEU A CA  
+1990 C  C   . LEU A 251 ? 0.2066 0.1417 0.0827 -0.0135 -0.0138 -0.0197 273 LEU A C   
+1991 O  O   . LEU A 251 ? 0.2620 0.1305 0.0796 0.0499  -0.0317 -0.0200 273 LEU A O   
+1992 C  CB  . LEU A 251 ? 0.2807 0.2055 0.0861 0.0545  -0.0347 -0.0200 273 LEU A CB  
+1993 C  CG  . LEU A 251 ? 0.2556 0.1887 0.0960 0.0168  -0.0216 -0.0245 273 LEU A CG  
+1994 C  CD1 . LEU A 251 ? 0.2791 0.2630 0.1007 0.1149  -0.0241 -0.0187 273 LEU A CD1 
+1995 C  CD2 . LEU A 251 ? 0.2869 0.2400 0.0986 0.0526  -0.0227 -0.0191 273 LEU A CD2 
+1996 N  N   . PRO A 252 ? 0.2425 0.1330 0.0885 0.0349  -0.0269 -0.0227 274 PRO A N   
+1997 C  CA  . PRO A 252 ? 0.2710 0.0953 0.0996 0.0498  -0.0219 -0.0220 274 PRO A CA  
+1998 C  C   . PRO A 252 ? 0.2522 0.1335 0.1037 0.0638  -0.0264 -0.0290 274 PRO A C   
+1999 O  O   . PRO A 252 ? 0.2885 0.1584 0.1046 0.0431  -0.0295 -0.0018 274 PRO A O   
+2000 C  CB  . PRO A 252 ? 0.3620 0.1056 0.1122 0.0465  -0.0328 -0.0132 274 PRO A CB  
+2001 C  CG  . PRO A 252 ? 0.3678 0.1430 0.1120 0.0530  -0.0373 -0.0265 274 PRO A CG  
+2002 C  CD  . PRO A 252 ? 0.2113 0.1348 0.0952 0.0543  -0.0191 -0.0360 274 PRO A CD  
+2003 N  N   . SER A 253 ? 0.2281 0.1828 0.1137 0.0444  -0.0413 -0.0421 275 SER A N   
+2004 C  CA  A SER A 253 ? 0.2474 0.1167 0.1171 0.0561  -0.0190 -0.0433 275 SER A CA  
+2005 C  CA  B SER A 253 ? 0.2659 0.1403 0.1120 0.0575  -0.0273 -0.0419 275 SER A CA  
+2006 C  C   . SER A 253 ? 0.2437 0.1238 0.1140 0.0137  -0.0329 -0.0346 275 SER A C   
+2007 O  O   . SER A 253 ? 0.2901 0.2253 0.1260 0.0491  -0.0435 -0.0685 275 SER A O   
+2008 C  CB  A SER A 253 ? 0.2354 0.1369 0.1043 0.0835  -0.0005 -0.0282 275 SER A CB  
+2009 C  CB  B SER A 253 ? 0.2721 0.1545 0.1096 0.0720  -0.0094 -0.0201 275 SER A CB  
+2010 O  OG  A SER A 253 ? 0.2635 0.1367 0.1004 0.0282  -0.0346 -0.0358 275 SER A OG  
+2011 O  OG  B SER A 253 ? 0.3017 0.2240 0.1102 0.1249  -0.0093 -0.0207 275 SER A OG  
+2012 N  N   . ASN A 254 ? 0.2884 0.1265 0.1150 0.0015  -0.0296 -0.0392 276 ASN A N   
+2013 C  CA  . ASN A 254 ? 0.3288 0.1213 0.1179 0.0066  -0.0122 -0.0370 276 ASN A CA  
+2014 C  C   . ASN A 254 ? 0.2951 0.1291 0.1115 -0.0139 -0.0156 -0.0432 276 ASN A C   
+2015 O  O   . ASN A 254 ? 0.2635 0.1761 0.1032 -0.0347 -0.0128 -0.0281 276 ASN A O   
+2016 C  CB  . ASN A 254 ? 0.3313 0.2006 0.1127 0.0356  -0.0161 -0.0331 276 ASN A CB  
+2017 C  CG  . ASN A 254 ? 0.3273 0.1741 0.1225 0.0008  -0.0227 -0.0289 276 ASN A CG  
+2018 O  OD1 . ASN A 254 ? 0.3359 0.1553 0.1231 0.0113  -0.0123 -0.0243 276 ASN A OD1 
+2019 N  ND2 . ASN A 254 ? 0.2670 0.1763 0.1232 0.0013  -0.0357 -0.0268 276 ASN A ND2 
+2020 N  N   . ILE A 255 ? 0.3362 0.1455 0.1300 0.0123  -0.0134 -0.0526 277 ILE A N   
+2021 C  CA  . ILE A 255 ? 0.2940 0.1782 0.1266 -0.0382 -0.0199 -0.0628 277 ILE A CA  
+2022 C  C   . ILE A 255 ? 0.2955 0.2005 0.1208 0.0041  -0.0152 -0.0451 277 ILE A C   
+2023 O  O   . ILE A 255 ? 0.3217 0.1679 0.1315 0.0333  -0.0208 -0.0476 277 ILE A O   
+2024 C  CB  . ILE A 255 ? 0.3108 0.2515 0.1415 -0.0137 -0.0322 -0.0687 277 ILE A CB  
+2025 C  CG1 . ILE A 255 ? 0.3300 0.2816 0.1540 -0.0277 -0.0647 -0.0817 277 ILE A CG1 
+2026 C  CG2 . ILE A 255 ? 0.3098 0.2943 0.1496 0.0335  -0.0279 -0.0506 277 ILE A CG2 
+2027 C  CD1 . ILE A 255 ? 0.3780 0.3410 0.1639 -0.0213 -0.0857 -0.0591 277 ILE A CD1 
+2028 N  N   . ASP A 256 ? 0.2608 0.1636 0.1185 -0.0175 -0.0117 -0.0259 278 ASP A N   
+2029 C  CA  . ASP A 256 ? 0.3133 0.1867 0.1306 0.0088  -0.0084 -0.0249 278 ASP A CA  
+2030 C  C   . ASP A 256 ? 0.2948 0.1181 0.1249 -0.0066 0.0012  -0.0475 278 ASP A C   
+2031 O  O   . ASP A 256 ? 0.2897 0.1393 0.1345 0.0321  0.0109  -0.0310 278 ASP A O   
+2032 C  CB  . ASP A 256 ? 0.2732 0.1706 0.1366 -0.0042 -0.0099 -0.0319 278 ASP A CB  
+2033 C  CG  . ASP A 256 ? 0.2605 0.1484 0.1410 -0.0065 0.0059  -0.0306 278 ASP A CG  
+2034 O  OD1 . ASP A 256 ? 0.2995 0.1797 0.1502 0.0270  0.0079  -0.0396 278 ASP A OD1 
+2035 O  OD2 . ASP A 256 ? 0.3065 0.1984 0.1385 -0.0093 0.0112  -0.0345 278 ASP A OD2 
+2036 N  N   . ALA A 257 ? 0.2604 0.1100 0.1184 -0.0140 0.0121  -0.0481 279 ALA A N   
+2037 C  CA  . ALA A 257 ? 0.2764 0.1012 0.1137 -0.0391 0.0070  -0.0252 279 ALA A CA  
+2038 C  C   . ALA A 257 ? 0.2495 0.1567 0.1122 0.0049  0.0115  -0.0201 279 ALA A C   
+2039 O  O   . ALA A 257 ? 0.2585 0.1492 0.1175 0.0341  -0.0243 -0.0186 279 ALA A O   
+2040 C  CB  . ALA A 257 ? 0.2086 0.1863 0.1148 0.0327  -0.0064 -0.0389 279 ALA A CB  
+2041 N  N   . ALA A 258 ? 0.2883 0.1703 0.1050 0.0175  -0.0191 -0.0190 280 ALA A N   
+2042 C  CA  . ALA A 258 ? 0.2872 0.1791 0.1104 0.0160  -0.0107 -0.0135 280 ALA A CA  
+2043 C  C   . ALA A 258 ? 0.3016 0.1571 0.1063 -0.0653 -0.0132 -0.0170 280 ALA A C   
+2044 O  O   . ALA A 258 ? 0.2722 0.2121 0.1076 -0.0278 -0.0075 -0.0359 280 ALA A O   
+2045 C  CB  . ALA A 258 ? 0.2959 0.1287 0.1122 -0.0075 -0.0075 -0.0291 280 ALA A CB  
+2046 N  N   . ALA A 259 ? 0.3014 0.1666 0.1095 0.0087  -0.0061 -0.0183 281 ALA A N   
+2047 C  CA  . ALA A 259 ? 0.3458 0.1875 0.1160 0.0414  -0.0091 -0.0504 281 ALA A CA  
+2048 C  C   . ALA A 259 ? 0.3252 0.1683 0.1181 0.0536  -0.0107 -0.0494 281 ALA A C   
+2049 O  O   . ALA A 259 ? 0.3154 0.1748 0.1274 0.0300  0.0157  -0.0294 281 ALA A O   
+2050 C  CB  . ALA A 259 ? 0.3589 0.1927 0.1266 0.0862  -0.0342 -0.0476 281 ALA A CB  
+2051 N  N   . THR A 260 ? 0.3268 0.1436 0.1153 0.0804  -0.0262 -0.0326 282 THR A N   
+2052 C  CA  . THR A 260 ? 0.2985 0.1661 0.1147 -0.0016 -0.0062 -0.0336 282 THR A CA  
+2053 C  C   . THR A 260 ? 0.2671 0.1757 0.1168 0.0165  -0.0201 -0.0338 282 THR A C   
+2054 O  O   . THR A 260 ? 0.2432 0.1699 0.1192 0.0540  -0.0280 -0.0619 282 THR A O   
+2055 C  CB  . THR A 260 ? 0.3304 0.2149 0.1121 0.0671  -0.0133 -0.0494 282 THR A CB  
+2056 O  OG1 . THR A 260 ? 0.3589 0.1824 0.0983 0.0602  -0.0154 -0.0175 282 THR A OG1 
+2057 C  CG2 . THR A 260 ? 0.3244 0.2103 0.1149 0.0584  -0.0185 -0.0483 282 THR A CG2 
+2058 N  N   . GLY A 261 ? 0.2935 0.1804 0.1303 0.0723  -0.0062 -0.0566 283 GLY A N   
+2059 C  CA  . GLY A 261 ? 0.2593 0.1575 0.1279 0.1056  0.0024  -0.0233 283 GLY A CA  
+2060 C  C   . GLY A 261 ? 0.2850 0.1615 0.1194 0.0608  -0.0188 -0.0481 283 GLY A C   
+2061 O  O   . GLY A 261 ? 0.2689 0.1527 0.1156 0.0579  -0.0149 -0.0364 283 GLY A O   
+2062 N  N   . TYR A 262 ? 0.3091 0.1942 0.1153 0.0634  -0.0392 -0.0127 284 TYR A N   
+2063 C  CA  . TYR A 262 ? 0.2615 0.1809 0.1244 0.0387  -0.0314 -0.0613 284 TYR A CA  
+2064 C  C   . TYR A 262 ? 0.2584 0.1568 0.1079 0.0453  -0.0327 -0.0446 284 TYR A C   
+2065 O  O   . TYR A 262 ? 0.2540 0.2353 0.1042 0.0661  -0.0246 -0.0235 284 TYR A O   
+2066 C  CB  . TYR A 262 ? 0.2687 0.1759 0.1460 0.0341  -0.0443 -0.0496 284 TYR A CB  
+2067 C  CG  . TYR A 262 ? 0.2804 0.1908 0.1623 -0.0170 -0.0166 -0.0579 284 TYR A CG  
+2068 C  CD1 . TYR A 262 ? 0.2474 0.1916 0.1654 0.0413  -0.0108 -0.0586 284 TYR A CD1 
+2069 C  CD2 . TYR A 262 ? 0.2669 0.2120 0.1757 0.0283  0.0123  -0.0093 284 TYR A CD2 
+2070 C  CE1 . TYR A 262 ? 0.3133 0.2027 0.1785 0.0820  0.0159  -0.0177 284 TYR A CE1 
+2071 C  CE2 . TYR A 262 ? 0.2601 0.2079 0.1930 0.0221  0.0283  -0.0043 284 TYR A CE2 
+2072 C  CZ  . TYR A 262 ? 0.3279 0.2752 0.1981 0.1244  0.0614  0.0169  284 TYR A CZ  
+2073 O  OH  . TYR A 262 ? 0.4212 0.4092 0.2326 0.2111  0.0866  0.0558  284 TYR A OH  
+2074 N  N   . ILE A 263 ? 0.2945 0.1725 0.1127 0.0455  -0.0325 -0.0545 285 ILE A N   
+2075 C  CA  . ILE A 263 ? 0.2595 0.1879 0.1064 0.0412  -0.0513 -0.0410 285 ILE A CA  
+2076 C  C   . ILE A 263 ? 0.2349 0.2297 0.1135 0.0339  -0.0525 -0.0413 285 ILE A C   
+2077 O  O   . ILE A 263 ? 0.2685 0.2240 0.1143 0.0405  -0.0293 -0.0268 285 ILE A O   
+2078 C  CB  . ILE A 263 ? 0.2683 0.1754 0.1310 0.0406  -0.0494 -0.0214 285 ILE A CB  
+2079 C  CG1 . ILE A 263 ? 0.3138 0.1551 0.1421 0.0556  -0.0503 -0.0407 285 ILE A CG1 
+2080 C  CG2 . ILE A 263 ? 0.2891 0.2133 0.1320 0.0065  -0.0440 -0.0004 285 ILE A CG2 
+2081 C  CD1 . ILE A 263 ? 0.2936 0.2174 0.1527 0.0612  -0.0352 -0.0290 285 ILE A CD1 
+2082 N  N   . GLN A 264 ? 0.2484 0.2310 0.1277 0.0598  -0.0530 -0.0538 286 GLN A N   
+2083 C  CA  . GLN A 264 ? 0.2183 0.2938 0.1622 0.0325  -0.0469 -0.0882 286 GLN A CA  
+2084 C  C   . GLN A 264 ? 0.2305 0.2657 0.1634 -0.0119 -0.0139 -0.0637 286 GLN A C   
+2085 O  O   . GLN A 264 ? 0.2751 0.2727 0.1717 0.0228  -0.0139 -0.0385 286 GLN A O   
+2086 C  CB  . GLN A 264 ? 0.2642 0.3274 0.1947 0.0199  -0.0325 -0.1190 286 GLN A CB  
+2087 C  CG  . GLN A 264 ? 0.3086 0.3665 0.2260 0.0009  -0.0411 -0.1275 286 GLN A CG  
+2088 C  CD  . GLN A 264 ? 0.4338 0.4783 0.2667 0.0187  -0.0344 -0.0923 286 GLN A CD  
+2089 O  OE1 . GLN A 264 ? 0.5133 0.5140 0.2988 0.0751  -0.0256 -0.0886 286 GLN A OE1 
+2090 N  NE2 . GLN A 264 ? 0.4476 0.5008 0.2749 -0.0566 -0.0877 -0.1074 286 GLN A NE2 
+2091 N  N   . ASP A 265 ? 0.2202 0.2775 0.1626 0.0336  -0.0119 -0.0489 287 ASP A N   
+2092 C  CA  . ASP A 265 ? 0.2219 0.2963 0.1648 0.0389  -0.0314 -0.0421 287 ASP A CA  
+2093 C  C   . ASP A 265 ? 0.2770 0.2698 0.1479 0.0863  -0.0164 -0.0461 287 ASP A C   
+2094 O  O   . ASP A 265 ? 0.2543 0.3019 0.1370 0.0753  -0.0154 -0.0552 287 ASP A O   
+2095 C  CB  . ASP A 265 ? 0.2396 0.3078 0.1926 0.0229  -0.0524 -0.0565 287 ASP A CB  
+2096 C  CG  . ASP A 265 ? 0.2440 0.3754 0.2181 0.0694  -0.0675 -0.0748 287 ASP A CG  
+2097 O  OD1 . ASP A 265 ? 0.2077 0.3414 0.2364 0.0618  -0.0233 -0.0597 287 ASP A OD1 
+2098 O  OD2 . ASP A 265 ? 0.3066 0.4513 0.2335 0.1442  -0.0754 -0.0721 287 ASP A OD2 
+2099 N  N   . PRO A 266 ? 0.3041 0.2527 0.1424 0.0653  -0.0124 -0.0410 288 PRO A N   
+2100 C  CA  . PRO A 266 ? 0.3179 0.2462 0.1338 0.0698  -0.0062 -0.0396 288 PRO A CA  
+2101 C  C   . PRO A 266 ? 0.2640 0.2418 0.1377 0.0534  -0.0030 -0.0317 288 PRO A C   
+2102 O  O   . PRO A 266 ? 0.2646 0.2573 0.1316 0.0678  -0.0185 -0.0279 288 PRO A O   
+2103 C  CB  . PRO A 266 ? 0.3521 0.1922 0.1317 0.0652  -0.0147 -0.0519 288 PRO A CB  
+2104 C  CG  . PRO A 266 ? 0.3828 0.2667 0.1452 0.0752  -0.0284 -0.0431 288 PRO A CG  
+2105 C  CD  . PRO A 266 ? 0.3250 0.2545 0.1398 0.0576  -0.0147 -0.0476 288 PRO A CD  
+2106 N  N   . GLN A 267 ? 0.2444 0.2601 0.1475 0.0684  0.0065  -0.0394 289 GLN A N   
+2107 C  CA  . GLN A 267 ? 0.2763 0.2503 0.1641 0.0602  -0.0136 -0.0466 289 GLN A CA  
+2108 C  C   . GLN A 267 ? 0.2280 0.1992 0.1519 0.0221  -0.0259 -0.0293 289 GLN A C   
+2109 O  O   . GLN A 267 ? 0.2639 0.2174 0.1529 0.0383  -0.0222 -0.0222 289 GLN A O   
+2110 C  CB  . GLN A 267 ? 0.3155 0.3241 0.1890 0.1199  -0.0013 -0.0322 289 GLN A CB  
+2111 C  CG  . GLN A 267 ? 0.2898 0.3097 0.2061 0.0993  0.0268  -0.0509 289 GLN A CG  
+2112 C  CD  . GLN A 267 ? 0.3049 0.3651 0.2296 0.0887  0.0248  -0.0566 289 GLN A CD  
+2113 O  OE1 . GLN A 267 ? 0.3777 0.4425 0.2440 0.1391  0.0461  -0.0760 289 GLN A OE1 
+2114 N  NE2 . GLN A 267 ? 0.3238 0.3527 0.2386 0.0515  0.0080  -0.0433 289 GLN A NE2 
+2115 N  N   . ASP A 268 ? 0.2710 0.2508 0.1539 0.0723  -0.0459 -0.0553 290 ASP A N   
+2116 C  CA  . ASP A 268 ? 0.2658 0.2879 0.1484 0.0927  -0.0460 -0.0435 290 ASP A CA  
+2117 C  C   . ASP A 268 ? 0.2793 0.2547 0.1422 0.0689  -0.0100 -0.0365 290 ASP A C   
+2118 O  O   . ASP A 268 ? 0.3041 0.2364 0.1321 0.0854  -0.0137 -0.0180 290 ASP A O   
+2119 C  CB  . ASP A 268 ? 0.2802 0.2973 0.1714 0.0841  -0.0545 -0.0778 290 ASP A CB  
+2120 C  CG  . ASP A 268 ? 0.3269 0.3114 0.1900 0.1025  -0.0477 -0.0910 290 ASP A CG  
+2121 O  OD1 . ASP A 268 ? 0.3573 0.4251 0.2100 0.1231  -0.0704 -0.0968 290 ASP A OD1 
+2122 O  OD2 . ASP A 268 ? 0.3632 0.3558 0.2044 0.0957  -0.0385 -0.0849 290 ASP A OD2 
+2123 N  N   . LEU A 269 ? 0.2521 0.2336 0.1466 0.0849  -0.0130 -0.0395 291 LEU A N   
+2124 C  CA  . LEU A 269 ? 0.2655 0.2431 0.1414 0.0842  -0.0127 -0.0414 291 LEU A CA  
+2125 C  C   . LEU A 269 ? 0.2503 0.2407 0.1350 0.0575  -0.0268 -0.0331 291 LEU A C   
+2126 O  O   . LEU A 269 ? 0.2520 0.2228 0.1264 0.0973  -0.0057 -0.0071 291 LEU A O   
+2127 C  CB  . LEU A 269 ? 0.2225 0.2384 0.1427 0.0717  -0.0186 -0.0437 291 LEU A CB  
+2128 C  CG  . LEU A 269 ? 0.2757 0.2160 0.1487 0.0923  -0.0097 -0.0224 291 LEU A CG  
+2129 C  CD1 . LEU A 269 ? 0.2889 0.2017 0.1539 0.0479  -0.0079 -0.0338 291 LEU A CD1 
+2130 C  CD2 . LEU A 269 ? 0.2712 0.2166 0.1470 0.1024  0.0063  -0.0084 291 LEU A CD2 
+2131 N  N   . TYR A 270 ? 0.2467 0.2160 0.1331 0.0920  -0.0161 -0.0145 292 TYR A N   
+2132 C  CA  . TYR A 270 ? 0.2650 0.2426 0.1311 0.1470  -0.0137 -0.0289 292 TYR A CA  
+2133 C  C   . TYR A 270 ? 0.2794 0.2412 0.1198 0.0580  -0.0247 -0.0133 292 TYR A C   
+2134 O  O   . TYR A 270 ? 0.2861 0.2144 0.1223 0.0930  -0.0026 -0.0104 292 TYR A O   
+2135 C  CB  . TYR A 270 ? 0.2253 0.2375 0.1253 0.1364  -0.0367 -0.0392 292 TYR A CB  
+2136 C  CG  . TYR A 270 ? 0.2242 0.2404 0.1387 0.1372  -0.0320 -0.0360 292 TYR A CG  
+2137 C  CD1 . TYR A 270 ? 0.2360 0.1691 0.1364 0.0931  -0.0231 -0.0291 292 TYR A CD1 
+2138 C  CD2 . TYR A 270 ? 0.2291 0.2256 0.1456 0.0758  -0.0453 -0.0426 292 TYR A CD2 
+2139 C  CE1 . TYR A 270 ? 0.2367 0.1834 0.1400 0.0253  -0.0432 -0.0377 292 TYR A CE1 
+2140 C  CE2 . TYR A 270 ? 0.2119 0.2435 0.1447 0.0842  -0.0498 -0.0304 292 TYR A CE2 
+2141 C  CZ  . TYR A 270 ? 0.2075 0.2154 0.1482 0.0459  -0.0488 -0.0123 292 TYR A CZ  
+2142 O  OH  . TYR A 270 ? 0.2776 0.2663 0.1634 0.0734  -0.0246 -0.0167 292 TYR A OH  
+2143 N  N   . LYS A 271 ? 0.2804 0.2422 0.1234 0.1074  -0.0287 0.0038  293 LYS A N   
+2144 C  CA  . LYS A 271 ? 0.2342 0.2401 0.1375 0.0664  -0.0245 0.0030  293 LYS A CA  
+2145 C  C   . LYS A 271 ? 0.2675 0.2268 0.1322 0.1399  -0.0231 -0.0210 293 LYS A C   
+2146 O  O   . LYS A 271 ? 0.2894 0.2642 0.1323 0.1371  -0.0121 -0.0042 293 LYS A O   
+2147 C  CB  . LYS A 271 ? 0.3398 0.2475 0.1585 0.1106  -0.0257 -0.0107 293 LYS A CB  
+2148 C  CG  . LYS A 271 ? 0.3397 0.3135 0.1786 0.1363  -0.0435 -0.0534 293 LYS A CG  
+2149 C  CD  . LYS A 271 ? 0.2933 0.3913 0.1872 0.1157  -0.0377 -0.0358 293 LYS A CD  
+2150 C  CE  . LYS A 271 ? 0.2648 0.4222 0.2093 0.0890  -0.0731 -0.0757 293 LYS A CE  
+2151 N  NZ  . LYS A 271 ? 0.3471 0.4923 0.2301 0.0858  -0.0765 -0.0883 293 LYS A NZ  
+2152 N  N   . ALA A 272 ? 0.2541 0.1765 0.1375 0.1053  -0.0266 -0.0331 294 ALA A N   
+2153 C  CA  . ALA A 272 ? 0.2391 0.2016 0.1241 0.0990  -0.0025 -0.0227 294 ALA A CA  
+2154 C  C   . ALA A 272 ? 0.2816 0.1783 0.1140 0.0758  -0.0105 -0.0195 294 ALA A C   
+2155 O  O   . ALA A 272 ? 0.3191 0.1883 0.1158 0.1023  -0.0149 0.0087  294 ALA A O   
+2156 C  CB  . ALA A 272 ? 0.2767 0.2428 0.1340 0.1310  0.0088  -0.0103 294 ALA A CB  
+2157 N  N   . PHE A 273 ? 0.2563 0.1976 0.1125 0.0909  -0.0050 -0.0032 295 PHE A N   
+2158 C  CA  . PHE A 273 ? 0.2298 0.2172 0.0990 0.0709  -0.0005 0.0074  295 PHE A CA  
+2159 C  C   . PHE A 273 ? 0.3180 0.2473 0.1077 0.1404  0.0121  0.0082  295 PHE A C   
+2160 O  O   . PHE A 273 ? 0.2951 0.2537 0.1189 0.1230  -0.0076 -0.0139 295 PHE A O   
+2161 C  CB  . PHE A 273 ? 0.2347 0.1936 0.0917 0.1043  -0.0257 -0.0238 295 PHE A CB  
+2162 C  CG  . PHE A 273 ? 0.2616 0.1684 0.0935 0.0832  -0.0128 -0.0257 295 PHE A CG  
+2163 C  CD1 . PHE A 273 ? 0.2970 0.1894 0.1136 0.1007  -0.0203 -0.0215 295 PHE A CD1 
+2164 C  CD2 . PHE A 273 ? 0.2813 0.1781 0.0871 0.1003  -0.0029 -0.0092 295 PHE A CD2 
+2165 C  CE1 . PHE A 273 ? 0.3103 0.2225 0.1103 0.0717  -0.0218 -0.0392 295 PHE A CE1 
+2166 C  CE2 . PHE A 273 ? 0.2911 0.2097 0.0865 0.0718  -0.0055 -0.0053 295 PHE A CE2 
+2167 C  CZ  . PHE A 273 ? 0.3315 0.2105 0.0943 0.0540  -0.0022 0.0025  295 PHE A CZ  
+2168 N  N   . ASP A 274 ? 0.3079 0.1646 0.1019 0.0993  0.0252  -0.0014 296 ASP A N   
+2169 C  CA  . ASP A 274 ? 0.3046 0.2351 0.1178 0.1361  0.0378  0.0128  296 ASP A CA  
+2170 C  C   . ASP A 274 ? 0.3121 0.1994 0.1274 0.1368  0.0252  0.0017  296 ASP A C   
+2171 O  O   . ASP A 274 ? 0.2929 0.2291 0.1393 0.1382  -0.0121 -0.0134 296 ASP A O   
+2172 C  CB  . ASP A 274 ? 0.3103 0.2123 0.1349 0.1343  -0.0001 -0.0077 296 ASP A CB  
+2173 C  CG  . ASP A 274 ? 0.3362 0.2548 0.1471 0.1438  -0.0079 -0.0113 296 ASP A CG  
+2174 O  OD1 . ASP A 274 ? 0.3240 0.2562 0.1379 0.1333  -0.0232 0.0024  296 ASP A OD1 
+2175 O  OD2 . ASP A 274 ? 0.3550 0.2646 0.1613 0.1418  -0.0127 -0.0113 296 ASP A OD2 
+2176 N  N   . ARG A 275 ? 0.3517 0.1841 0.1175 0.1035  -0.0010 0.0054  297 ARG A N   
+2177 C  CA  . ARG A 275 ? 0.3305 0.2101 0.1267 0.1282  -0.0033 -0.0112 297 ARG A CA  
+2178 C  C   . ARG A 275 ? 0.3672 0.2245 0.1294 0.1462  0.0069  -0.0128 297 ARG A C   
+2179 O  O   . ARG A 275 ? 0.3672 0.2083 0.1436 0.1518  0.0026  -0.0065 297 ARG A O   
+2180 C  CB  . ARG A 275 ? 0.3769 0.2260 0.1290 0.1111  -0.0109 -0.0014 297 ARG A CB  
+2181 C  CG  . ARG A 275 ? 0.3813 0.2362 0.1274 0.0800  -0.0148 -0.0281 297 ARG A CG  
+2182 C  CD  . ARG A 275 ? 0.4177 0.3097 0.1412 0.1747  -0.0098 -0.0221 297 ARG A CD  
+2183 N  NE  . ARG A 275 ? 0.4090 0.3537 0.1418 0.1583  -0.0239 -0.0337 297 ARG A NE  
+2184 C  CZ  . ARG A 275 ? 0.4134 0.4046 0.1522 0.1733  -0.0298 -0.0350 297 ARG A CZ  
+2185 N  NH1 . ARG A 275 ? 0.3951 0.4604 0.1685 0.1845  -0.0497 -0.0537 297 ARG A NH1 
+2186 N  NH2 . ARG A 275 ? 0.4841 0.3945 0.1719 0.2081  -0.0330 0.0008  297 ARG A NH2 
+2187 N  N   . LEU A 276 ? 0.3325 0.2002 0.1212 0.1350  0.0281  0.0127  298 LEU A N   
+2188 C  CA  . LEU A 276 ? 0.3395 0.2044 0.1296 0.1377  0.0226  0.0120  298 LEU A CA  
+2189 C  C   . LEU A 276 ? 0.3613 0.1993 0.1296 0.1394  0.0142  0.0105  298 LEU A C   
+2190 O  O   . LEU A 276 ? 0.3798 0.1903 0.1214 0.1357  0.0052  0.0112  298 LEU A O   
+2191 C  CB  . LEU A 276 ? 0.2735 0.1650 0.1258 0.1121  -0.0303 -0.0001 298 LEU A CB  
+2192 C  CG  . LEU A 276 ? 0.3197 0.1766 0.1348 0.1120  0.0084  -0.0156 298 LEU A CG  
+2193 C  CD1 . LEU A 276 ? 0.2968 0.1684 0.1364 0.0701  0.0171  -0.0239 298 LEU A CD1 
+2194 C  CD2 . LEU A 276 ? 0.3663 0.2434 0.1469 0.1015  -0.0149 -0.0470 298 LEU A CD2 
+2195 N  N   . LYS A 277 ? 0.3693 0.1865 0.1373 0.1382  0.0178  0.0148  299 LYS A N   
+2196 C  CA  . LYS A 277 ? 0.3887 0.1790 0.1597 0.1272  0.0324  -0.0030 299 LYS A CA  
+2197 C  C   . LYS A 277 ? 0.3723 0.1734 0.1578 0.1131  0.0507  -0.0049 299 LYS A C   
+2198 O  O   . LYS A 277 ? 0.4006 0.1470 0.1546 0.0876  0.0537  -0.0041 299 LYS A O   
+2199 C  CB  . LYS A 277 ? 0.3922 0.1786 0.1794 0.1208  0.0404  -0.0115 299 LYS A CB  
+2200 C  CG  A LYS A 277 ? 0.3326 0.1570 0.1855 0.0413  0.0382  -0.0319 299 LYS A CG  
+2201 C  CG  C LYS A 277 ? 0.4433 0.2230 0.1934 0.1501  0.0442  -0.0065 299 LYS A CG  
+2202 C  CD  A LYS A 277 ? 0.3078 0.1414 0.1959 -0.0436 0.0428  -0.0455 299 LYS A CD  
+2203 C  CD  C LYS A 277 ? 0.4747 0.3166 0.2006 0.1933  0.0202  0.0092  299 LYS A CD  
+2204 C  CE  A LYS A 277 ? 0.3353 0.1608 0.2068 0.0112  0.0351  -0.0350 299 LYS A CE  
+2205 C  CE  C LYS A 277 ? 0.4488 0.3727 0.2083 0.2103  0.0037  0.0124  299 LYS A CE  
+2206 N  NZ  A LYS A 277 ? 0.3529 0.1340 0.2097 -0.0236 0.0229  -0.0572 299 LYS A NZ  
+2207 N  NZ  C LYS A 277 ? 0.4466 0.4105 0.2176 0.2558  0.0063  -0.0029 299 LYS A NZ  
+2208 N  N   . ALA A 278 ? 0.3746 0.1996 0.1514 0.1390  0.0326  -0.0029 300 ALA A N   
+2209 C  CA  . ALA A 278 ? 0.4166 0.2566 0.1557 0.1852  0.0189  0.0118  300 ALA A CA  
+2210 C  C   . ALA A 278 ? 0.4291 0.2594 0.1645 0.1881  0.0129  0.0075  300 ALA A C   
+2211 O  O   . ALA A 278 ? 0.4430 0.2830 0.1897 0.1976  0.0246  -0.0025 300 ALA A O   
+2212 C  CB  . ALA A 278 ? 0.4129 0.2553 0.1513 0.1842  0.0028  0.0036  300 ALA A CB  
+2213 N  N   . GLN A 279 ? 0.4040 0.2200 0.1539 0.1505  -0.0016 0.0047  301 GLN A N   
+2214 C  CA  . GLN A 279 ? 0.3797 0.2399 0.1465 0.1506  0.0202  0.0148  301 GLN A CA  
+2215 C  C   . GLN A 279 ? 0.4043 0.1746 0.1502 0.1224  0.0386  0.0016  301 GLN A C   
+2216 O  O   . GLN A 279 ? 0.4528 0.2114 0.1456 0.1567  0.0483  0.0236  301 GLN A O   
+2217 C  CB  . GLN A 279 ? 0.3893 0.2329 0.1376 0.1364  0.0217  0.0058  301 GLN A CB  
+2218 C  CG  . GLN A 279 ? 0.3668 0.2091 0.1386 0.1499  0.0179  -0.0007 301 GLN A CG  
+2219 C  CD  . GLN A 279 ? 0.3786 0.2195 0.1348 0.1581  0.0131  0.0001  301 GLN A CD  
+2220 O  OE1 . GLN A 279 ? 0.4671 0.2614 0.1470 0.1514  -0.0032 -0.0250 301 GLN A OE1 
+2221 N  NE2 . GLN A 279 ? 0.4207 0.2269 0.1376 0.1675  0.0051  -0.0003 301 GLN A NE2 
+2222 N  N   . GLY A 280 ? 0.4496 0.1768 0.1633 0.1285  0.0144  0.0098  302 GLY A N   
+2223 C  CA  . GLY A 280 ? 0.4268 0.1663 0.1594 0.1195  0.0355  0.0099  302 GLY A CA  
+2224 C  C   . GLY A 280 ? 0.3749 0.1295 0.1484 0.0420  0.0279  0.0150  302 GLY A C   
+2225 O  O   . GLY A 280 ? 0.4403 0.1634 0.1528 0.1146  0.0313  0.0054  302 GLY A O   
+2226 N  N   . GLN A 281 ? 0.3689 0.1852 0.1388 0.0841  0.0221  0.0234  303 GLN A N   
+2227 C  CA  . GLN A 281 ? 0.3495 0.1410 0.1333 0.0840  0.0164  0.0069  303 GLN A CA  
+2228 C  C   . GLN A 281 ? 0.3479 0.1348 0.1223 0.0800  0.0032  0.0102  303 GLN A C   
+2229 O  O   . GLN A 281 ? 0.3819 0.1619 0.1304 0.0922  -0.0007 0.0174  303 GLN A O   
+2230 C  CB  . GLN A 281 ? 0.3662 0.1781 0.1372 0.1131  0.0261  0.0256  303 GLN A CB  
+2231 C  CG  . GLN A 281 ? 0.3861 0.1551 0.1407 0.1088  0.0468  0.0097  303 GLN A CG  
+2232 C  CD  . GLN A 281 ? 0.3958 0.2175 0.1457 0.1308  0.0607  0.0136  303 GLN A CD  
+2233 O  OE1 . GLN A 281 ? 0.3793 0.1854 0.1357 0.1376  0.0325  0.0140  303 GLN A OE1 
+2234 N  NE2 . GLN A 281 ? 0.4983 0.2094 0.1672 0.1402  0.0674  0.0137  303 GLN A NE2 
+2235 N  N   . PRO A 282 ? 0.3420 0.1665 0.1110 0.1236  0.0303  0.0168  304 PRO A N   
+2236 C  CA  . PRO A 282 ? 0.3246 0.1824 0.1124 0.1246  0.0110  0.0192  304 PRO A CA  
+2237 C  C   . PRO A 282 ? 0.2955 0.1557 0.1059 0.0565  0.0147  0.0272  304 PRO A C   
+2238 O  O   . PRO A 282 ? 0.3570 0.1332 0.1191 0.0710  0.0424  0.0105  304 PRO A O   
+2239 C  CB  . PRO A 282 ? 0.3369 0.2103 0.1181 0.1499  0.0377  0.0256  304 PRO A CB  
+2240 C  CG  . PRO A 282 ? 0.3518 0.1766 0.1201 0.0651  0.0401  -0.0109 304 PRO A CG  
+2241 C  CD  . PRO A 282 ? 0.3728 0.1893 0.1217 0.1170  0.0475  0.0105  304 PRO A CD  
+2242 N  N   . LEU A 283 ? 0.3108 0.1586 0.0984 0.1010  0.0134  -0.0015 305 LEU A N   
+2243 C  CA  . LEU A 283 ? 0.3212 0.1383 0.0918 0.1023  -0.0042 -0.0018 305 LEU A CA  
+2244 C  C   . LEU A 283 ? 0.2917 0.1445 0.0904 0.0863  -0.0032 -0.0152 305 LEU A C   
+2245 O  O   . LEU A 283 ? 0.3204 0.1910 0.1045 0.1186  0.0088  -0.0093 305 LEU A O   
+2246 C  CB  . LEU A 283 ? 0.3119 0.1366 0.0923 0.0933  -0.0014 0.0008  305 LEU A CB  
+2247 C  CG  . LEU A 283 ? 0.3179 0.1876 0.0990 0.0887  -0.0042 -0.0051 305 LEU A CG  
+2248 C  CD1 . LEU A 283 ? 0.2997 0.1468 0.1010 0.0408  -0.0124 -0.0158 305 LEU A CD1 
+2249 C  CD2 . LEU A 283 ? 0.3098 0.2023 0.1023 0.0941  -0.0210 0.0139  305 LEU A CD2 
+2250 N  N   . ARG A 284 ? 0.2222 0.1609 0.0853 0.0599  0.0005  -0.0380 306 ARG A N   
+2251 C  CA  . ARG A 284 ? 0.2549 0.1357 0.0777 0.0347  0.0145  -0.0164 306 ARG A CA  
+2252 C  C   . ARG A 284 ? 0.2763 0.1271 0.0816 0.0294  0.0058  -0.0232 306 ARG A C   
+2253 O  O   . ARG A 284 ? 0.3049 0.1137 0.0796 0.0341  -0.0067 -0.0081 306 ARG A O   
+2254 C  CB  . ARG A 284 ? 0.3110 0.1500 0.0846 0.0493  -0.0145 -0.0143 306 ARG A CB  
+2255 C  CG  . ARG A 284 ? 0.3106 0.1368 0.0851 0.0176  -0.0153 -0.0191 306 ARG A CG  
+2256 C  CD  . ARG A 284 ? 0.3267 0.1412 0.0858 0.0305  -0.0023 -0.0127 306 ARG A CD  
+2257 N  NE  . ARG A 284 ? 0.3376 0.1648 0.0846 -0.0020 0.0014  -0.0035 306 ARG A NE  
+2258 C  CZ  . ARG A 284 ? 0.3897 0.1475 0.1050 -0.0144 -0.0403 -0.0023 306 ARG A CZ  
+2259 N  NH1 . ARG A 284 ? 0.4386 0.2059 0.1290 0.0202  -0.0619 0.0160  306 ARG A NH1 
+2260 N  NH2 . ARG A 284 ? 0.3852 0.1932 0.1206 -0.0044 -0.0650 0.0237  306 ARG A NH2 
+2261 N  N   . GLY A 285 ? 0.2655 0.1420 0.0781 0.0690  -0.0167 -0.0153 307 GLY A N   
+2262 C  CA  . GLY A 285 ? 0.2881 0.1477 0.0845 0.0685  -0.0090 0.0001  307 GLY A CA  
+2263 C  C   . GLY A 285 ? 0.2436 0.1411 0.0967 0.0459  -0.0190 0.0033  307 GLY A C   
+2264 O  O   . GLY A 285 ? 0.2905 0.1347 0.0845 0.0599  -0.0085 -0.0077 307 GLY A O   
+2265 N  N   . VAL A 286 ? 0.2502 0.1047 0.1084 0.0775  0.0018  0.0041  308 VAL A N   
+2266 C  CA  . VAL A 286 ? 0.2091 0.0753 0.1004 0.0525  0.0123  0.0058  308 VAL A CA  
+2267 C  C   . VAL A 286 ? 0.2425 0.0963 0.0801 0.0194  -0.0044 0.0048  308 VAL A C   
+2268 O  O   . VAL A 286 ? 0.2539 0.1575 0.0701 0.0367  -0.0202 0.0003  308 VAL A O   
+2269 C  CB  . VAL A 286 ? 0.2327 0.1763 0.1223 0.0886  0.0133  0.0052  308 VAL A CB  
+2270 C  CG1 . VAL A 286 ? 0.3059 0.1627 0.1334 0.1062  0.0211  -0.0143 308 VAL A CG1 
+2271 C  CG2 . VAL A 286 ? 0.1821 0.2038 0.1330 0.0660  -0.0049 -0.0237 308 VAL A CG2 
+2272 N  N   . MET A 287 ? 0.2589 0.1361 0.0708 0.0241  -0.0049 -0.0185 309 MET A N   
+2273 C  CA  . MET A 287 ? 0.2470 0.1339 0.0773 0.0877  -0.0183 -0.0134 309 MET A CA  
+2274 C  C   . MET A 287 ? 0.2251 0.1307 0.0693 0.0574  -0.0246 -0.0167 309 MET A C   
+2275 O  O   . MET A 287 ? 0.2307 0.1101 0.0719 0.0362  -0.0287 0.0063  309 MET A O   
+2276 C  CB  . MET A 287 ? 0.2586 0.1572 0.0900 0.0694  -0.0158 -0.0342 309 MET A CB  
+2277 C  CG  . MET A 287 ? 0.2654 0.1425 0.0875 0.0161  0.0047  -0.0189 309 MET A CG  
+2278 S  SD  . MET A 287 ? 0.2388 0.1403 0.0820 0.0416  -0.0113 -0.0124 309 MET A SD  
+2279 C  CE  . MET A 287 ? 0.2184 0.1442 0.0949 0.0479  -0.0365 -0.0367 309 MET A CE  
+2280 N  N   . THR A 288 ? 0.2347 0.1310 0.0709 0.0755  -0.0174 -0.0066 310 THR A N   
+2281 C  CA  . THR A 288 ? 0.2501 0.1206 0.0749 0.0717  -0.0249 -0.0082 310 THR A CA  
+2282 C  C   . THR A 288 ? 0.2537 0.1220 0.0738 0.0418  -0.0226 -0.0031 310 THR A C   
+2283 O  O   . THR A 288 ? 0.2391 0.1253 0.0913 0.0283  -0.0261 0.0006  310 THR A O   
+2284 C  CB  . THR A 288 ? 0.2504 0.1277 0.0863 0.0199  -0.0359 -0.0271 310 THR A CB  
+2285 O  OG1 . THR A 288 ? 0.2054 0.1700 0.0783 0.0299  -0.0293 -0.0316 310 THR A OG1 
+2286 C  CG2 . THR A 288 ? 0.2924 0.1549 0.0970 0.0122  -0.0170 -0.0299 310 THR A CG2 
+2287 N  N   . TRP A 289 ? 0.2507 0.1030 0.0696 0.0336  -0.0023 0.0006  311 TRP A N   
+2288 C  CA  . TRP A 289 ? 0.2336 0.1320 0.0779 0.0668  -0.0200 -0.0097 311 TRP A CA  
+2289 C  C   . TRP A 289 ? 0.2422 0.1715 0.0786 0.0515  -0.0173 -0.0223 311 TRP A C   
+2290 O  O   . TRP A 289 ? 0.2352 0.1690 0.0700 0.0153  -0.0046 -0.0262 311 TRP A O   
+2291 C  CB  . TRP A 289 ? 0.2472 0.1114 0.0865 0.0417  -0.0242 -0.0109 311 TRP A CB  
+2292 C  CG  . TRP A 289 ? 0.2351 0.1148 0.0889 0.0364  -0.0299 -0.0145 311 TRP A CG  
+2293 C  CD1 . TRP A 289 ? 0.2115 0.1771 0.0811 0.0158  -0.0385 -0.0173 311 TRP A CD1 
+2294 C  CD2 . TRP A 289 ? 0.2375 0.1144 0.0865 0.0479  -0.0215 -0.0083 311 TRP A CD2 
+2295 N  NE1 . TRP A 289 ? 0.2814 0.1209 0.0902 0.0844  -0.0250 -0.0126 311 TRP A NE1 
+2296 C  CE2 . TRP A 289 ? 0.2608 0.1033 0.0936 0.0302  -0.0064 -0.0067 311 TRP A CE2 
+2297 C  CE3 . TRP A 289 ? 0.2327 0.1795 0.0815 0.0634  -0.0181 -0.0161 311 TRP A CE3 
+2298 C  CZ2 . TRP A 289 ? 0.2753 0.1234 0.1005 0.0433  0.0145  -0.0018 311 TRP A CZ2 
+2299 C  CZ3 . TRP A 289 ? 0.2130 0.1940 0.0785 0.0558  -0.0150 0.0010  311 TRP A CZ3 
+2300 C  CH2 . TRP A 289 ? 0.2508 0.1865 0.0833 0.1035  0.0006  -0.0075 311 TRP A CH2 
+2301 N  N   . SER A 290 ? 0.2651 0.1255 0.0924 0.0376  -0.0071 0.0038  312 SER A N   
+2302 C  CA  . SER A 290 ? 0.2538 0.1180 0.0939 0.0161  -0.0047 0.0068  312 SER A CA  
+2303 C  C   . SER A 290 ? 0.2547 0.0971 0.0986 0.0319  -0.0038 -0.0212 312 SER A C   
+2304 O  O   . SER A 290 ? 0.2366 0.1488 0.1061 0.0221  0.0014  -0.0284 312 SER A O   
+2305 C  CB  . SER A 290 ? 0.2601 0.1053 0.1027 0.0110  0.0127  0.0011  312 SER A CB  
+2306 O  OG  . SER A 290 ? 0.2651 0.1130 0.1219 0.0257  0.0012  -0.0058 312 SER A OG  
+2307 N  N   . VAL A 291 ? 0.2359 0.1418 0.0973 0.0207  -0.0214 -0.0230 313 VAL A N   
+2308 C  CA  . VAL A 291 ? 0.2444 0.1376 0.0938 -0.0034 -0.0169 -0.0251 313 VAL A CA  
+2309 C  C   . VAL A 291 ? 0.2745 0.1706 0.1030 0.0056  -0.0128 -0.0178 313 VAL A C   
+2310 O  O   . VAL A 291 ? 0.2623 0.1497 0.1148 0.0313  -0.0145 -0.0138 313 VAL A O   
+2311 C  CB  . VAL A 291 ? 0.2547 0.1472 0.0939 0.0702  0.0062  -0.0158 313 VAL A CB  
+2312 C  CG1 . VAL A 291 ? 0.2250 0.1647 0.1058 0.0147  -0.0154 -0.0394 313 VAL A CG1 
+2313 C  CG2 . VAL A 291 ? 0.2764 0.1245 0.0911 0.0605  0.0087  -0.0203 313 VAL A CG2 
+2314 N  N   . ASN A 292 ? 0.2524 0.1019 0.1114 0.0042  -0.0187 -0.0329 314 ASN A N   
+2315 C  CA  . ASN A 292 ? 0.2470 0.1368 0.1129 0.0239  -0.0380 -0.0188 314 ASN A CA  
+2316 C  C   . ASN A 292 ? 0.2381 0.0917 0.1109 -0.0300 -0.0075 0.0039  314 ASN A C   
+2317 O  O   . ASN A 292 ? 0.2920 0.1382 0.1162 -0.0318 0.0044  0.0002  314 ASN A O   
+2318 C  CB  . ASN A 292 ? 0.2702 0.1424 0.1138 0.0442  -0.0331 -0.0187 314 ASN A CB  
+2319 C  CG  . ASN A 292 ? 0.2890 0.1421 0.1199 0.0757  -0.0172 -0.0144 314 ASN A CG  
+2320 O  OD1 . ASN A 292 ? 0.2893 0.1228 0.1192 0.0654  0.0004  -0.0226 314 ASN A OD1 
+2321 N  ND2 . ASN A 292 ? 0.2837 0.1231 0.1414 0.0060  -0.0335 -0.0222 314 ASN A ND2 
+2322 N  N   . TRP A 293 ? 0.2195 0.1223 0.1089 0.0169  -0.0028 0.0047  315 TRP A N   
+2323 C  CA  . TRP A 293 ? 0.2857 0.1318 0.1099 0.0297  -0.0156 -0.0076 315 TRP A CA  
+2324 C  C   . TRP A 293 ? 0.2703 0.1372 0.1168 -0.0137 -0.0152 -0.0133 315 TRP A C   
+2325 O  O   . TRP A 293 ? 0.2816 0.1286 0.1171 0.0008  -0.0207 -0.0133 315 TRP A O   
+2326 C  CB  . TRP A 293 ? 0.2818 0.1155 0.1026 0.0318  -0.0014 -0.0089 315 TRP A CB  
+2327 C  CG  . TRP A 293 ? 0.2703 0.1167 0.1043 0.0212  0.0028  0.0032  315 TRP A CG  
+2328 C  CD1 . TRP A 293 ? 0.2990 0.1191 0.1018 0.0067  -0.0019 -0.0117 315 TRP A CD1 
+2329 C  CD2 . TRP A 293 ? 0.2781 0.1288 0.1105 0.0068  0.0029  -0.0138 315 TRP A CD2 
+2330 N  NE1 . TRP A 293 ? 0.3253 0.1393 0.1082 0.0428  -0.0093 -0.0124 315 TRP A NE1 
+2331 C  CE2 . TRP A 293 ? 0.3561 0.1217 0.1124 0.0605  -0.0008 -0.0136 315 TRP A CE2 
+2332 C  CE3 . TRP A 293 ? 0.3084 0.1311 0.1201 0.0005  0.0172  -0.0063 315 TRP A CE3 
+2333 C  CZ2 . TRP A 293 ? 0.3322 0.1107 0.1218 0.0443  -0.0046 -0.0260 315 TRP A CZ2 
+2334 C  CZ3 . TRP A 293 ? 0.3414 0.1329 0.1203 -0.0510 0.0220  -0.0220 315 TRP A CZ3 
+2335 C  CH2 . TRP A 293 ? 0.3408 0.1101 0.1230 0.0270  0.0164  -0.0257 315 TRP A CH2 
+2336 N  N   . ASP A 294 ? 0.2564 0.1404 0.1344 0.0077  0.0076  -0.0216 316 ASP A N   
+2337 C  CA  . ASP A 294 ? 0.2513 0.1246 0.1298 -0.0016 0.0071  -0.0403 316 ASP A CA  
+2338 C  C   . ASP A 294 ? 0.2631 0.1228 0.1481 0.0421  0.0273  -0.0303 316 ASP A C   
+2339 O  O   . ASP A 294 ? 0.2973 0.1544 0.1701 0.0172  0.0468  0.0010  316 ASP A O   
+2340 C  CB  . ASP A 294 ? 0.2292 0.1231 0.1217 0.0034  0.0027  -0.0217 316 ASP A CB  
+2341 C  CG  . ASP A 294 ? 0.2481 0.1421 0.1146 0.0462  0.0075  -0.0169 316 ASP A CG  
+2342 O  OD1 . ASP A 294 ? 0.2592 0.2096 0.1170 0.0193  0.0073  0.0151  316 ASP A OD1 
+2343 O  OD2 . ASP A 294 ? 0.2565 0.1571 0.1100 0.0287  0.0097  -0.0261 316 ASP A OD2 
+2344 N  N   . MET A 295 ? 0.2406 0.1418 0.1510 0.0016  0.0167  -0.0208 317 MET A N   
+2345 C  CA  . MET A 295 ? 0.2855 0.1325 0.1461 0.0406  -0.0020 -0.0128 317 MET A CA  
+2346 C  C   . MET A 295 ? 0.3070 0.1430 0.1503 0.0087  -0.0252 -0.0066 317 MET A C   
+2347 O  O   . MET A 295 ? 0.3631 0.1732 0.1470 0.0154  -0.0077 0.0046  317 MET A O   
+2348 C  CB  . MET A 295 ? 0.3113 0.1413 0.1480 -0.0188 -0.0118 0.0024  317 MET A CB  
+2349 C  CG  . MET A 295 ? 0.3619 0.1330 0.1404 0.0097  -0.0149 -0.0223 317 MET A CG  
+2350 S  SD  . MET A 295 ? 0.4122 0.2367 0.1710 0.0662  -0.0586 -0.0553 317 MET A SD  
+2351 C  CE  . MET A 295 ? 0.4986 0.2356 0.1822 0.0663  0.0444  -0.0194 317 MET A CE  
+2352 N  N   . GLY A 296 ? 0.3318 0.1045 0.1569 0.0151  -0.0314 -0.0043 318 GLY A N   
+2353 C  CA  . GLY A 296 ? 0.3183 0.1305 0.1539 0.0055  -0.0187 -0.0293 318 GLY A CA  
+2354 C  C   . GLY A 296 ? 0.3252 0.1505 0.1663 -0.0014 -0.0021 -0.0131 318 GLY A C   
+2355 O  O   . GLY A 296 ? 0.3095 0.1782 0.1682 -0.0310 0.0090  -0.0297 318 GLY A O   
+2356 N  N   . THR A 297 ? 0.3245 0.1303 0.1700 -0.0300 -0.0036 -0.0491 319 THR A N   
+2357 C  CA  . THR A 297 ? 0.3851 0.1343 0.1813 -0.0254 0.0122  -0.0549 319 THR A CA  
+2358 C  C   . THR A 297 ? 0.3610 0.1342 0.1712 -0.0416 0.0009  -0.0531 319 THR A C   
+2359 O  O   . THR A 297 ? 0.3503 0.1994 0.1494 -0.0180 -0.0110 -0.0584 319 THR A O   
+2360 C  CB  . THR A 297 ? 0.3863 0.1578 0.1924 -0.0688 0.0238  -0.0416 319 THR A CB  
+2361 O  OG1 . THR A 297 ? 0.4253 0.2214 0.1991 -0.0040 0.0620  0.0035  319 THR A OG1 
+2362 C  CG2 . THR A 297 ? 0.4115 0.2096 0.1988 -0.0500 0.0494  -0.0268 319 THR A CG2 
+2363 N  N   . ASP A 298 ? 0.3569 0.1983 0.1835 -0.0604 0.0032  -0.0751 320 ASP A N   
+2364 C  CA  . ASP A 298 ? 0.3628 0.1745 0.2114 -0.0593 -0.0100 -0.0852 320 ASP A CA  
+2365 C  C   . ASP A 298 ? 0.3932 0.1591 0.2197 -0.0377 -0.0093 -0.0795 320 ASP A C   
+2366 O  O   . ASP A 298 ? 0.4012 0.1851 0.2158 -0.0252 0.0167  -0.0414 320 ASP A O   
+2367 C  CB  . ASP A 298 ? 0.3828 0.2426 0.2186 -0.0267 -0.0300 -0.0990 320 ASP A CB  
+2368 C  CG  . ASP A 298 ? 0.3651 0.3464 0.2389 -0.0080 -0.0277 -0.1038 320 ASP A CG  
+2369 O  OD1 . ASP A 298 ? 0.3857 0.2659 0.2275 -0.0542 -0.0191 -0.1053 320 ASP A OD1 
+2370 O  OD2 . ASP A 298 ? 0.3352 0.4883 0.2709 -0.0139 -0.0149 -0.0750 320 ASP A OD2 
+2371 N  N   . ALA A 299 ? 0.4122 0.1995 0.2287 -0.0330 0.0019  -0.1064 321 ALA A N   
+2372 C  CA  . ALA A 299 ? 0.4169 0.2137 0.2537 -0.0732 0.0419  -0.1112 321 ALA A CA  
+2373 C  C   . ALA A 299 ? 0.4444 0.1870 0.2795 -0.0875 0.0640  -0.0888 321 ALA A C   
+2374 O  O   . ALA A 299 ? 0.5160 0.2087 0.3104 -0.1257 0.1064  -0.0753 321 ALA A O   
+2375 C  CB  . ALA A 299 ? 0.4516 0.2698 0.2622 -0.0218 0.0259  -0.1480 321 ALA A CB  
+2376 N  N   . ALA A 300 ? 0.4772 0.2001 0.2772 -0.1062 0.0850  -0.0838 322 ALA A N   
+2377 C  CA  . ALA A 300 ? 0.5143 0.2555 0.2654 -0.1201 0.1028  -0.0847 322 ALA A CA  
+2378 C  C   . ALA A 300 ? 0.5475 0.2221 0.2682 -0.1456 0.1079  -0.0627 322 ALA A C   
+2379 O  O   . ALA A 300 ? 0.5893 0.2739 0.2791 -0.1808 0.1026  -0.0813 322 ALA A O   
+2380 C  CB  . ALA A 300 ? 0.5232 0.2473 0.2589 -0.1195 0.0980  -0.0978 322 ALA A CB  
+2381 N  N   . ASN A 301 ? 0.5474 0.1925 0.2682 -0.0480 0.0859  -0.0483 323 ASN A N   
+2382 C  CA  A ASN A 301 ? 0.5598 0.1924 0.2703 -0.0324 0.0638  -0.0522 323 ASN A CA  
+2383 C  CA  B ASN A 301 ? 0.5791 0.2501 0.2750 -0.0239 0.0578  -0.0480 323 ASN A CA  
+2384 C  C   . ASN A 301 ? 0.5552 0.2394 0.2607 -0.0459 0.0556  -0.0481 323 ASN A C   
+2385 O  O   . ASN A 301 ? 0.6287 0.2207 0.2568 -0.0506 0.0319  -0.0155 323 ASN A O   
+2386 C  CB  A ASN A 301 ? 0.5703 0.2007 0.2781 -0.0371 0.0582  -0.0508 323 ASN A CB  
+2387 C  CB  B ASN A 301 ? 0.6237 0.3459 0.2912 -0.0160 0.0403  -0.0406 323 ASN A CB  
+2388 C  CG  A ASN A 301 ? 0.5599 0.1874 0.2816 -0.0289 0.0432  -0.0668 323 ASN A CG  
+2389 C  CG  B ASN A 301 ? 0.6500 0.4219 0.3035 0.0007  0.0152  -0.0479 323 ASN A CG  
+2390 O  OD1 A ASN A 301 ? 0.5739 0.2108 0.2846 -0.0208 0.0309  -0.0806 323 ASN A OD1 
+2391 O  OD1 B ASN A 301 ? 0.6473 0.4034 0.3091 -0.0487 -0.0193 -0.0843 323 ASN A OD1 
+2392 N  ND2 A ASN A 301 ? 0.5406 0.1708 0.2858 -0.0091 0.0379  -0.0598 323 ASN A ND2 
+2393 N  ND2 B ASN A 301 ? 0.6738 0.4946 0.3055 0.0312  0.0079  -0.0497 323 ASN A ND2 
+2394 N  N   . ASN A 302 ? 0.4802 0.1832 0.2452 -0.0739 0.0462  -0.0712 324 ASN A N   
+2395 C  CA  . ASN A 302 ? 0.4075 0.1882 0.2377 -0.1060 0.0332  -0.0744 324 ASN A CA  
+2396 C  C   . ASN A 302 ? 0.3706 0.1901 0.2232 -0.0634 0.0347  -0.0557 324 ASN A C   
+2397 O  O   . ASN A 302 ? 0.3705 0.2369 0.2190 -0.0654 0.0418  -0.0629 324 ASN A O   
+2398 C  CB  . ASN A 302 ? 0.4536 0.3020 0.2394 -0.0808 0.0163  -0.1170 324 ASN A CB  
+2399 C  CG  . ASN A 302 ? 0.4550 0.3826 0.2451 -0.1209 0.0359  -0.1448 324 ASN A CG  
+2400 O  OD1 . ASN A 302 ? 0.4951 0.5424 0.2537 -0.0406 0.0080  -0.1568 324 ASN A OD1 
+2401 N  ND2 . ASN A 302 ? 0.4266 0.4018 0.2565 -0.1995 0.0730  -0.1319 324 ASN A ND2 
+2402 N  N   A SER A 303 ? 0.3577 0.1669 0.2155 -0.1192 0.0443  -0.0376 325 SER A N   
+2403 N  N   B SER A 303 ? 0.3924 0.1897 0.2170 -0.0847 0.0433  -0.0496 325 SER A N   
+2404 C  CA  A SER A 303 ? 0.3262 0.1571 0.2082 -0.1075 0.0371  -0.0461 325 SER A CA  
+2405 C  CA  B SER A 303 ? 0.3755 0.1966 0.2097 -0.0674 0.0356  -0.0717 325 SER A CA  
+2406 C  C   . SER A 303 ? 0.3040 0.1882 0.2041 -0.0966 0.0243  -0.0588 325 SER A C   
+2407 O  O   . SER A 303 ? 0.3231 0.2648 0.2189 -0.0628 0.0207  -0.0469 325 SER A O   
+2408 C  CB  A SER A 303 ? 0.3847 0.1542 0.2071 -0.0712 0.0378  -0.0264 325 SER A CB  
+2409 C  CB  B SER A 303 ? 0.4676 0.2610 0.2096 0.0038  0.0300  -0.0879 325 SER A CB  
+2410 O  OG  A SER A 303 ? 0.4134 0.1330 0.2026 -0.0408 0.0306  -0.0059 325 SER A OG  
+2411 O  OG  B SER A 303 ? 0.5341 0.3016 0.2112 0.0539  0.0275  -0.1034 325 SER A OG  
+2412 N  N   . TYR A 304 ? 0.3308 0.1379 0.1826 -0.0082 0.0031  -0.0435 326 TYR A N   
+2413 C  CA  . TYR A 304 ? 0.3147 0.1131 0.1721 -0.0153 0.0075  -0.0426 326 TYR A CA  
+2414 C  C   . TYR A 304 ? 0.3280 0.2260 0.1720 -0.0250 -0.0045 -0.0507 326 TYR A C   
+2415 O  O   . TYR A 304 ? 0.3184 0.2388 0.1693 -0.0310 -0.0143 -0.0507 326 TYR A O   
+2416 C  CB  . TYR A 304 ? 0.2973 0.2175 0.1561 -0.0157 0.0051  -0.0376 326 TYR A CB  
+2417 C  CG  . TYR A 304 ? 0.3105 0.2016 0.1529 -0.0395 0.0017  -0.0415 326 TYR A CG  
+2418 C  CD1 . TYR A 304 ? 0.2822 0.2019 0.1477 -0.0506 -0.0340 -0.0714 326 TYR A CD1 
+2419 C  CD2 . TYR A 304 ? 0.2975 0.2096 0.1487 -0.0220 -0.0152 -0.0480 326 TYR A CD2 
+2420 C  CE1 . TYR A 304 ? 0.3132 0.2316 0.1503 -0.0178 -0.0370 -0.0536 326 TYR A CE1 
+2421 C  CE2 . TYR A 304 ? 0.2840 0.2210 0.1475 -0.0400 -0.0108 -0.0563 326 TYR A CE2 
+2422 C  CZ  . TYR A 304 ? 0.3342 0.2124 0.1500 0.0151  -0.0123 -0.0507 326 TYR A CZ  
+2423 O  OH  . TYR A 304 ? 0.3464 0.1960 0.1523 -0.0140 0.0047  -0.0391 326 TYR A OH  
+2424 N  N   . ASN A 305 ? 0.3119 0.1481 0.1660 -0.0197 -0.0031 -0.0561 327 ASN A N   
+2425 C  CA  . ASN A 305 ? 0.3037 0.1678 0.1718 -0.0413 0.0275  -0.0511 327 ASN A CA  
+2426 C  C   . ASN A 305 ? 0.2730 0.1754 0.1600 -0.0319 0.0381  -0.0437 327 ASN A C   
+2427 O  O   . ASN A 305 ? 0.2702 0.2358 0.1828 -0.0422 0.0395  -0.0418 327 ASN A O   
+2428 C  CB  . ASN A 305 ? 0.3463 0.2514 0.1994 -0.0619 0.0466  -0.0589 327 ASN A CB  
+2429 C  CG  . ASN A 305 ? 0.4334 0.2990 0.2263 -0.0476 0.0623  -0.0248 327 ASN A CG  
+2430 O  OD1 . ASN A 305 ? 0.4575 0.2666 0.2233 -0.0363 0.0490  -0.0159 327 ASN A OD1 
+2431 N  ND2 . ASN A 305 ? 0.5019 0.3247 0.2480 0.0200  0.0489  -0.0518 327 ASN A ND2 
+2432 N  N   . GLN A 306 ? 0.2821 0.1978 0.1330 0.0189  0.0282  -0.0438 328 GLN A N   
+2433 C  CA  . GLN A 306 ? 0.2764 0.1477 0.1214 0.0392  0.0223  -0.0488 328 GLN A CA  
+2434 C  C   . GLN A 306 ? 0.2371 0.1584 0.1301 0.0016  0.0200  -0.0530 328 GLN A C   
+2435 O  O   . GLN A 306 ? 0.2583 0.1502 0.1324 0.0116  0.0055  -0.0246 328 GLN A O   
+2436 C  CB  . GLN A 306 ? 0.2729 0.1788 0.1197 -0.0011 0.0079  -0.0021 328 GLN A CB  
+2437 C  CG  . GLN A 306 ? 0.3304 0.2342 0.1177 -0.0330 0.0216  -0.0104 328 GLN A CG  
+2438 C  CD  . GLN A 306 ? 0.3290 0.2476 0.1239 -0.0019 0.0023  -0.0125 328 GLN A CD  
+2439 O  OE1 . GLN A 306 ? 0.3029 0.2386 0.1232 -0.0407 0.0038  0.0123  328 GLN A OE1 
+2440 N  NE2 . GLN A 306 ? 0.3413 0.1720 0.1424 0.0063  -0.0171 -0.0218 328 GLN A NE2 
+2441 N  N   . GLN A 307 ? 0.2605 0.1741 0.1427 -0.0003 -0.0043 -0.0554 329 GLN A N   
+2442 C  CA  . GLN A 307 ? 0.2661 0.2198 0.1457 0.0126  -0.0120 -0.0433 329 GLN A CA  
+2443 C  C   . GLN A 307 ? 0.2654 0.2078 0.1393 0.0053  -0.0124 -0.0451 329 GLN A C   
+2444 O  O   . GLN A 307 ? 0.2585 0.1925 0.1378 0.0077  -0.0048 -0.0423 329 GLN A O   
+2445 C  CB  . GLN A 307 ? 0.2733 0.2245 0.1721 -0.0259 -0.0475 -0.0723 329 GLN A CB  
+2446 C  CG  . GLN A 307 ? 0.3024 0.2265 0.1875 -0.0208 -0.0511 -0.0412 329 GLN A CG  
+2447 C  CD  . GLN A 307 ? 0.3011 0.2524 0.2168 -0.0181 -0.0316 -0.0156 329 GLN A CD  
+2448 O  OE1 . GLN A 307 ? 0.2940 0.2566 0.2349 -0.0296 -0.0165 0.0135  329 GLN A OE1 
+2449 N  NE2 . GLN A 307 ? 0.3277 0.2701 0.2215 0.0192  -0.0094 -0.0059 329 GLN A NE2 
+2450 N  N   . PHE A 308 ? 0.2284 0.1303 0.1293 -0.0067 -0.0159 -0.0353 330 PHE A N   
+2451 C  CA  . PHE A 308 ? 0.2448 0.1250 0.1131 0.0315  -0.0163 -0.0408 330 PHE A CA  
+2452 C  C   . PHE A 308 ? 0.2419 0.1541 0.1096 0.0560  -0.0208 -0.0449 330 PHE A C   
+2453 O  O   . PHE A 308 ? 0.2396 0.2098 0.1027 0.0652  -0.0055 -0.0210 330 PHE A O   
+2454 C  CB  . PHE A 308 ? 0.2267 0.1747 0.1124 0.0042  -0.0165 -0.0069 330 PHE A CB  
+2455 C  CG  . PHE A 308 ? 0.2405 0.1533 0.1090 0.0441  -0.0146 -0.0230 330 PHE A CG  
+2456 C  CD1 . PHE A 308 ? 0.2883 0.1766 0.1124 0.0164  -0.0195 -0.0096 330 PHE A CD1 
+2457 C  CD2 . PHE A 308 ? 0.2624 0.1676 0.1075 0.0544  -0.0105 -0.0061 330 PHE A CD2 
+2458 C  CE1 . PHE A 308 ? 0.2033 0.1739 0.1066 0.0102  -0.0147 -0.0241 330 PHE A CE1 
+2459 C  CE2 . PHE A 308 ? 0.1935 0.1965 0.1137 0.0330  -0.0090 -0.0088 330 PHE A CE2 
+2460 C  CZ  . PHE A 308 ? 0.2206 0.1904 0.1128 0.0431  -0.0049 -0.0158 330 PHE A CZ  
+2461 N  N   . ILE A 309 ? 0.2614 0.1523 0.0905 -0.0034 -0.0310 -0.0146 331 ILE A N   
+2462 C  CA  . ILE A 309 ? 0.2116 0.1804 0.0886 -0.0140 -0.0203 -0.0037 331 ILE A CA  
+2463 C  C   . ILE A 309 ? 0.2241 0.1908 0.1000 0.0121  -0.0024 -0.0188 331 ILE A C   
+2464 O  O   . ILE A 309 ? 0.2138 0.1807 0.1140 0.0122  0.0103  -0.0281 331 ILE A O   
+2465 C  CB  . ILE A 309 ? 0.2281 0.1478 0.1007 -0.0105 -0.0333 -0.0264 331 ILE A CB  
+2466 C  CG1 . ILE A 309 ? 0.2627 0.1785 0.1062 0.0412  -0.0554 -0.0480 331 ILE A CG1 
+2467 C  CG2 . ILE A 309 ? 0.2286 0.1533 0.1002 -0.0219 -0.0037 -0.0199 331 ILE A CG2 
+2468 C  CD1 . ILE A 309 ? 0.2532 0.2090 0.1042 0.0619  -0.0247 -0.0521 331 ILE A CD1 
+2469 N  N   . LYS A 310 ? 0.2607 0.1765 0.1112 0.0384  0.0037  -0.0241 332 LYS A N   
+2470 C  CA  . LYS A 310 ? 0.2423 0.2018 0.1217 -0.0007 0.0153  -0.0459 332 LYS A CA  
+2471 C  C   . LYS A 310 ? 0.2119 0.2188 0.1322 0.0136  0.0085  -0.0485 332 LYS A C   
+2472 O  O   . LYS A 310 ? 0.2531 0.2545 0.1423 0.0805  -0.0117 -0.0548 332 LYS A O   
+2473 C  CB  . LYS A 310 ? 0.2387 0.2258 0.1302 -0.0269 0.0261  -0.0239 332 LYS A CB  
+2474 C  CG  . LYS A 310 ? 0.2778 0.1993 0.1449 -0.0190 0.0184  -0.0547 332 LYS A CG  
+2475 C  CD  . LYS A 310 ? 0.3133 0.2245 0.1603 -0.0412 0.0307  -0.0659 332 LYS A CD  
+2476 C  CE  . LYS A 310 ? 0.3444 0.2454 0.1674 -0.0072 0.0208  -0.0677 332 LYS A CE  
+2477 N  NZ  . LYS A 310 ? 0.3645 0.2253 0.1735 -0.0371 0.0122  -0.0417 332 LYS A NZ  
+2478 N  N   . ASP A 311 ? 0.1833 0.2442 0.1343 0.0353  0.0040  -0.0311 333 ASP A N   
+2479 C  CA  . ASP A 311 ? 0.2295 0.2123 0.1365 0.0187  -0.0176 -0.0400 333 ASP A CA  
+2480 C  C   . ASP A 311 ? 0.2468 0.1994 0.1341 0.0946  -0.0152 -0.0274 333 ASP A C   
+2481 O  O   . ASP A 311 ? 0.2313 0.2073 0.1524 0.0818  -0.0192 -0.0312 333 ASP A O   
+2482 C  CB  . ASP A 311 ? 0.2635 0.2104 0.1385 0.0409  -0.0141 -0.0501 333 ASP A CB  
+2483 C  CG  . ASP A 311 ? 0.2969 0.2150 0.1553 0.0198  -0.0313 -0.0725 333 ASP A CG  
+2484 O  OD1 . ASP A 311 ? 0.3878 0.2440 0.1742 0.0112  -0.0221 -0.0460 333 ASP A OD1 
+2485 O  OD2 . ASP A 311 ? 0.3150 0.2647 0.1630 0.0493  -0.0481 -0.0830 333 ASP A OD2 
+2486 N  N   . TYR A 312 ? 0.2449 0.1622 0.1132 0.0237  -0.0052 -0.0075 334 TYR A N   
+2487 C  CA  . TYR A 312 ? 0.2428 0.1458 0.1131 0.0136  -0.0211 -0.0347 334 TYR A CA  
+2488 C  C   . TYR A 312 ? 0.2649 0.1167 0.1079 0.0021  0.0009  -0.0026 334 TYR A C   
+2489 O  O   . TYR A 312 ? 0.2572 0.1153 0.1169 0.0455  -0.0079 -0.0211 334 TYR A O   
+2490 C  CB  . TYR A 312 ? 0.2502 0.1848 0.1176 0.0611  -0.0089 -0.0476 334 TYR A CB  
+2491 C  CG  . TYR A 312 ? 0.2328 0.1702 0.1127 0.0559  -0.0177 -0.0345 334 TYR A CG  
+2492 C  CD1 . TYR A 312 ? 0.2797 0.2141 0.1116 0.0900  -0.0322 -0.0300 334 TYR A CD1 
+2493 C  CD2 . TYR A 312 ? 0.1621 0.1703 0.1184 0.0086  -0.0193 -0.0232 334 TYR A CD2 
+2494 C  CE1 . TYR A 312 ? 0.2679 0.2066 0.1131 0.0765  -0.0336 -0.0169 334 TYR A CE1 
+2495 C  CE2 . TYR A 312 ? 0.2391 0.2393 0.1197 0.0551  -0.0335 -0.0013 334 TYR A CE2 
+2496 C  CZ  . TYR A 312 ? 0.2321 0.2310 0.1131 0.0419  -0.0237 -0.0131 334 TYR A CZ  
+2497 O  OH  . TYR A 312 ? 0.2558 0.2651 0.1201 0.0511  -0.0266 -0.0356 334 TYR A OH  
+2498 N  N   . GLY A 313 ? 0.2782 0.1456 0.1040 0.0482  -0.0155 0.0005  335 GLY A N   
+2499 C  CA  . GLY A 313 ? 0.2848 0.1313 0.1071 0.0662  -0.0239 0.0086  335 GLY A CA  
+2500 C  C   . GLY A 313 ? 0.2951 0.1397 0.1144 0.0814  -0.0296 0.0013  335 GLY A C   
+2501 O  O   . GLY A 313 ? 0.3176 0.1484 0.1072 0.0490  -0.0213 -0.0330 335 GLY A O   
+2502 N  N   . ASN A 314 ? 0.3081 0.1549 0.1342 0.0396  -0.0233 -0.0216 336 ASN A N   
+2503 C  CA  . ASN A 314 ? 0.2762 0.1398 0.1405 0.0365  -0.0097 -0.0139 336 ASN A CA  
+2504 C  C   . ASN A 314 ? 0.2890 0.2033 0.1293 0.0825  -0.0198 -0.0131 336 ASN A C   
+2505 O  O   . ASN A 314 ? 0.2683 0.1967 0.1246 0.0643  -0.0132 -0.0333 336 ASN A O   
+2506 C  CB  . ASN A 314 ? 0.2908 0.2198 0.1628 0.0674  0.0258  0.0158  336 ASN A CB  
+2507 C  CG  . ASN A 314 ? 0.3521 0.3218 0.1837 0.0639  0.0441  0.0010  336 ASN A CG  
+2508 O  OD1 . ASN A 314 ? 0.4702 0.3899 0.1833 0.1282  0.0759  -0.0355 336 ASN A OD1 
+2509 N  ND2 . ASN A 314 ? 0.4154 0.4034 0.2090 0.1402  0.0262  0.0081  336 ASN A ND2 
+2510 N  N   . PHE A 315 ? 0.2540 0.2125 0.1243 0.0661  -0.0091 -0.0175 337 PHE A N   
+2511 C  CA  . PHE A 315 ? 0.2450 0.2017 0.1176 0.0705  -0.0104 -0.0222 337 PHE A CA  
+2512 C  C   . PHE A 315 ? 0.2381 0.1492 0.1227 0.0822  -0.0012 -0.0191 337 PHE A C   
+2513 O  O   . PHE A 315 ? 0.2871 0.1599 0.1345 0.0788  0.0097  -0.0234 337 PHE A O   
+2514 C  CB  . PHE A 315 ? 0.2598 0.2462 0.1157 0.0893  -0.0270 -0.0164 337 PHE A CB  
+2515 C  CG  . PHE A 315 ? 0.2221 0.2200 0.1143 0.0707  -0.0169 -0.0041 337 PHE A CG  
+2516 C  CD1 . PHE A 315 ? 0.2071 0.2278 0.1169 0.0644  -0.0073 -0.0003 337 PHE A CD1 
+2517 C  CD2 . PHE A 315 ? 0.2852 0.1889 0.1154 0.0627  -0.0129 -0.0232 337 PHE A CD2 
+2518 C  CE1 . PHE A 315 ? 0.2413 0.2432 0.1276 0.0874  -0.0181 -0.0024 337 PHE A CE1 
+2519 C  CE2 . PHE A 315 ? 0.2547 0.2186 0.1175 0.0571  0.0180  0.0122  337 PHE A CE2 
+2520 C  CZ  . PHE A 315 ? 0.2981 0.1931 0.1225 0.1143  0.0069  -0.0248 337 PHE A CZ  
+2521 N  N   . ILE A 316 ? 0.2732 0.1528 0.1172 0.0742  -0.0039 -0.0196 338 ILE A N   
+2522 C  CA  . ILE A 316 ? 0.2791 0.1574 0.1121 0.0932  0.0037  -0.0047 338 ILE A CA  
+2523 C  C   . ILE A 316 ? 0.2389 0.1791 0.1077 0.0626  0.0128  0.0068  338 ILE A C   
+2524 O  O   . ILE A 316 ? 0.2938 0.1794 0.1039 0.0442  -0.0083 0.0014  338 ILE A O   
+2525 C  CB  . ILE A 316 ? 0.2731 0.1619 0.1043 0.0708  0.0013  0.0101  338 ILE A CB  
+2526 C  CG1 . ILE A 316 ? 0.2387 0.2313 0.1042 0.0594  -0.0059 -0.0016 338 ILE A CG1 
+2527 C  CG2 . ILE A 316 ? 0.2943 0.2135 0.0891 0.0881  0.0047  0.0123  338 ILE A CG2 
+2528 C  CD1 . ILE A 316 ? 0.2135 0.2047 0.0972 0.0813  -0.0026 -0.0185 338 ILE A CD1 
+2529 N  N   . HIS A 317 ? 0.2555 0.1794 0.0919 0.0548  0.0129  -0.0002 339 HIS A N   
+2530 C  CA  . HIS A 317 ? 0.2985 0.1499 0.0965 0.0820  0.0169  0.0096  339 HIS A CA  
+2531 C  C   . HIS A 317 ? 0.3021 0.1596 0.1158 0.0678  0.0058  -0.0004 339 HIS A C   
+2532 O  O   . HIS A 317 ? 0.3127 0.1558 0.1276 0.0370  -0.0180 -0.0143 339 HIS A O   
+2533 C  CB  . HIS A 317 ? 0.2775 0.1697 0.0862 0.0792  -0.0199 -0.0151 339 HIS A CB  
+2534 C  CG  . HIS A 317 ? 0.2657 0.1142 0.0991 0.0492  -0.0145 0.0015  339 HIS A CG  
+2535 N  ND1 . HIS A 317 ? 0.3267 0.1189 0.1288 0.0840  -0.0069 -0.0039 339 HIS A ND1 
+2536 C  CD2 . HIS A 317 ? 0.2741 0.1432 0.1055 0.0447  -0.0153 -0.0084 339 HIS A CD2 
+2537 C  CE1 . HIS A 317 ? 0.2567 0.1502 0.1283 0.0809  -0.0123 0.0041  339 HIS A CE1 
+2538 N  NE2 . HIS A 317 ? 0.2664 0.1495 0.1209 0.0201  -0.0151 0.0015  339 HIS A NE2 
+2539 N  N   . ASN A 318 ? 0.3026 0.1560 0.1402 0.0934  0.0013  -0.0380 340 ASN A N   
+2540 C  CA  . ASN A 318 ? 0.2870 0.1816 0.1802 0.0875  -0.0095 -0.0253 340 ASN A CA  
+2541 C  C   . ASN A 318 ? 0.2530 0.1856 0.1803 0.0242  -0.0127 0.0172  340 ASN A C   
+2542 O  O   . ASN A 318 ? 0.3400 0.2355 0.1956 0.0733  0.0116  0.0140  340 ASN A O   
+2543 C  CB  . ASN A 318 ? 0.3556 0.2386 0.2191 0.1485  0.0240  -0.0173 340 ASN A CB  
+2544 C  CG  . ASN A 318 ? 0.3853 0.3639 0.2562 0.0909  0.0197  -0.0280 340 ASN A CG  
+2545 O  OD1 . ASN A 318 ? 0.4141 0.3873 0.2546 0.1519  0.0531  -0.0312 340 ASN A OD1 
+2546 N  ND2 . ASN A 318 ? 0.4709 0.4751 0.2889 0.1495  0.0122  -0.0307 340 ASN A ND2 
+2547 N  N   . GLN A 319 ? 0.2829 0.1420 0.1743 0.0634  -0.0293 0.0327  341 GLN A N   
+2548 C  CA  . GLN A 319 ? 0.3156 0.1505 0.1743 0.0814  -0.0232 -0.0006 341 GLN A CA  
+2549 C  C   . GLN A 319 ? 0.3256 0.1201 0.1620 0.0596  -0.0037 -0.0052 341 GLN A C   
+2550 O  O   . GLN A 319 ? 0.3375 0.1772 0.1720 0.0434  -0.0018 0.0071  341 GLN A O   
+2551 C  CB  . GLN A 319 ? 0.2945 0.1727 0.1751 0.0481  0.0033  -0.0263 341 GLN A CB  
+2552 C  CG  . GLN A 319 ? 0.2942 0.2331 0.1747 0.0631  -0.0089 -0.0108 341 GLN A CG  
+2553 C  CD  . GLN A 319 ? 0.3542 0.2051 0.1887 0.1063  -0.0190 -0.0147 341 GLN A CD  
+2554 O  OE1 . GLN A 319 ? 0.3700 0.1812 0.2054 0.0901  -0.0226 0.0239  341 GLN A OE1 
+2555 N  NE2 . GLN A 319 ? 0.4255 0.1942 0.1905 0.1274  -0.0621 -0.0244 341 GLN A NE2 
+2556 N  N   . LEU A 320 ? 0.3213 0.1603 0.1548 0.0991  0.0221  -0.0102 342 LEU A N   
+2557 C  CA  . LEU A 320 ? 0.3408 0.1411 0.1551 0.0867  0.0323  -0.0047 342 LEU A CA  
+2558 C  C   . LEU A 320 ? 0.3488 0.1468 0.1423 0.1068  0.0080  -0.0068 342 LEU A C   
+2559 O  O   . LEU A 320 ? 0.3484 0.1495 0.1401 0.0652  0.0326  -0.0326 342 LEU A O   
+2560 C  CB  . LEU A 320 ? 0.3622 0.1584 0.1724 0.0996  0.0414  -0.0187 342 LEU A CB  
+2561 C  CG  . LEU A 320 ? 0.3940 0.2404 0.1942 0.1258  0.0094  -0.0110 342 LEU A CG  
+2562 C  CD1 . LEU A 320 ? 0.4331 0.2084 0.2088 0.0530  0.0125  0.0150  342 LEU A CD1 
+2563 C  CD2 . LEU A 320 ? 0.4101 0.3266 0.2003 0.1648  0.0322  -0.0018 342 LEU A CD2 
+2564 N  N   . PRO A 321 ? 0.3526 0.1578 0.1262 0.0700  0.0068  -0.0078 343 PRO A N   
+2565 C  CA  . PRO A 321 ? 0.3290 0.1797 0.1203 0.0464  0.0106  -0.0081 343 PRO A CA  
+2566 C  C   . PRO A 321 ? 0.3311 0.1616 0.1175 0.0416  -0.0137 -0.0240 343 PRO A C   
+2567 O  O   . PRO A 321 ? 0.3336 0.1490 0.1320 0.0728  0.0033  -0.0246 343 PRO A O   
+2568 C  CB  . PRO A 321 ? 0.3476 0.2686 0.1281 0.0384  0.0155  -0.0238 343 PRO A CB  
+2569 C  CG  . PRO A 321 ? 0.4046 0.3117 0.1280 0.0706  0.0186  -0.0425 343 PRO A CG  
+2570 C  CD  . PRO A 321 ? 0.3557 0.2247 0.1268 0.0571  -0.0013 -0.0334 343 PRO A CD  
+2571 N  N   . PRO A 322 ? 0.3057 0.1627 0.1246 0.0479  0.0305  0.0084  344 PRO A N   
+2572 C  CA  . PRO A 322 ? 0.2787 0.1551 0.1283 0.0408  0.0099  -0.0086 344 PRO A CA  
+2573 C  C   . PRO A 322 ? 0.3113 0.1601 0.1348 0.0340  0.0079  -0.0261 344 PRO A C   
+2574 O  O   . PRO A 322 ? 0.3672 0.1946 0.1385 0.0434  -0.0253 -0.0257 344 PRO A O   
+2575 C  CB  . PRO A 322 ? 0.3231 0.2448 0.1362 0.0535  0.0197  -0.0080 344 PRO A CB  
+2576 C  CG  . PRO A 322 ? 0.4239 0.2502 0.1465 0.1299  0.0211  0.0097  344 PRO A CG  
+2577 C  CD  . PRO A 322 ? 0.3948 0.1829 0.1329 0.1192  0.0064  -0.0179 344 PRO A CD  
+2578 N  N   . VAL A 323 ? 0.3645 0.1733 0.1362 0.0336  0.0196  -0.0298 345 VAL A N   
+2579 C  CA  . VAL A 323 ? 0.3857 0.1871 0.1621 0.0752  0.0269  -0.0225 345 VAL A CA  
+2580 C  C   . VAL A 323 ? 0.3805 0.1203 0.1671 -0.0103 0.0222  -0.0416 345 VAL A C   
+2581 O  O   . VAL A 323 ? 0.4615 0.1428 0.1479 -0.0363 0.0314  -0.0161 345 VAL A O   
+2582 C  CB  . VAL A 323 ? 0.4494 0.1320 0.1830 0.0654  0.0247  -0.0094 345 VAL A CB  
+2583 C  CG1 . VAL A 323 ? 0.4830 0.1654 0.2088 0.0943  0.0379  -0.0206 345 VAL A CG1 
+2584 C  CG2 . VAL A 323 ? 0.4401 0.1767 0.1869 0.0256  0.0330  -0.0364 345 VAL A CG2 
+2585 N  N   . THR A 324 ? 0.4122 0.1841 0.1872 -0.0120 0.0331  -0.0312 346 THR A N   
+2586 C  CA  . THR A 324 ? 0.3757 0.1587 0.1973 -0.0277 0.0489  -0.0182 346 THR A CA  
+2587 C  C   . THR A 324 ? 0.3955 0.1867 0.1960 0.0285  0.0764  -0.0068 346 THR A C   
+2588 O  O   . THR A 324 ? 0.4106 0.1754 0.2026 0.0450  0.0620  -0.0027 346 THR A O   
+2589 C  CB  . THR A 324 ? 0.3839 0.2663 0.1992 -0.0087 0.0283  -0.0191 346 THR A CB  
+2590 O  OG1 . THR A 324 ? 0.4151 0.3230 0.2089 -0.0097 0.0130  -0.0013 346 THR A OG1 
+2591 C  CG2 . THR A 324 ? 0.4030 0.3056 0.2104 0.0366  0.0040  -0.0454 346 THR A CG2 
+2592 N  N   . ASP A 325 ? 0.3698 0.1845 0.2030 0.0217  0.0749  -0.0249 347 ASP A N   
+2593 C  CA  . ASP A 325 ? 0.4074 0.2020 0.1959 -0.0070 0.0669  -0.0328 347 ASP A CA  
+2594 C  C   . ASP A 325 ? 0.4047 0.2832 0.1962 0.0242  0.0663  -0.0033 347 ASP A C   
+2595 O  O   . ASP A 325 ? 0.4274 0.1995 0.2218 -0.0046 0.0696  -0.0082 347 ASP A O   
+2596 C  CB  . ASP A 325 ? 0.4488 0.2199 0.1851 -0.0298 0.0583  -0.0419 347 ASP A CB  
+2597 C  CG  . ASP A 325 ? 0.4779 0.2637 0.1920 -0.0236 0.0465  -0.0259 347 ASP A CG  
+2598 O  OD1 . ASP A 325 ? 0.4926 0.2529 0.1978 -0.0295 0.0325  -0.0230 347 ASP A OD1 
+2599 O  OD2 . ASP A 325 ? 0.5583 0.2788 0.2019 -0.0411 0.0292  -0.0061 347 ASP A OD2 
+2600 N  N   . MET A 326 ? 0.3940 0.2206 0.1795 -0.0066 0.0633  -0.0197 348 MET A N   
+2601 C  CA  . MET A 326 ? 0.4647 0.2142 0.1855 -0.0231 0.0835  -0.0179 348 MET A CA  
+2602 C  C   . MET A 326 ? 0.4626 0.2227 0.1948 -0.0138 0.0824  -0.0045 348 MET A C   
+2603 O  O   . MET A 326 ? 0.4618 0.2758 0.2002 -0.0046 0.0682  -0.0068 348 MET A O   
+2604 C  CB  . MET A 326 ? 0.4877 0.2409 0.1906 -0.0020 0.0777  -0.0420 348 MET A CB  
+2605 C  CG  . MET A 326 ? 0.5469 0.2551 0.1987 -0.0431 0.0719  -0.0601 348 MET A CG  
+2606 S  SD  . MET A 326 ? 0.6377 0.2960 0.2238 -0.0372 0.0691  -0.0650 348 MET A SD  
+2607 C  CE  . MET A 326 ? 0.6726 0.4093 0.2319 -0.0515 0.0692  -0.0322 348 MET A CE  
+2608 N  N   . THR A 327 ? 0.4613 0.2132 0.2012 -0.0507 0.0825  -0.0193 349 THR A N   
+2609 C  CA  . THR A 327 ? 0.3952 0.2063 0.2008 -0.0516 0.0643  -0.0079 349 THR A CA  
+2610 C  C   . THR A 327 ? 0.4292 0.1711 0.1907 0.0095  0.0524  -0.0086 349 THR A C   
+2611 O  O   . THR A 327 ? 0.4489 0.1943 0.2105 -0.0098 0.0799  -0.0017 349 THR A O   
+2612 C  CB  . THR A 327 ? 0.4444 0.2499 0.2299 0.0101  0.0604  -0.0009 349 THR A CB  
+2613 O  OG1 . THR A 327 ? 0.5224 0.3187 0.2536 0.0567  0.0648  0.0404  349 THR A OG1 
+2614 C  CG2 . THR A 327 ? 0.3830 0.2827 0.2300 -0.0442 0.0456  -0.0151 349 THR A CG2 
+2615 N  N   . PRO A 328 ? 0.4032 0.1712 0.1759 -0.0219 0.0196  -0.0087 350 PRO A N   
+2616 C  CA  . PRO A 328 ? 0.4047 0.2131 0.1587 -0.0179 0.0349  0.0020  350 PRO A CA  
+2617 C  C   . PRO A 328 ? 0.3752 0.2224 0.1491 0.0059  0.0168  -0.0041 350 PRO A C   
+2618 O  O   . PRO A 328 ? 0.3836 0.2346 0.1477 -0.0328 0.0184  0.0028  350 PRO A O   
+2619 C  CB  . PRO A 328 ? 0.4011 0.2444 0.1589 -0.0316 0.0352  -0.0327 350 PRO A CB  
+2620 C  CG  . PRO A 328 ? 0.4113 0.2038 0.1700 -0.0535 0.0281  -0.0169 350 PRO A CG  
+2621 C  CD  . PRO A 328 ? 0.4137 0.1532 0.1779 -0.0249 0.0311  -0.0171 350 PRO A CD  
+2622 N  N   . THR A 329 ? 0.3662 0.1594 0.1449 -0.0559 -0.0061 -0.0069 351 THR A N   
+2623 C  CA  . THR A 329 ? 0.3642 0.1613 0.1522 -0.0775 0.0014  -0.0377 351 THR A CA  
+2624 C  C   . THR A 329 ? 0.3485 0.2012 0.1512 -0.0836 0.0029  -0.0482 351 THR A C   
+2625 O  O   . THR A 329 ? 0.3887 0.1878 0.1536 -0.0528 0.0315  -0.0268 351 THR A O   
+2626 C  CB  . THR A 329 ? 0.3704 0.2054 0.1657 -0.0920 -0.0011 -0.0255 351 THR A CB  
+2627 O  OG1 . THR A 329 ? 0.4186 0.2225 0.1834 -0.0970 -0.0142 -0.0389 351 THR A OG1 
+2628 C  CG2 . THR A 329 ? 0.4367 0.2010 0.1769 -0.0112 0.0083  -0.0035 351 THR A CG2 
+2629 N  N   . LEU A 330 ? 0.3253 0.2533 0.1489 -0.0693 -0.0020 -0.0597 352 LEU A N   
+2630 C  CA  . LEU A 330 ? 0.3135 0.2103 0.1696 -0.0731 -0.0112 -0.0472 352 LEU A CA  
+2631 C  C   . LEU A 330 ? 0.3351 0.2224 0.1783 -0.0735 -0.0084 -0.0792 352 LEU A C   
+2632 O  O   . LEU A 330 ? 0.3323 0.2582 0.2067 -0.0617 0.0173  -0.0948 352 LEU A O   
+2633 C  CB  . LEU A 330 ? 0.3596 0.1573 0.1747 -0.0784 -0.0267 -0.0329 352 LEU A CB  
+2634 C  CG  . LEU A 330 ? 0.3377 0.1899 0.1801 -0.0295 -0.0263 -0.0118 352 LEU A CG  
+2635 C  CD1 . LEU A 330 ? 0.2536 0.2820 0.1853 -0.0735 -0.0014 0.0221  352 LEU A CD1 
+2636 C  CD2 . LEU A 330 ? 0.3736 0.1816 0.1822 -0.0049 -0.0355 -0.0082 352 LEU A CD2 
+2637 N  N   . SER A 331 ? 0.3708 0.1702 0.1671 -0.0846 0.0178  -0.0377 353 SER A N   
+2638 C  CA  . SER A 331 ? 0.3807 0.1430 0.1546 -0.0269 0.0112  -0.0274 353 SER A CA  
+2639 C  C   . SER A 331 ? 0.3697 0.1757 0.1616 -0.0541 0.0003  -0.0520 353 SER A C   
+2640 O  O   . SER A 331 ? 0.4167 0.2019 0.1662 -0.0817 0.0192  -0.0496 353 SER A O   
+2641 C  CB  . SER A 331 ? 0.4177 0.2479 0.1575 -0.0247 0.0271  0.0281  353 SER A CB  
+2642 O  OG  . SER A 331 ? 0.4763 0.2862 0.1729 -0.0481 0.0264  0.0268  353 SER A OG  
+2643 N  N   . GLY A 332 ? 0.3979 0.1765 0.1587 -0.0452 0.0126  -0.0493 354 GLY A N   
+2644 C  CA  . GLY A 332 ? 0.4100 0.1889 0.1637 -0.0117 0.0115  -0.0426 354 GLY A CA  
+2645 C  C   . GLY A 332 ? 0.4070 0.2164 0.1585 -0.0341 0.0165  -0.0283 354 GLY A C   
+2646 O  O   . GLY A 332 ? 0.3862 0.2770 0.1722 -0.0471 0.0329  -0.0284 354 GLY A O   
+2647 N  N   . ILE A 333 ? 0.3700 0.1989 0.1461 -0.1125 -0.0034 -0.0245 355 ILE A N   
+2648 C  CA  . ILE A 333 ? 0.4021 0.1815 0.1469 -0.0902 -0.0001 -0.0180 355 ILE A CA  
+2649 C  C   . ILE A 333 ? 0.3678 0.1570 0.1374 -0.1170 0.0011  -0.0006 355 ILE A C   
+2650 O  O   . ILE A 333 ? 0.3803 0.2259 0.1333 -0.1483 0.0091  -0.0116 355 ILE A O   
+2651 C  CB  . ILE A 333 ? 0.3818 0.1945 0.1540 -0.1034 0.0041  -0.0257 355 ILE A CB  
+2652 C  CG1 . ILE A 333 ? 0.4287 0.1871 0.1558 -0.0872 -0.0126 -0.0291 355 ILE A CG1 
+2653 C  CG2 . ILE A 333 ? 0.3933 0.2302 0.1670 -0.0604 0.0102  -0.0057 355 ILE A CG2 
+2654 C  CD1 . ILE A 333 ? 0.4492 0.1841 0.1552 -0.1073 -0.0036 -0.0250 355 ILE A CD1 
+2655 N  N   . VAL A 334 ? 0.3634 0.1788 0.1292 -0.0815 -0.0165 -0.0145 356 VAL A N   
+2656 C  CA  . VAL A 334 ? 0.3778 0.1538 0.1356 -0.1042 -0.0040 -0.0060 356 VAL A CA  
+2657 C  C   . VAL A 334 ? 0.3666 0.1815 0.1437 -0.0604 0.0028  -0.0192 356 VAL A C   
+2658 O  O   . VAL A 334 ? 0.3486 0.2060 0.1501 -0.0628 0.0056  -0.0333 356 VAL A O   
+2659 C  CB  . VAL A 334 ? 0.4389 0.1514 0.1472 -0.0959 -0.0065 -0.0092 356 VAL A CB  
+2660 C  CG1 . VAL A 334 ? 0.4163 0.1881 0.1670 -0.0666 -0.0246 -0.0444 356 VAL A CG1 
+2661 C  CG2 . VAL A 334 ? 0.4925 0.2854 0.1635 -0.0855 0.0024  0.0060  356 VAL A CG2 
+2662 N  N   . ASP A 335 ? 0.3548 0.1772 0.1367 -0.0995 0.0118  -0.0316 357 ASP A N   
+2663 C  CA  . ASP A 335 ? 0.3704 0.1824 0.1323 -0.1143 0.0088  -0.0045 357 ASP A CA  
+2664 C  C   . ASP A 335 ? 0.3819 0.1873 0.1238 -0.0783 -0.0051 -0.0323 357 ASP A C   
+2665 O  O   . ASP A 335 ? 0.3871 0.1758 0.1357 -0.0806 0.0141  -0.0123 357 ASP A O   
+2666 C  CB  . ASP A 335 ? 0.3818 0.1659 0.1403 -0.0887 0.0024  -0.0037 357 ASP A CB  
+2667 C  CG  . ASP A 335 ? 0.3382 0.1901 0.1501 -0.1101 -0.0183 -0.0362 357 ASP A CG  
+2668 O  OD1 . ASP A 335 ? 0.3384 0.1849 0.1389 -0.0904 -0.0188 -0.0418 357 ASP A OD1 
+2669 O  OD2 . ASP A 335 ? 0.3869 0.1924 0.1576 -0.0796 -0.0165 -0.0440 357 ASP A OD2 
+2670 N  N   . THR A 336 ? 0.3762 0.1746 0.1189 -0.0895 0.0041  -0.0275 358 THR A N   
+2671 C  CA  . THR A 336 ? 0.3928 0.2354 0.1332 -0.0786 0.0021  -0.0283 358 THR A CA  
+2672 C  C   . THR A 336 ? 0.4062 0.2218 0.1352 -0.1074 0.0171  -0.0298 358 THR A C   
+2673 O  O   . THR A 336 ? 0.4399 0.2040 0.1416 -0.0889 0.0431  0.0011  358 THR A O   
+2674 C  CB  . THR A 336 ? 0.3721 0.2817 0.1454 -0.1111 0.0062  -0.0307 358 THR A CB  
+2675 O  OG1 . THR A 336 ? 0.3788 0.2162 0.1375 -0.0782 0.0107  -0.0251 358 THR A OG1 
+2676 C  CG2 . THR A 336 ? 0.3916 0.3301 0.1578 -0.1199 -0.0145 -0.0482 358 THR A CG2 
+2677 N  N   . ARG A 337 ? 0.3947 0.1722 0.1362 -0.1250 0.0322  -0.0214 359 ARG A N   
+2678 C  CA  . ARG A 337 ? 0.3562 0.1761 0.1458 -0.1310 0.0242  -0.0156 359 ARG A CA  
+2679 C  C   . ARG A 337 ? 0.3936 0.1951 0.1491 -0.1453 0.0203  -0.0140 359 ARG A C   
+2680 O  O   . ARG A 337 ? 0.4175 0.2101 0.1589 -0.1276 0.0211  -0.0143 359 ARG A O   
+2681 C  CB  . ARG A 337 ? 0.3615 0.1981 0.1491 -0.1389 0.0124  -0.0268 359 ARG A CB  
+2682 C  CG  . ARG A 337 ? 0.3827 0.1372 0.1473 -0.0937 0.0240  -0.0155 359 ARG A CG  
+2683 C  CD  . ARG A 337 ? 0.3700 0.1983 0.1449 -0.0979 0.0169  -0.0294 359 ARG A CD  
+2684 N  NE  . ARG A 337 ? 0.4205 0.1747 0.1464 -0.1069 0.0341  -0.0231 359 ARG A NE  
+2685 C  CZ  . ARG A 337 ? 0.4091 0.1816 0.1586 -0.1338 0.0459  -0.0213 359 ARG A CZ  
+2686 N  NH1 . ARG A 337 ? 0.4423 0.2071 0.1569 -0.1247 0.0431  -0.0176 359 ARG A NH1 
+2687 N  NH2 . ARG A 337 ? 0.4261 0.2258 0.1698 -0.1169 0.0617  -0.0154 359 ARG A NH2 
+2688 N  N   . VAL A 338 ? 0.4250 0.1942 0.1498 -0.1344 -0.0016 -0.0096 360 VAL A N   
+2689 C  CA  A VAL A 338 ? 0.3896 0.2336 0.1554 -0.1405 0.0057  -0.0206 360 VAL A CA  
+2690 C  CA  B VAL A 338 ? 0.4182 0.2361 0.1581 -0.1362 0.0121  -0.0060 360 VAL A CA  
+2691 C  C   . VAL A 338 ? 0.4156 0.2405 0.1584 -0.1469 0.0230  -0.0245 360 VAL A C   
+2692 O  O   . VAL A 338 ? 0.4362 0.2548 0.1602 -0.1531 0.0300  -0.0135 360 VAL A O   
+2693 C  CB  A VAL A 338 ? 0.3379 0.2331 0.1635 -0.1562 -0.0014 -0.0238 360 VAL A CB  
+2694 C  CB  B VAL A 338 ? 0.4365 0.2640 0.1677 -0.1695 0.0076  0.0087  360 VAL A CB  
+2695 C  CG1 A VAL A 338 ? 0.3087 0.2563 0.1787 -0.1507 -0.0094 -0.0408 360 VAL A CG1 
+2696 C  CG1 B VAL A 338 ? 0.4761 0.2050 0.1752 -0.1528 -0.0002 -0.0017 360 VAL A CG1 
+2697 C  CG2 A VAL A 338 ? 0.3949 0.1990 0.1551 -0.1339 -0.0119 -0.0215 360 VAL A CG2 
+2698 C  CG2 B VAL A 338 ? 0.4722 0.2952 0.1712 -0.1678 0.0034  0.0208  360 VAL A CG2 
+2699 N  N   . GLU A 339 ? 0.4247 0.2502 0.1714 -0.1671 0.0524  -0.0216 361 GLU A N   
+2700 C  CA  . GLU A 339 ? 0.4640 0.2840 0.2005 -0.1826 0.0629  -0.0098 361 GLU A CA  
+2701 C  C   . GLU A 339 ? 0.4562 0.2618 0.2112 -0.1716 0.0802  -0.0094 361 GLU A C   
+2702 O  O   . GLU A 339 ? 0.4726 0.3158 0.2163 -0.1969 0.0768  -0.0222 361 GLU A O   
+2703 C  CB  . GLU A 339 ? 0.4916 0.4249 0.2315 -0.1787 0.0651  0.0011  361 GLU A CB  
+2704 C  CG  . GLU A 339 ? 0.5187 0.4858 0.2651 -0.2150 0.0581  -0.0407 361 GLU A CG  
+2705 C  CD  . GLU A 339 ? 0.5948 0.6209 0.2948 -0.1627 0.0583  -0.0585 361 GLU A CD  
+2706 O  OE1 . GLU A 339 ? 0.6402 0.6297 0.3153 -0.0860 0.0602  -0.0430 361 GLU A OE1 
+2707 O  OE2 . GLU A 339 ? 0.6147 0.6776 0.3097 -0.1646 0.0541  -0.0903 361 GLU A OE2 
+2708 N  N   . LEU A 340 ? 0.4454 0.2401 0.2157 -0.1713 0.0629  -0.0155 362 LEU A N   
+2709 C  CA  . LEU A 340 ? 0.4561 0.2774 0.2339 -0.1858 0.0853  -0.0185 362 LEU A CA  
+2710 C  C   . LEU A 340 ? 0.5063 0.2876 0.2419 -0.1847 0.1038  -0.0196 362 LEU A C   
+2711 O  O   . LEU A 340 ? 0.5041 0.2800 0.2379 -0.1830 0.1048  -0.0210 362 LEU A O   
+2712 C  CB  . LEU A 340 ? 0.4595 0.2815 0.2477 -0.1571 0.1042  0.0132  362 LEU A CB  
+2713 C  CG  . LEU A 340 ? 0.5043 0.2830 0.2504 -0.1543 0.1105  0.0154  362 LEU A CG  
+2714 C  CD1 . LEU A 340 ? 0.5805 0.2206 0.2400 -0.1422 0.1138  -0.0221 362 LEU A CD1 
+2715 C  CD2 . LEU A 340 ? 0.5399 0.3456 0.2552 -0.1594 0.1128  0.0361  362 LEU A CD2 
+2716 N  N   . ASP A 341 ? 0.5413 0.2837 0.2554 -0.2020 0.1056  -0.0448 363 ASP A N   
+2717 C  CA  . ASP A 341 ? 0.5542 0.3329 0.2817 -0.2349 0.0863  -0.0350 363 ASP A CA  
+2718 C  C   . ASP A 341 ? 0.5743 0.3583 0.2894 -0.2563 0.0505  -0.0346 363 ASP A C   
+2719 O  O   . ASP A 341 ? 0.5819 0.4148 0.2883 -0.2503 0.0381  -0.0438 363 ASP A O   
+2720 C  CB  . ASP A 341 ? 0.5473 0.3737 0.3111 -0.2503 0.1033  -0.0389 363 ASP A CB  
+2721 C  CG  . ASP A 341 ? 0.6259 0.3891 0.3382 -0.2535 0.1399  -0.0345 363 ASP A CG  
+2722 O  OD1 . ASP A 341 ? 0.6593 0.3945 0.3538 -0.2471 0.1598  -0.0281 363 ASP A OD1 
+2723 O  OD2 . ASP A 341 ? 0.7046 0.3745 0.3432 -0.2230 0.1697  -0.0158 363 ASP A OD2 
+2724 N  N   . SER A 342 ? 0.5393 0.3552 0.2956 -0.2500 0.0431  -0.0155 364 SER A N   
+2725 C  CA  . SER A 342 ? 0.5824 0.4813 0.3035 -0.2637 0.0551  0.0155  364 SER A CA  
+2726 C  C   . SER A 342 ? 0.5643 0.5905 0.2963 -0.2784 0.0555  0.0086  364 SER A C   
+2727 O  O   . SER A 342 ? 0.6050 0.6057 0.2912 -0.2562 0.0501  -0.0090 364 SER A O   
+2728 C  CB  . SER A 342 ? 0.6097 0.5554 0.3223 -0.2355 0.0678  0.0686  364 SER A CB  
+2729 O  OG  . SER A 342 ? 0.6440 0.5276 0.3336 -0.2590 0.0776  0.0829  364 SER A OG  
+2730 N  N   . HIS A 343 ? 0.5793 0.6742 0.2919 -0.2454 0.0459  0.0056  365 HIS A N   
+2731 C  CA  . HIS A 343 ? 0.6023 0.7048 0.2952 -0.2137 0.0377  0.0028  365 HIS A CA  
+2732 C  C   . HIS A 343 ? 0.5511 0.5997 0.2841 -0.2274 0.0487  0.0266  365 HIS A C   
+2733 O  O   . HIS A 343 ? 0.5445 0.6574 0.2965 -0.1787 0.0651  0.0548  365 HIS A O   
+2734 C  CB  . HIS A 343 ? 0.6748 0.8251 0.3104 -0.1434 0.0182  -0.0195 365 HIS A CB  
+2735 C  CG  . HIS A 343 ? 0.7369 0.8843 0.3235 -0.1023 0.0019  -0.0457 365 HIS A CG  
+2736 N  ND1 . HIS A 343 ? 0.7584 0.9029 0.3239 -0.1070 -0.0089 -0.0608 365 HIS A ND1 
+2737 C  CD2 . HIS A 343 ? 0.7735 0.9247 0.3314 -0.0581 -0.0063 -0.0523 365 HIS A CD2 
+2738 C  CE1 . HIS A 343 ? 0.7646 0.9087 0.3250 -0.0953 -0.0079 -0.0709 365 HIS A CE1 
+2739 N  NE2 . HIS A 343 ? 0.7791 0.9261 0.3286 -0.0590 -0.0111 -0.0740 365 HIS A NE2 
+2740 N  N   . PHE A 344 ? 0.5350 0.5171 0.2609 -0.2343 0.0478  0.0364  366 PHE A N   
+2741 C  CA  . PHE A 344 ? 0.5192 0.4658 0.2418 -0.2339 0.0342  0.0080  366 PHE A CA  
+2742 C  C   . PHE A 344 ? 0.5203 0.4491 0.2348 -0.2233 0.0254  -0.0050 366 PHE A C   
+2743 O  O   . PHE A 344 ? 0.5766 0.3712 0.2316 -0.2323 0.0285  0.0060  366 PHE A O   
+2744 C  CB  . PHE A 344 ? 0.4610 0.3747 0.2337 -0.2452 0.0265  -0.0078 366 PHE A CB  
+2745 C  CG  . PHE A 344 ? 0.4237 0.3220 0.2274 -0.2168 0.0340  -0.0230 366 PHE A CG  
+2746 C  CD1 . PHE A 344 ? 0.4107 0.3011 0.2249 -0.1924 0.0357  -0.0658 366 PHE A CD1 
+2747 C  CD2 . PHE A 344 ? 0.4596 0.4029 0.2313 -0.1373 0.0338  -0.0192 366 PHE A CD2 
+2748 C  CE1 . PHE A 344 ? 0.4293 0.3202 0.2226 -0.1787 0.0269  -0.0513 366 PHE A CE1 
+2749 C  CE2 . PHE A 344 ? 0.4170 0.4079 0.2275 -0.1304 0.0506  -0.0417 366 PHE A CE2 
+2750 C  CZ  . PHE A 344 ? 0.4157 0.3934 0.2256 -0.1505 0.0422  -0.0312 366 PHE A CZ  
+2751 N  N   . ASP A 345 ? 0.4708 0.4811 0.2332 -0.2136 0.0006  -0.0249 367 ASP A N   
+2752 C  CA  . ASP A 345 ? 0.4757 0.4595 0.2249 -0.2247 -0.0075 -0.0090 367 ASP A CA  
+2753 C  C   . ASP A 345 ? 0.4422 0.3598 0.2103 -0.2263 -0.0119 -0.0053 367 ASP A C   
+2754 O  O   . ASP A 345 ? 0.4349 0.3630 0.2004 -0.1710 0.0030  0.0189  367 ASP A O   
+2755 C  CB  . ASP A 345 ? 0.4811 0.6060 0.2393 -0.2180 -0.0081 -0.0032 367 ASP A CB  
+2756 C  CG  . ASP A 345 ? 0.4968 0.6895 0.2507 -0.2110 -0.0223 -0.0232 367 ASP A CG  
+2757 O  OD1 . ASP A 345 ? 0.4680 0.6986 0.2481 -0.2233 -0.0147 -0.0224 367 ASP A OD1 
+2758 O  OD2 . ASP A 345 ? 0.5347 0.7194 0.2632 -0.2159 -0.0190 -0.0242 367 ASP A OD2 
+2759 N  N   . PRO A 346 ? 0.5157 0.2652 0.2132 -0.1805 0.0058  -0.0082 368 PRO A N   
+2760 C  CA  . PRO A 346 ? 0.4959 0.2205 0.2223 -0.1615 0.0024  -0.0189 368 PRO A CA  
+2761 C  C   . PRO A 346 ? 0.4497 0.2751 0.2172 -0.1914 0.0105  -0.0358 368 PRO A C   
+2762 O  O   . PRO A 346 ? 0.4436 0.2835 0.2141 -0.1866 0.0028  -0.0448 368 PRO A O   
+2763 C  CB  . PRO A 346 ? 0.5778 0.2212 0.2277 -0.0984 -0.0004 -0.0603 368 PRO A CB  
+2764 C  CG  . PRO A 346 ? 0.5865 0.3155 0.2296 -0.1146 0.0113  -0.0296 368 PRO A CG  
+2765 C  CD  . PRO A 346 ? 0.5406 0.2728 0.2237 -0.1725 0.0153  -0.0409 368 PRO A CD  
+2766 N  N   . LEU A 347 ? 0.4261 0.3198 0.2182 -0.1947 0.0069  -0.0278 369 LEU A N   
+2767 C  CA  . LEU A 347 ? 0.4148 0.3260 0.2111 -0.1622 0.0176  -0.0405 369 LEU A CA  
+2768 C  C   . LEU A 347 ? 0.4009 0.3018 0.2229 -0.1986 0.0355  -0.0138 369 LEU A C   
+2769 O  O   . LEU A 347 ? 0.3821 0.3631 0.2181 -0.1223 0.0411  0.0380  369 LEU A O   
+2770 C  CB  . LEU A 347 ? 0.4764 0.2995 0.2080 -0.0903 -0.0011 -0.0621 369 LEU A CB  
+2771 C  CG  . LEU A 347 ? 0.4709 0.3589 0.2138 -0.0766 -0.0069 -0.0718 369 LEU A CG  
+2772 C  CD1 . LEU A 347 ? 0.4632 0.4040 0.2222 -0.0735 -0.0012 -0.0702 369 LEU A CD1 
+2773 C  CD2 . LEU A 347 ? 0.4500 0.3624 0.2144 -0.0908 0.0146  -0.0585 369 LEU A CD2 
+2774 N  N   . ILE A 348 ? 0.4325 0.3782 0.2424 -0.1548 0.0315  -0.0278 370 ILE A N   
+2775 C  CA  . ILE A 348 ? 0.3963 0.3871 0.2681 -0.1701 0.0360  -0.0392 370 ILE A CA  
+2776 C  C   . ILE A 348 ? 0.4031 0.3769 0.2595 -0.0758 0.0294  -0.0455 370 ILE A C   
+2777 O  O   . ILE A 348 ? 0.3625 0.3030 0.2604 -0.0858 0.0196  -0.0235 370 ILE A O   
+2778 C  CB  . ILE A 348 ? 0.4520 0.4945 0.3125 -0.1395 0.0559  -0.0002 370 ILE A CB  
+2779 C  CG1 . ILE A 348 ? 0.5269 0.6324 0.3206 -0.0564 0.0587  0.0040  370 ILE A CG1 
+2780 C  CG2 . ILE A 348 ? 0.4659 0.5552 0.3293 -0.0989 0.0711  0.0106  370 ILE A CG2 
+2781 C  CD1 . ILE A 348 ? 0.5561 0.7147 0.3257 -0.0134 0.0645  0.0138  370 ILE A CD1 
+2782 N  N   . GLY A 349 ? 0.4003 0.4198 0.2580 -0.0490 0.0313  -0.0521 371 GLY A N   
+2783 C  CA  . GLY A 349 ? 0.3669 0.3676 0.2392 -0.0486 0.0447  -0.0365 371 GLY A CA  
+2784 C  C   . GLY A 349 ? 0.3708 0.2845 0.2144 -0.0694 0.0408  -0.0053 371 GLY A C   
+2785 O  O   . GLY A 349 ? 0.3477 0.2761 0.2253 -0.0622 0.0264  -0.0086 371 GLY A O   
+2786 N  N   . ILE A 350 ? 0.3696 0.2859 0.1777 -0.0484 0.0258  -0.0175 372 ILE A N   
+2787 C  CA  . ILE A 350 ? 0.3683 0.2446 0.1660 -0.0921 0.0167  -0.0272 372 ILE A CA  
+2788 C  C   . ILE A 350 ? 0.3615 0.2116 0.1690 -0.0912 0.0052  -0.0288 372 ILE A C   
+2789 O  O   . ILE A 350 ? 0.3599 0.2760 0.1671 -0.0926 -0.0067 -0.0325 372 ILE A O   
+2790 C  CB  . ILE A 350 ? 0.4251 0.3439 0.1612 -0.0474 0.0190  -0.0054 372 ILE A CB  
+2791 C  CG1 . ILE A 350 ? 0.4326 0.4550 0.1691 -0.0586 0.0277  0.0446  372 ILE A CG1 
+2792 C  CG2 . ILE A 350 ? 0.4831 0.2703 0.1646 -0.0145 0.0042  -0.0141 372 ILE A CG2 
+2793 C  CD1 . ILE A 350 ? 0.4980 0.5454 0.1921 -0.0173 0.0179  0.0172  372 ILE A CD1 
+2794 N  N   . THR A 351 ? 0.3816 0.2217 0.1634 -0.0908 0.0097  -0.0332 373 THR A N   
+2795 C  CA  . THR A 351 ? 0.3664 0.1564 0.1567 -0.0535 0.0169  -0.0351 373 THR A CA  
+2796 C  C   . THR A 351 ? 0.3873 0.1773 0.1472 -0.0597 0.0043  -0.0551 373 THR A C   
+2797 O  O   . THR A 351 ? 0.3878 0.2200 0.1406 -0.0698 0.0132  -0.0625 373 THR A O   
+2798 C  CB  . THR A 351 ? 0.3774 0.2166 0.1647 -0.0521 0.0221  -0.0325 373 THR A CB  
+2799 O  OG1 . THR A 351 ? 0.4141 0.2079 0.1705 -0.0588 0.0214  -0.0340 373 THR A OG1 
+2800 C  CG2 . THR A 351 ? 0.4159 0.2738 0.1833 -0.0526 0.0078  -0.0268 373 THR A CG2 
+2801 N  N   . ALA A 352 ? 0.3990 0.2003 0.1470 -0.0786 -0.0197 -0.0465 374 ALA A N   
+2802 C  CA  . ALA A 352 ? 0.4061 0.1612 0.1556 -0.0574 -0.0286 -0.0308 374 ALA A CA  
+2803 C  C   . ALA A 352 ? 0.4002 0.1325 0.1640 -0.0684 -0.0191 -0.0202 374 ALA A C   
+2804 O  O   . ALA A 352 ? 0.3828 0.1684 0.1778 -0.0095 -0.0401 -0.0308 374 ALA A O   
+2805 C  CB  . ALA A 352 ? 0.3735 0.1362 0.1649 -0.0394 -0.0333 -0.0201 374 ALA A CB  
+2806 N  N   . LYS A 353 ? 0.3816 0.1714 0.1659 -0.0864 0.0139  -0.0161 375 LYS A N   
+2807 C  CA  . LYS A 353 ? 0.4107 0.1499 0.1630 -0.0471 -0.0268 -0.0187 375 LYS A CA  
+2808 C  C   . LYS A 353 ? 0.4567 0.1574 0.1463 -0.0527 -0.0199 -0.0043 375 LYS A C   
+2809 O  O   . LYS A 353 ? 0.4492 0.2030 0.1281 -0.0073 -0.0159 -0.0020 375 LYS A O   
+2810 C  CB  . LYS A 353 ? 0.4454 0.2040 0.1888 -0.0433 -0.0330 -0.0406 375 LYS A CB  
+2811 C  CG  . LYS A 353 ? 0.4863 0.1646 0.2099 -0.0066 -0.0372 -0.0583 375 LYS A CG  
+2812 C  CD  . LYS A 353 ? 0.5535 0.1669 0.2413 0.0259  0.0254  -0.0264 375 LYS A CD  
+2813 C  CE  . LYS A 353 ? 0.6333 0.2020 0.2676 -0.0258 0.0538  -0.0280 375 LYS A CE  
+2814 N  NZ  . LYS A 353 ? 0.6730 0.2024 0.2886 -0.0499 0.0782  -0.0245 375 LYS A NZ  
+2815 N  N   . ASP A 354 ? 0.4359 0.1883 0.1442 -0.0611 -0.0034 -0.0216 376 ASP A N   
+2816 C  CA  . ASP A 354 ? 0.4267 0.1850 0.1507 -0.0775 -0.0202 -0.0395 376 ASP A CA  
+2817 C  C   . ASP A 354 ? 0.4444 0.2065 0.1484 -0.0569 -0.0215 -0.0320 376 ASP A C   
+2818 O  O   . ASP A 354 ? 0.4056 0.2093 0.1515 -0.0829 -0.0127 -0.0190 376 ASP A O   
+2819 C  CB  . ASP A 354 ? 0.4166 0.1809 0.1541 -0.0833 -0.0178 -0.0399 376 ASP A CB  
+2820 C  CG  . ASP A 354 ? 0.4891 0.2577 0.1491 -0.0586 0.0092  -0.0315 376 ASP A CG  
+2821 O  OD1 . ASP A 354 ? 0.4850 0.2065 0.1548 -0.0810 0.0059  -0.0233 376 ASP A OD1 
+2822 O  OD2 . ASP A 354 ? 0.5230 0.2099 0.1493 -0.0672 0.0044  -0.0317 376 ASP A OD2 
+2823 N  N   . TYR A 355 ? 0.4687 0.1951 0.1625 -0.0517 -0.0075 -0.0382 377 TYR A N   
+2824 C  CA  . TYR A 355 ? 0.4877 0.1906 0.1670 -0.0491 -0.0122 -0.0452 377 TYR A CA  
+2825 C  C   . TYR A 355 ? 0.4840 0.1714 0.1784 -0.0796 0.0094  -0.0219 377 TYR A C   
+2826 O  O   . TYR A 355 ? 0.5246 0.1943 0.1858 -0.0751 0.0244  -0.0238 377 TYR A O   
+2827 C  CB  . TYR A 355 ? 0.4943 0.2157 0.1580 -0.0469 0.0140  -0.0533 377 TYR A CB  
+2828 C  CG  . TYR A 355 ? 0.5080 0.2990 0.1521 -0.0486 0.0069  -0.0272 377 TYR A CG  
+2829 C  CD1 . TYR A 355 ? 0.4903 0.2619 0.1605 -0.0792 0.0184  -0.0085 377 TYR A CD1 
+2830 C  CD2 . TYR A 355 ? 0.5216 0.3143 0.1521 -0.0440 0.0131  -0.0386 377 TYR A CD2 
+2831 C  CE1 . TYR A 355 ? 0.5060 0.3011 0.1567 -0.0715 0.0262  -0.0123 377 TYR A CE1 
+2832 C  CE2 . TYR A 355 ? 0.5625 0.3640 0.1558 -0.0516 0.0342  -0.0210 377 TYR A CE2 
+2833 C  CZ  . TYR A 355 ? 0.5453 0.3252 0.1547 -0.0695 0.0439  -0.0169 377 TYR A CZ  
+2834 O  OH  . TYR A 355 ? 0.5803 0.4271 0.1629 -0.0215 0.0708  -0.0173 377 TYR A OH  
+2835 N  N   . GLN A 356 ? 0.4825 0.1745 0.1758 -0.1201 0.0165  -0.0154 378 GLN A N   
+2836 C  CA  . GLN A 356 ? 0.5127 0.1941 0.1757 -0.0755 0.0186  0.0181  378 GLN A CA  
+2837 C  C   . GLN A 356 ? 0.5104 0.1831 0.1736 -0.0537 0.0100  0.0226  378 GLN A C   
+2838 O  O   . GLN A 356 ? 0.5290 0.2467 0.1716 -0.0705 -0.0071 0.0116  378 GLN A O   
+2839 C  CB  . GLN A 356 ? 0.5504 0.2459 0.1790 -0.0766 0.0069  -0.0244 378 GLN A CB  
+2840 C  CG  . GLN A 356 ? 0.5813 0.2220 0.1957 -0.0950 0.0157  -0.0497 378 GLN A CG  
+2841 C  CD  . GLN A 356 ? 0.6910 0.3234 0.2076 -0.0500 0.0311  -0.0561 378 GLN A CD  
+2842 O  OE1 . GLN A 356 ? 0.7219 0.4269 0.2317 -0.0140 0.0456  -0.0819 378 GLN A OE1 
+2843 N  NE2 . GLN A 356 ? 0.7390 0.3548 0.1952 0.0154  0.0432  -0.0310 378 GLN A NE2 
+2844 N  N   . GLY A 357 ? 0.4973 0.1756 0.1832 -0.0248 0.0006  -0.0227 379 GLY A N   
+2845 C  CA  . GLY A 357 ? 0.4909 0.1630 0.1885 -0.0724 -0.0159 -0.0227 379 GLY A CA  
+2846 C  C   . GLY A 357 ? 0.4512 0.1597 0.1867 -0.1011 -0.0277 -0.0136 379 GLY A C   
+2847 O  O   . GLY A 357 ? 0.5075 0.2569 0.1869 -0.0445 -0.0132 -0.0136 379 GLY A O   
+2848 N  N   . ASN A 358 ? 0.4583 0.1992 0.1752 -0.0919 -0.0184 -0.0228 380 ASN A N   
+2849 C  CA  . ASN A 358 ? 0.4610 0.2032 0.1744 -0.0962 -0.0238 -0.0181 380 ASN A CA  
+2850 C  C   . ASN A 358 ? 0.4493 0.1718 0.1839 -0.1104 -0.0165 -0.0221 380 ASN A C   
+2851 O  O   . ASN A 358 ? 0.4765 0.2030 0.1864 -0.0649 -0.0209 -0.0167 380 ASN A O   
+2852 C  CB  . ASN A 358 ? 0.4921 0.2737 0.1622 -0.1440 -0.0232 0.0027  380 ASN A CB  
+2853 C  CG  . ASN A 358 ? 0.5699 0.3587 0.1636 -0.1007 -0.0445 -0.0106 380 ASN A CG  
+2854 O  OD1 . ASN A 358 ? 0.6251 0.5087 0.1778 -0.0806 -0.0593 -0.0180 380 ASN A OD1 
+2855 N  ND2 . ASN A 358 ? 0.5546 0.3177 0.1586 -0.0912 -0.0278 -0.0089 380 ASN A ND2 
+2856 N  N   . ASP A 359 ? 0.4243 0.2609 0.1904 -0.1215 -0.0163 -0.0247 381 ASP A N   
+2857 C  CA  . ASP A 359 ? 0.4316 0.2175 0.2096 -0.1565 -0.0382 -0.0035 381 ASP A CA  
+2858 C  C   . ASP A 359 ? 0.4386 0.1845 0.2064 -0.1295 -0.0458 -0.0031 381 ASP A C   
+2859 O  O   . ASP A 359 ? 0.4556 0.2273 0.2305 -0.1026 -0.0762 -0.0073 381 ASP A O   
+2860 C  CB  . ASP A 359 ? 0.5041 0.2754 0.2295 -0.1430 -0.0421 0.0145  381 ASP A CB  
+2861 C  CG  . ASP A 359 ? 0.5238 0.4250 0.2372 -0.2144 -0.0358 0.0137  381 ASP A CG  
+2862 O  OD1 . ASP A 359 ? 0.5718 0.4399 0.2220 -0.1305 -0.0310 0.0456  381 ASP A OD1 
+2863 O  OD2 . ASP A 359 ? 0.5653 0.6368 0.2529 -0.2022 -0.0404 0.0153  381 ASP A OD2 
+2864 N  N   . ILE A 360 ? 0.4507 0.1715 0.1879 -0.0819 -0.0338 -0.0380 382 ILE A N   
+2865 C  CA  . ILE A 360 ? 0.5006 0.2103 0.1787 -0.0500 -0.0281 -0.0466 382 ILE A CA  
+2866 C  C   . ILE A 360 ? 0.4583 0.1424 0.1753 -0.0470 0.0040  -0.0345 382 ILE A C   
+2867 O  O   . ILE A 360 ? 0.4184 0.1732 0.1777 -0.1170 0.0088  -0.0294 382 ILE A O   
+2868 C  CB  . ILE A 360 ? 0.4884 0.2124 0.1759 -0.1116 -0.0239 -0.0363 382 ILE A CB  
+2869 C  CG1 . ILE A 360 ? 0.5031 0.1761 0.1832 -0.1079 -0.0166 -0.0156 382 ILE A CG1 
+2870 C  CG2 . ILE A 360 ? 0.5170 0.2207 0.1716 -0.1051 -0.0377 -0.0294 382 ILE A CG2 
+2871 C  CD1 . ILE A 360 ? 0.4907 0.1919 0.1818 -0.0668 -0.0007 -0.0176 382 ILE A CD1 
+2872 N  N   . THR A 361 ? 0.4162 0.1698 0.1829 -0.0294 -0.0031 -0.0249 383 THR A N   
+2873 C  CA  . THR A 361 ? 0.4012 0.1356 0.1924 -0.0892 -0.0201 -0.0036 383 THR A CA  
+2874 C  C   . THR A 361 ? 0.3988 0.2179 0.2025 -0.1034 -0.0181 -0.0464 383 THR A C   
+2875 O  O   . THR A 361 ? 0.4420 0.1814 0.1977 -0.0976 -0.0243 -0.0401 383 THR A O   
+2876 C  CB  . THR A 361 ? 0.3927 0.1971 0.1960 -0.0935 -0.0252 -0.0246 383 THR A CB  
+2877 O  OG1 . THR A 361 ? 0.4199 0.2024 0.1966 -0.1333 0.0045  -0.0333 383 THR A OG1 
+2878 C  CG2 . THR A 361 ? 0.3694 0.2587 0.2009 -0.0518 -0.0411 -0.0182 383 THR A CG2 
+2879 N  N   . ALA A 362 ? 0.4311 0.2407 0.2170 -0.1309 -0.0237 -0.0639 384 ALA A N   
+2880 C  CA  . ALA A 362 ? 0.4715 0.2540 0.2283 -0.1388 -0.0247 -0.0652 384 ALA A CA  
+2881 C  C   . ALA A 362 ? 0.4723 0.1943 0.2188 -0.1036 -0.0087 -0.0553 384 ALA A C   
+2882 O  O   . ALA A 362 ? 0.4540 0.1946 0.2288 -0.1302 0.0092  -0.0377 384 ALA A O   
+2883 C  CB  . ALA A 362 ? 0.5410 0.3071 0.2465 -0.0901 -0.0407 -0.0799 384 ALA A CB  
+2884 N  N   . ASP A 363 ? 0.4715 0.2462 0.2028 -0.0837 -0.0013 -0.0541 385 ASP A N   
+2885 C  CA  . ASP A 363 ? 0.4483 0.2039 0.2005 -0.1125 -0.0196 -0.0498 385 ASP A CA  
+2886 C  C   . ASP A 363 ? 0.4406 0.1959 0.1984 -0.1046 -0.0142 -0.0525 385 ASP A C   
+2887 O  O   . ASP A 363 ? 0.4678 0.2072 0.2005 -0.0415 -0.0136 -0.0541 385 ASP A O   
+2888 C  CB  . ASP A 363 ? 0.4417 0.2436 0.1913 -0.1320 -0.0129 -0.0570 385 ASP A CB  
+2889 C  CG  . ASP A 363 ? 0.5469 0.2504 0.1984 -0.1516 0.0012  -0.0427 385 ASP A CG  
+2890 O  OD1 . ASP A 363 ? 0.5275 0.2903 0.2145 -0.1932 0.0094  -0.0450 385 ASP A OD1 
+2891 O  OD2 . ASP A 363 ? 0.6433 0.3171 0.2003 -0.1418 0.0028  -0.0228 385 ASP A OD2 
+2892 N  N   . VAL A 364 ? 0.4437 0.1787 0.1982 -0.1032 -0.0189 -0.0388 386 VAL A N   
+2893 C  CA  . VAL A 364 ? 0.4101 0.1799 0.1963 -0.1245 -0.0072 -0.0267 386 VAL A CA  
+2894 C  C   . VAL A 364 ? 0.4770 0.1572 0.1969 -0.0834 0.0065  -0.0322 386 VAL A C   
+2895 O  O   . VAL A 364 ? 0.5137 0.2133 0.2123 -0.1063 -0.0073 -0.0043 386 VAL A O   
+2896 C  CB  . VAL A 364 ? 0.4463 0.1584 0.1971 -0.0611 -0.0349 -0.0434 386 VAL A CB  
+2897 C  CG1 . VAL A 364 ? 0.4432 0.1709 0.1972 -0.0574 -0.0357 -0.0545 386 VAL A CG1 
+2898 C  CG2 . VAL A 364 ? 0.4584 0.1797 0.1971 -0.0823 -0.0503 -0.0386 386 VAL A CG2 
+2899 N  N   . THR A 365 ? 0.5001 0.1646 0.1861 -0.0533 0.0023  -0.0192 387 THR A N   
+2900 C  CA  . THR A 365 ? 0.5405 0.1869 0.2063 -0.0586 0.0149  -0.0258 387 THR A CA  
+2901 C  C   . THR A 365 ? 0.5163 0.1747 0.1978 -0.1112 0.0369  0.0039  387 THR A C   
+2902 O  O   . THR A 365 ? 0.5023 0.1875 0.1908 -0.0680 0.0330  -0.0215 387 THR A O   
+2903 C  CB  . THR A 365 ? 0.5942 0.2124 0.2318 -0.0268 -0.0057 -0.0297 387 THR A CB  
+2904 O  OG1 . THR A 365 ? 0.5722 0.2303 0.2415 -0.0106 0.0106  -0.0137 387 THR A OG1 
+2905 C  CG2 . THR A 365 ? 0.6476 0.2135 0.2432 0.0288  -0.0318 -0.0635 387 THR A CG2 
+2906 N  N   . VAL A 366 ? 0.5439 0.2190 0.1903 -0.1435 0.0242  0.0113  388 VAL A N   
+2907 C  CA  . VAL A 366 ? 0.5606 0.2505 0.1919 -0.0682 0.0124  -0.0108 388 VAL A CA  
+2908 C  C   . VAL A 366 ? 0.6021 0.2251 0.2034 -0.0602 0.0208  -0.0111 388 VAL A C   
+2909 O  O   . VAL A 366 ? 0.6539 0.1809 0.2188 -0.0819 -0.0086 0.0045  388 VAL A O   
+2910 C  CB  . VAL A 366 ? 0.5632 0.3152 0.1940 -0.0651 0.0163  -0.0122 388 VAL A CB  
+2911 C  CG1 . VAL A 366 ? 0.5691 0.3376 0.1961 -0.0428 0.0414  -0.0405 388 VAL A CG1 
+2912 C  CG2 . VAL A 366 ? 0.5952 0.3439 0.2141 -0.0569 0.0192  -0.0264 388 VAL A CG2 
+2913 N  N   . SER A 367 ? 0.5792 0.2144 0.1996 -0.0026 0.0127  -0.0216 389 SER A N   
+2914 C  CA  . SER A 367 ? 0.6165 0.2867 0.2094 0.0538  0.0223  -0.0515 389 SER A CA  
+2915 C  C   . SER A 367 ? 0.6138 0.2283 0.2096 -0.0065 0.0462  -0.0175 389 SER A C   
+2916 O  O   . SER A 367 ? 0.6044 0.2011 0.1958 0.0067  0.0566  0.0129  389 SER A O   
+2917 C  CB  . SER A 367 ? 0.6521 0.4763 0.2273 0.0950  0.0062  -0.0824 389 SER A CB  
+2918 O  OG  . SER A 367 ? 0.6861 0.5957 0.2381 0.0913  0.0176  -0.1221 389 SER A OG  
+2919 N  N   . GLY A 368 ? 0.6363 0.1729 0.2240 0.0131  0.0652  -0.0011 390 GLY A N   
+2920 C  CA  . GLY A 368 ? 0.6439 0.2557 0.2385 -0.0078 0.0521  -0.0266 390 GLY A CA  
+2921 C  C   . GLY A 368 ? 0.7061 0.2803 0.2614 -0.0374 0.0641  -0.0534 390 GLY A C   
+2922 O  O   . GLY A 368 ? 0.7418 0.3272 0.2766 -0.0730 0.0706  -0.0656 390 GLY A O   
+2923 N  N   . SER A 369 ? 0.7273 0.2331 0.2785 -0.0753 0.0970  -0.0361 391 SER A N   
+2924 C  CA  A SER A 369 ? 0.7466 0.2549 0.2824 -0.0792 0.1049  -0.0479 391 SER A CA  
+2925 C  CA  B SER A 369 ? 0.7840 0.2412 0.2871 -0.0424 0.1049  -0.0338 391 SER A CA  
+2926 C  C   . SER A 369 ? 0.7462 0.2483 0.2838 -0.0786 0.1076  -0.0478 391 SER A C   
+2927 O  O   . SER A 369 ? 0.7620 0.2822 0.2864 -0.0098 0.1019  -0.0382 391 SER A O   
+2928 C  CB  A SER A 369 ? 0.7588 0.3128 0.2843 -0.0956 0.1082  -0.0626 391 SER A CB  
+2929 C  CB  B SER A 369 ? 0.8602 0.3296 0.2965 -0.0067 0.1017  -0.0234 391 SER A CB  
+2930 O  OG  A SER A 369 ? 0.7616 0.3394 0.2840 -0.1149 0.1116  -0.0727 391 SER A OG  
+2931 O  OG  B SER A 369 ? 0.9134 0.3324 0.3017 0.0110  0.0971  -0.0056 391 SER A OG  
+2932 N  N   . VAL A 370 ? 0.7097 0.2947 0.2773 -0.1979 0.1214  -0.0596 392 VAL A N   
+2933 C  CA  . VAL A 370 ? 0.6522 0.2901 0.2602 -0.2077 0.1242  -0.0559 392 VAL A CA  
+2934 C  C   . VAL A 370 ? 0.6702 0.2783 0.2761 -0.1962 0.1195  -0.0550 392 VAL A C   
+2935 O  O   . VAL A 370 ? 0.7634 0.3067 0.2809 -0.2107 0.1350  -0.0544 392 VAL A O   
+2936 C  CB  . VAL A 370 ? 0.6511 0.3038 0.2442 -0.2167 0.1212  -0.0503 392 VAL A CB  
+2937 C  CG1 . VAL A 370 ? 0.6776 0.3594 0.2448 -0.1522 0.1450  -0.0164 392 VAL A CG1 
+2938 C  CG2 . VAL A 370 ? 0.6698 0.3124 0.2372 -0.2164 0.0884  -0.0202 392 VAL A CG2 
+2939 N  N   . ASN A 371 ? 0.6488 0.2465 0.2918 -0.1582 0.1447  -0.0336 393 ASN A N   
+2940 C  CA  . ASN A 371 ? 0.6176 0.2562 0.3066 -0.1693 0.1396  -0.0301 393 ASN A CA  
+2941 C  C   . ASN A 371 ? 0.5758 0.2589 0.2962 -0.1742 0.1327  -0.0313 393 ASN A C   
+2942 O  O   . ASN A 371 ? 0.6214 0.2496 0.2849 -0.1643 0.1301  -0.0317 393 ASN A O   
+2943 C  CB  . ASN A 371 ? 0.6564 0.2760 0.3316 -0.1691 0.1447  -0.0078 393 ASN A CB  
+2944 C  CG  . ASN A 371 ? 0.6924 0.3231 0.3505 -0.1557 0.1420  -0.0146 393 ASN A CG  
+2945 O  OD1 . ASN A 371 ? 0.6752 0.2783 0.3597 -0.1795 0.1556  -0.0242 393 ASN A OD1 
+2946 N  ND2 . ASN A 371 ? 0.7369 0.3337 0.3589 -0.1625 0.1401  0.0053  393 ASN A ND2 
+2947 N  N   . THR A 372 ? 0.5765 0.2676 0.3018 -0.1294 0.1570  -0.0039 394 THR A N   
+2948 C  CA  . THR A 372 ? 0.5663 0.3052 0.3065 -0.1160 0.1280  0.0082  394 THR A CA  
+2949 C  C   . THR A 372 ? 0.5799 0.2480 0.2944 -0.1387 0.1270  0.0130  394 THR A C   
+2950 O  O   . THR A 372 ? 0.5857 0.2180 0.2875 -0.1353 0.1055  -0.0027 394 THR A O   
+2951 C  CB  . THR A 372 ? 0.5125 0.3525 0.3226 -0.1997 0.0839  0.0260  394 THR A CB  
+2952 O  OG1 . THR A 372 ? 0.5060 0.4426 0.3419 -0.2301 0.0664  0.0553  394 THR A OG1 
+2953 C  CG2 . THR A 372 ? 0.5165 0.3583 0.3219 -0.2017 0.0614  0.0240  394 THR A CG2 
+2954 N  N   . ASN A 373 ? 0.5553 0.2660 0.2993 -0.1687 0.1191  -0.0011 395 ASN A N   
+2955 C  CA  . ASN A 373 ? 0.5385 0.2844 0.3151 -0.1838 0.1042  0.0088  395 ASN A CA  
+2956 C  C   . ASN A 373 ? 0.5832 0.2787 0.3029 -0.1621 0.1210  0.0180  395 ASN A C   
+2957 O  O   . ASN A 373 ? 0.5992 0.2986 0.2963 -0.1151 0.1220  0.0305  395 ASN A O   
+2958 C  CB  . ASN A 373 ? 0.6031 0.2671 0.3332 -0.1761 0.1157  -0.0019 395 ASN A CB  
+2959 C  CG  . ASN A 373 ? 0.6642 0.2522 0.3519 -0.1549 0.1281  0.0001  395 ASN A CG  
+2960 O  OD1 . ASN A 373 ? 0.7395 0.2871 0.3633 -0.1309 0.1367  0.0489  395 ASN A OD1 
+2961 N  ND2 . ASN A 373 ? 0.7025 0.2983 0.3611 -0.1904 0.1416  -0.0045 395 ASN A ND2 
+2962 N  N   . GLN A 374 ? 0.5900 0.3108 0.2984 -0.1604 0.1200  0.0387  396 GLN A N   
+2963 C  CA  . GLN A 374 ? 0.6188 0.3058 0.2909 -0.1668 0.1040  0.0377  396 GLN A CA  
+2964 C  C   . GLN A 374 ? 0.5687 0.2436 0.2743 -0.1401 0.0962  0.0244  396 GLN A C   
+2965 O  O   . GLN A 374 ? 0.6046 0.2340 0.2714 -0.1146 0.1283  0.0146  396 GLN A O   
+2966 C  CB  . GLN A 374 ? 0.6684 0.3300 0.3098 -0.1518 0.0912  0.0350  396 GLN A CB  
+2967 C  CG  . GLN A 374 ? 0.7321 0.3725 0.3343 -0.1353 0.0868  0.0660  396 GLN A CG  
+2968 C  CD  . GLN A 374 ? 0.7899 0.4251 0.3583 -0.1008 0.0846  0.0930  396 GLN A CD  
+2969 O  OE1 . GLN A 374 ? 0.7929 0.4025 0.3863 -0.1490 0.0936  0.1315  396 GLN A OE1 
+2970 N  NE2 . GLN A 374 ? 0.8137 0.4058 0.3631 -0.0548 0.0582  0.0510  396 GLN A NE2 
+2971 N  N   . VAL A 375 ? 0.5992 0.2442 0.2523 -0.1486 0.0711  0.0079  397 VAL A N   
+2972 C  CA  . VAL A 375 ? 0.5974 0.2428 0.2408 -0.1402 0.0637  -0.0019 397 VAL A CA  
+2973 C  C   . VAL A 375 ? 0.6010 0.3045 0.2382 -0.1174 0.0467  0.0099  397 VAL A C   
+2974 O  O   . VAL A 375 ? 0.6061 0.3523 0.2478 -0.1200 0.0507  0.0343  397 VAL A O   
+2975 C  CB  . VAL A 375 ? 0.6340 0.3382 0.2315 -0.1008 0.0642  0.0042  397 VAL A CB  
+2976 C  CG1 . VAL A 375 ? 0.6336 0.2755 0.2208 -0.0817 0.0864  -0.0201 397 VAL A CG1 
+2977 C  CG2 . VAL A 375 ? 0.6475 0.4141 0.2235 -0.1096 0.0592  0.0057  397 VAL A CG2 
+2978 N  N   . GLY A 376 ? 0.5667 0.2621 0.2226 -0.1585 0.0523  0.0195  398 GLY A N   
+2979 C  CA  . GLY A 376 ? 0.5667 0.2516 0.2160 -0.0696 0.0674  0.0200  398 GLY A CA  
+2980 C  C   . GLY A 376 ? 0.5545 0.2669 0.2188 -0.0659 0.0595  0.0113  398 GLY A C   
+2981 O  O   . GLY A 376 ? 0.5669 0.2505 0.2172 -0.1139 0.0711  0.0155  398 GLY A O   
+2982 N  N   . ASP A 377 ? 0.5413 0.3440 0.2305 -0.0647 0.0597  0.0112  399 ASP A N   
+2983 C  CA  . ASP A 377 ? 0.5331 0.2860 0.2477 -0.0827 0.0545  -0.0119 399 ASP A CA  
+2984 C  C   . ASP A 377 ? 0.5513 0.2564 0.2562 -0.0532 0.0659  0.0185  399 ASP A C   
+2985 O  O   . ASP A 377 ? 0.5433 0.3091 0.2658 -0.0100 0.0624  0.0282  399 ASP A O   
+2986 C  CB  . ASP A 377 ? 0.5423 0.3369 0.2742 -0.0854 0.0322  -0.0665 399 ASP A CB  
+2987 C  CG  . ASP A 377 ? 0.5381 0.3782 0.3068 -0.1301 0.0215  -0.0790 399 ASP A CG  
+2988 O  OD1 . ASP A 377 ? 0.5682 0.4159 0.3176 -0.1132 0.0120  -0.0751 399 ASP A OD1 
+2989 O  OD2 . ASP A 377 ? 0.5322 0.3637 0.3204 -0.1422 0.0200  -0.0560 399 ASP A OD2 
+2990 N  N   . TYR A 378 ? 0.5306 0.1898 0.2448 -0.1069 0.0772  0.0158  400 TYR A N   
+2991 C  CA  . TYR A 378 ? 0.4964 0.1677 0.2430 -0.0814 0.0792  0.0206  400 TYR A CA  
+2992 C  C   . TYR A 378 ? 0.5067 0.1770 0.2487 -0.0347 0.0821  0.0277  400 TYR A C   
+2993 O  O   . TYR A 378 ? 0.5313 0.2472 0.2689 -0.0439 0.1248  0.0431  400 TYR A O   
+2994 C  CB  . TYR A 378 ? 0.4655 0.2017 0.2523 -0.1176 0.0816  0.0246  400 TYR A CB  
+2995 C  CG  . TYR A 378 ? 0.4932 0.2197 0.2625 -0.1310 0.0887  0.0213  400 TYR A CG  
+2996 C  CD1 . TYR A 378 ? 0.5167 0.2601 0.2727 -0.1337 0.0949  0.0461  400 TYR A CD1 
+2997 C  CD2 . TYR A 378 ? 0.5708 0.2371 0.2556 -0.1029 0.1003  0.0261  400 TYR A CD2 
+2998 C  CE1 . TYR A 378 ? 0.5724 0.3066 0.2737 -0.1327 0.0811  0.0425  400 TYR A CE1 
+2999 C  CE2 . TYR A 378 ? 0.6002 0.2148 0.2670 -0.0696 0.0873  0.0306  400 TYR A CE2 
+3000 C  CZ  . TYR A 378 ? 0.6077 0.2577 0.2752 -0.0925 0.0736  0.0517  400 TYR A CZ  
+3001 O  OH  . TYR A 378 ? 0.6474 0.2592 0.2991 -0.1437 0.0574  0.0519  400 TYR A OH  
+3002 N  N   . LEU A 379 ? 0.4502 0.1972 0.2329 -0.0450 0.0566  0.0113  401 LEU A N   
+3003 C  CA  . LEU A 379 ? 0.4573 0.2204 0.2281 -0.0733 0.0461  0.0068  401 LEU A CA  
+3004 C  C   . LEU A 379 ? 0.5181 0.2112 0.2109 0.0309  0.0518  -0.0190 401 LEU A C   
+3005 O  O   . LEU A 379 ? 0.5935 0.2743 0.2184 0.0906  0.0531  -0.0076 401 LEU A O   
+3006 C  CB  . LEU A 379 ? 0.5008 0.3360 0.2537 -0.0090 0.0365  0.0260  401 LEU A CB  
+3007 C  CG  . LEU A 379 ? 0.5172 0.4397 0.2894 -0.0139 0.0178  0.0306  401 LEU A CG  
+3008 C  CD1 . LEU A 379 ? 0.5129 0.4138 0.2998 -0.0446 0.0050  0.0060  401 LEU A CD1 
+3009 C  CD2 . LEU A 379 ? 0.5322 0.5140 0.3020 0.0038  0.0342  0.0479  401 LEU A CD2 
+3010 N  N   . LEU A 380 ? 0.5074 0.1627 0.1813 -0.0019 0.0409  -0.0012 402 LEU A N   
+3011 C  CA  . LEU A 380 ? 0.4850 0.2060 0.1720 -0.0361 0.0357  0.0003  402 LEU A CA  
+3012 C  C   . LEU A 380 ? 0.4703 0.1568 0.1579 -0.0669 0.0353  -0.0129 402 LEU A C   
+3013 O  O   . LEU A 380 ? 0.4984 0.1798 0.1519 -0.0484 0.0559  -0.0023 402 LEU A O   
+3014 C  CB  . LEU A 380 ? 0.5151 0.2246 0.1921 -0.0464 0.0264  0.0179  402 LEU A CB  
+3015 C  CG  . LEU A 380 ? 0.5570 0.2533 0.2078 -0.0539 0.0250  0.0187  402 LEU A CG  
+3016 C  CD1 . LEU A 380 ? 0.5720 0.2953 0.2070 -0.0553 0.0276  0.0272  402 LEU A CD1 
+3017 C  CD2 . LEU A 380 ? 0.5907 0.2188 0.2258 -0.0785 0.0375  0.0091  402 LEU A CD2 
+3018 N  N   . THR A 381 ? 0.4627 0.2116 0.1449 -0.0479 0.0197  -0.0134 403 THR A N   
+3019 C  CA  . THR A 381 ? 0.4381 0.2510 0.1460 -0.0443 0.0228  -0.0061 403 THR A CA  
+3020 C  C   . THR A 381 ? 0.4117 0.2399 0.1602 -0.0545 0.0231  -0.0177 403 THR A C   
+3021 O  O   . THR A 381 ? 0.4571 0.2536 0.1742 -0.0604 0.0167  -0.0142 403 THR A O   
+3022 C  CB  . THR A 381 ? 0.4898 0.3658 0.1430 0.0248  0.0023  0.0323  403 THR A CB  
+3023 O  OG1 . THR A 381 ? 0.4997 0.4493 0.1413 0.0790  -0.0171 0.0142  403 THR A OG1 
+3024 C  CG2 . THR A 381 ? 0.4959 0.4527 0.1472 0.0599  0.0154  0.0544  403 THR A CG2 
+3025 N  N   . TYR A 382 ? 0.4247 0.1618 0.1529 -0.0781 -0.0100 -0.0135 404 TYR A N   
+3026 C  CA  . TYR A 382 ? 0.4538 0.1623 0.1531 -0.0723 -0.0024 -0.0316 404 TYR A CA  
+3027 C  C   . TYR A 382 ? 0.4623 0.1910 0.1631 -0.0671 0.0235  -0.0121 404 TYR A C   
+3028 O  O   . TYR A 382 ? 0.4480 0.2500 0.1737 -0.0435 0.0458  -0.0109 404 TYR A O   
+3029 C  CB  . TYR A 382 ? 0.4618 0.1962 0.1491 -0.0421 0.0208  -0.0286 404 TYR A CB  
+3030 C  CG  . TYR A 382 ? 0.4285 0.1556 0.1471 -0.0707 0.0507  -0.0240 404 TYR A CG  
+3031 C  CD1 . TYR A 382 ? 0.4137 0.1847 0.1439 -0.0587 0.0441  -0.0418 404 TYR A CD1 
+3032 C  CD2 . TYR A 382 ? 0.4467 0.1760 0.1576 -0.1048 0.0456  -0.0221 404 TYR A CD2 
+3033 C  CE1 . TYR A 382 ? 0.4140 0.2050 0.1487 -0.1189 0.0229  -0.0428 404 TYR A CE1 
+3034 C  CE2 . TYR A 382 ? 0.4579 0.1976 0.1561 -0.0974 0.0612  -0.0358 404 TYR A CE2 
+3035 C  CZ  . TYR A 382 ? 0.4444 0.2040 0.1579 -0.1247 0.0542  -0.0453 404 TYR A CZ  
+3036 O  OH  . TYR A 382 ? 0.4491 0.2141 0.1752 -0.0955 0.0548  -0.0661 404 TYR A OH  
+3037 N  N   . SER A 383 ? 0.4666 0.1652 0.1600 -0.0877 0.0342  -0.0036 405 SER A N   
+3038 C  CA  A SER A 383 ? 0.4912 0.1805 0.1600 -0.0366 0.0170  0.0156  405 SER A CA  
+3039 C  CA  B SER A 383 ? 0.4684 0.1653 0.1593 -0.0613 0.0266  0.0113  405 SER A CA  
+3040 C  C   . SER A 383 ? 0.4837 0.1743 0.1591 -0.0326 0.0180  0.0048  405 SER A C   
+3041 O  O   . SER A 383 ? 0.4994 0.2001 0.1618 -0.0716 0.0150  0.0043  405 SER A O   
+3042 C  CB  A SER A 383 ? 0.5561 0.2227 0.1656 0.0652  0.0298  0.0251  405 SER A CB  
+3043 C  CB  B SER A 383 ? 0.4850 0.1652 0.1629 -0.0073 0.0516  0.0169  405 SER A CB  
+3044 O  OG  A SER A 383 ? 0.6027 0.2770 0.1937 0.1714  0.0292  0.0407  405 SER A OG  
+3045 O  OG  B SER A 383 ? 0.4971 0.1672 0.1765 0.0482  0.0625  0.0396  405 SER A OG  
+3046 N  N   . VAL A 384 ? 0.4642 0.1734 0.1583 0.0094  0.0018  -0.0070 406 VAL A N   
+3047 C  CA  . VAL A 384 ? 0.4365 0.2472 0.1699 -0.0411 0.0115  -0.0194 406 VAL A CA  
+3048 C  C   . VAL A 384 ? 0.4053 0.1743 0.1735 -0.1049 0.0263  -0.0357 406 VAL A C   
+3049 O  O   . VAL A 384 ? 0.3371 0.2038 0.1776 -0.0069 0.0138  -0.0208 406 VAL A O   
+3050 C  CB  . VAL A 384 ? 0.3964 0.2151 0.1815 -0.0911 0.0004  -0.0316 406 VAL A CB  
+3051 C  CG1 . VAL A 384 ? 0.3695 0.2630 0.1951 -0.1014 -0.0006 -0.0284 406 VAL A CG1 
+3052 C  CG2 . VAL A 384 ? 0.4125 0.2590 0.1852 -0.0509 0.0092  -0.0316 406 VAL A CG2 
+3053 N  N   . SER A 385 ? 0.4992 0.2305 0.1797 -0.0419 0.0402  -0.0497 407 SER A N   
+3054 C  CA  . SER A 385 ? 0.5012 0.2054 0.1924 -0.0753 0.0425  -0.0515 407 SER A CA  
+3055 C  C   . SER A 385 ? 0.5001 0.1840 0.1874 -0.1032 0.0306  -0.0413 407 SER A C   
+3056 O  O   . SER A 385 ? 0.5241 0.2526 0.1768 -0.0764 0.0228  -0.0370 407 SER A O   
+3057 C  CB  . SER A 385 ? 0.5277 0.2188 0.2054 -0.0109 0.0668  -0.0468 407 SER A CB  
+3058 O  OG  . SER A 385 ? 0.5784 0.2614 0.2155 0.0577  0.0736  -0.0175 407 SER A OG  
+3059 N  N   . SER A 386 ? 0.5416 0.1970 0.1901 -0.0326 0.0467  -0.0334 408 SER A N   
+3060 C  CA  . SER A 386 ? 0.5386 0.2014 0.2018 -0.0222 0.0465  -0.0384 408 SER A CA  
+3061 C  C   . SER A 386 ? 0.5269 0.2018 0.2056 -0.0472 0.0621  -0.0441 408 SER A C   
+3062 O  O   . SER A 386 ? 0.4862 0.1894 0.2001 -0.0350 0.0754  -0.0344 408 SER A O   
+3063 C  CB  . SER A 386 ? 0.5531 0.2672 0.2161 0.0269  0.0277  -0.0379 408 SER A CB  
+3064 O  OG  . SER A 386 ? 0.6164 0.3344 0.2405 0.0415  0.0120  -0.0353 408 SER A OG  
+3065 N  N   . ASP A 387 ? 0.5163 0.2388 0.2126 -0.0128 0.0621  -0.0523 409 ASP A N   
+3066 C  CA  . ASP A 387 ? 0.5313 0.2082 0.2181 -0.0702 0.0894  -0.0381 409 ASP A CA  
+3067 C  C   . ASP A 387 ? 0.5816 0.2482 0.2449 -0.0026 0.1180  -0.0390 409 ASP A C   
+3068 O  O   . ASP A 387 ? 0.5815 0.2633 0.2507 -0.0163 0.1242  -0.0344 409 ASP A O   
+3069 C  CB  . ASP A 387 ? 0.5363 0.2482 0.2124 -0.0822 0.0872  -0.0346 409 ASP A CB  
+3070 C  CG  . ASP A 387 ? 0.5822 0.2416 0.2189 -0.0129 0.0512  -0.0543 409 ASP A CG  
+3071 O  OD1 . ASP A 387 ? 0.6552 0.3051 0.2275 0.0177  0.0127  -0.0670 409 ASP A OD1 
+3072 O  OD2 . ASP A 387 ? 0.5972 0.2209 0.2369 -0.0134 -0.0011 -0.0560 409 ASP A OD2 
+3073 N  N   . ASP A 388 ? 0.6076 0.2358 0.2655 0.0364  0.1278  -0.0370 410 ASP A N   
+3074 C  CA  A ASP A 388 ? 0.6388 0.2809 0.2801 0.0655  0.1223  -0.0408 410 ASP A CA  
+3075 C  CA  B ASP A 388 ? 0.6230 0.2921 0.2759 0.0798  0.1234  -0.0238 410 ASP A CA  
+3076 C  C   . ASP A 388 ? 0.6015 0.2914 0.2782 0.0651  0.1044  -0.0269 410 ASP A C   
+3077 O  O   . ASP A 388 ? 0.5989 0.3513 0.2870 0.0786  0.0959  -0.0259 410 ASP A O   
+3078 C  CB  A ASP A 388 ? 0.7496 0.3907 0.3014 0.1415  0.1155  -0.0587 410 ASP A CB  
+3079 C  CB  B ASP A 388 ? 0.6838 0.3870 0.2865 0.1627  0.1267  -0.0099 410 ASP A CB  
+3080 C  CG  A ASP A 388 ? 0.8313 0.4924 0.3211 0.1889  0.1107  -0.0752 410 ASP A CG  
+3081 C  CG  B ASP A 388 ? 0.7236 0.4763 0.2962 0.2260  0.1330  0.0065  410 ASP A CG  
+3082 O  OD1 A ASP A 388 ? 0.8387 0.5095 0.3346 0.2017  0.1054  -0.0946 410 ASP A OD1 
+3083 O  OD1 B ASP A 388 ? 0.7442 0.5139 0.2977 0.2496  0.1289  0.0159  410 ASP A OD1 
+3084 O  OD2 A ASP A 388 ? 0.8887 0.5495 0.3312 0.2225  0.0944  -0.0776 410 ASP A OD2 
+3085 O  OD2 B ASP A 388 ? 0.7497 0.5067 0.3024 0.2601  0.1406  0.0069  410 ASP A OD2 
+3086 N  N   . GLU A 389 ? 0.5318 0.2099 0.2655 0.0271  0.0941  -0.0254 411 GLU A N   
+3087 C  CA  . GLU A 389 ? 0.4708 0.1967 0.2648 0.0199  0.1146  -0.0084 411 GLU A CA  
+3088 C  C   . GLU A 389 ? 0.4754 0.2757 0.2487 0.0181  0.0927  -0.0123 411 GLU A C   
+3089 O  O   . GLU A 389 ? 0.4670 0.3254 0.2408 0.0185  0.0936  0.0050  411 GLU A O   
+3090 C  CB  . GLU A 389 ? 0.4785 0.2515 0.2861 -0.0091 0.1148  0.0279  411 GLU A CB  
+3091 C  CG  . GLU A 389 ? 0.4810 0.2942 0.3169 -0.0063 0.1207  0.0442  411 GLU A CG  
+3092 C  CD  . GLU A 389 ? 0.5029 0.3457 0.3391 0.0068  0.1009  0.0410  411 GLU A CD  
+3093 O  OE1 . GLU A 389 ? 0.5350 0.3492 0.3558 -0.0012 0.0819  0.0237  411 GLU A OE1 
+3094 O  OE2 . GLU A 389 ? 0.5162 0.4136 0.3551 0.0937  0.0976  0.0187  411 GLU A OE2 
+3095 N  N   . THR A 390 ? 0.4890 0.2950 0.2435 0.0166  0.0703  -0.0311 412 THR A N   
+3096 C  CA  . THR A 390 ? 0.4542 0.2498 0.2299 0.0460  0.0802  -0.0396 412 THR A CA  
+3097 C  C   . THR A 390 ? 0.4386 0.2284 0.2206 0.0003  0.0453  -0.0432 412 THR A C   
+3098 O  O   . THR A 390 ? 0.4550 0.3031 0.2246 -0.0181 0.0247  -0.0586 412 THR A O   
+3099 C  CB  . THR A 390 ? 0.5271 0.2791 0.2414 0.0435  0.1010  -0.0335 412 THR A CB  
+3100 O  OG1 . THR A 390 ? 0.5167 0.2965 0.2473 0.0286  0.1079  -0.0312 412 THR A OG1 
+3101 C  CG2 . THR A 390 ? 0.5365 0.2464 0.2525 -0.0056 0.0872  -0.0207 412 THR A CG2 
+3102 N  N   . THR A 391 ? 0.4121 0.1794 0.1988 -0.0156 0.0632  -0.0133 413 THR A N   
+3103 C  CA  . THR A 391 ? 0.4292 0.1494 0.1878 -0.0323 0.0533  -0.0092 413 THR A CA  
+3104 C  C   . THR A 391 ? 0.4416 0.1989 0.1783 -0.0363 0.0391  -0.0282 413 THR A C   
+3105 O  O   . THR A 391 ? 0.4547 0.2063 0.1740 -0.0753 0.0405  -0.0251 413 THR A O   
+3106 C  CB  . THR A 391 ? 0.4912 0.1715 0.1936 -0.0305 0.0408  -0.0039 413 THR A CB  
+3107 O  OG1 . THR A 391 ? 0.5206 0.2567 0.2255 -0.0114 0.0177  0.0459  413 THR A OG1 
+3108 C  CG2 . THR A 391 ? 0.5656 0.1472 0.1997 -0.0252 0.0217  -0.0156 413 THR A CG2 
+3109 N  N   . ASN A 392 ? 0.4043 0.2319 0.1660 -0.0727 0.0271  -0.0225 414 ASN A N   
+3110 C  CA  A ASN A 392 ? 0.4281 0.2482 0.1740 -0.0676 0.0206  0.0073  414 ASN A CA  
+3111 C  CA  B ASN A 392 ? 0.4471 0.2667 0.1660 -0.0472 0.0383  0.0180  414 ASN A CA  
+3112 C  C   . ASN A 392 ? 0.4235 0.2682 0.1644 -0.0999 0.0303  0.0197  414 ASN A C   
+3113 O  O   . ASN A 392 ? 0.4331 0.3170 0.1657 -0.0945 0.0278  -0.0039 414 ASN A O   
+3114 C  CB  A ASN A 392 ? 0.4684 0.2735 0.1969 0.0215  0.0173  0.0183  414 ASN A CB  
+3115 C  CB  B ASN A 392 ? 0.5201 0.3242 0.1719 0.0661  0.0681  0.0495  414 ASN A CB  
+3116 C  CG  A ASN A 392 ? 0.4751 0.3077 0.2199 0.0386  -0.0018 0.0149  414 ASN A CG  
+3117 C  CG  B ASN A 392 ? 0.5772 0.4052 0.1854 0.1373  0.0756  0.0524  414 ASN A CG  
+3118 O  OD1 A ASN A 392 ? 0.4697 0.2824 0.2343 0.0030  -0.0107 0.0053  414 ASN A OD1 
+3119 O  OD1 B ASN A 392 ? 0.6252 0.4791 0.2001 0.1465  0.0494  0.0540  414 ASN A OD1 
+3120 N  ND2 A ASN A 392 ? 0.4893 0.3394 0.2299 0.0813  -0.0187 0.0228  414 ASN A ND2 
+3121 N  ND2 B ASN A 392 ? 0.6308 0.4397 0.2051 0.1812  0.0815  0.0470  414 ASN A ND2 
+3122 N  N   . GLN A 393 ? 0.3923 0.2710 0.1422 -0.1084 0.0304  0.0184  415 GLN A N   
+3123 C  CA  . GLN A 393 ? 0.3979 0.2332 0.1540 -0.1087 0.0231  0.0068  415 GLN A CA  
+3124 C  C   . GLN A 393 ? 0.3878 0.1881 0.1567 -0.0556 0.0180  0.0144  415 GLN A C   
+3125 O  O   . GLN A 393 ? 0.4346 0.2049 0.1727 -0.0660 0.0154  0.0340  415 GLN A O   
+3126 C  CB  . GLN A 393 ? 0.3867 0.2336 0.1537 -0.1203 0.0350  -0.0128 415 GLN A CB  
+3127 C  CG  . GLN A 393 ? 0.4355 0.2175 0.1501 -0.1082 0.0321  -0.0493 415 GLN A CG  
+3128 C  CD  . GLN A 393 ? 0.4820 0.2245 0.1501 -0.0726 0.0295  -0.0427 415 GLN A CD  
+3129 O  OE1 . GLN A 393 ? 0.4924 0.2527 0.1490 -0.1279 0.0172  -0.0248 415 GLN A OE1 
+3130 N  NE2 . GLN A 393 ? 0.4878 0.2544 0.1578 -0.0593 0.0104  -0.0604 415 GLN A NE2 
+3131 N  N   . PRO A 394 ? 0.3502 0.3559 0.1494 -0.0620 -0.0077 0.0142  416 PRO A N   
+3132 C  CA  . PRO A 394 ? 0.3547 0.3555 0.1519 -0.0875 -0.0109 0.0225  416 PRO A CA  
+3133 C  C   . PRO A 394 ? 0.3208 0.2476 0.1467 -0.1475 -0.0040 0.0070  416 PRO A C   
+3134 O  O   . PRO A 394 ? 0.3680 0.2233 0.1422 -0.1059 0.0076  -0.0198 416 PRO A O   
+3135 C  CB  . PRO A 394 ? 0.3789 0.5091 0.1551 -0.0385 -0.0061 0.0376  416 PRO A CB  
+3136 C  CG  . PRO A 394 ? 0.3613 0.4963 0.1535 -0.0136 -0.0040 0.0309  416 PRO A CG  
+3137 C  CD  . PRO A 394 ? 0.3390 0.4622 0.1476 -0.0440 -0.0054 0.0014  416 PRO A CD  
+3138 N  N   . ARG A 395 ? 0.3431 0.2025 0.1551 -0.0595 0.0117  0.0074  417 ARG A N   
+3139 C  CA  . ARG A 395 ? 0.3661 0.1844 0.1544 -0.0617 0.0139  0.0079  417 ARG A CA  
+3140 C  C   . ARG A 395 ? 0.3819 0.1494 0.1540 -0.0880 0.0194  -0.0107 417 ARG A C   
+3141 O  O   . ARG A 395 ? 0.4735 0.1410 0.1631 -0.0685 0.0199  -0.0186 417 ARG A O   
+3142 C  CB  . ARG A 395 ? 0.3910 0.1666 0.1461 -0.0681 0.0009  -0.0219 417 ARG A CB  
+3143 C  CG  . ARG A 395 ? 0.3858 0.1846 0.1495 -0.0874 -0.0097 -0.0208 417 ARG A CG  
+3144 C  CD  . ARG A 395 ? 0.3849 0.1778 0.1445 -0.1213 0.0028  -0.0100 417 ARG A CD  
+3145 N  NE  . ARG A 395 ? 0.3863 0.1873 0.1453 -0.0772 0.0153  -0.0295 417 ARG A NE  
+3146 C  CZ  . ARG A 395 ? 0.3713 0.1973 0.1443 -0.0967 0.0301  -0.0408 417 ARG A CZ  
+3147 N  NH1 . ARG A 395 ? 0.3821 0.2115 0.1515 -0.1100 0.0307  -0.0575 417 ARG A NH1 
+3148 N  NH2 . ARG A 395 ? 0.4279 0.2363 0.1404 -0.0897 0.0470  -0.0345 417 ARG A NH2 
+3149 N  N   . LYS A 396 ? 0.4134 0.1605 0.1406 -0.0657 0.0034  -0.0059 418 LYS A N   
+3150 C  CA  . LYS A 396 ? 0.4259 0.1593 0.1477 -0.0262 0.0073  -0.0117 418 LYS A CA  
+3151 C  C   . LYS A 396 ? 0.4548 0.1635 0.1558 -0.0671 -0.0026 -0.0020 418 LYS A C   
+3152 O  O   . LYS A 396 ? 0.4072 0.1814 0.1621 -0.1098 0.0248  0.0029  418 LYS A O   
+3153 C  CB  . LYS A 396 ? 0.4670 0.1510 0.1544 -0.0238 -0.0094 -0.0253 418 LYS A CB  
+3154 C  CG  . LYS A 396 ? 0.5018 0.2111 0.1813 -0.0507 -0.0268 -0.0101 418 LYS A CG  
+3155 C  CD  . LYS A 396 ? 0.5608 0.2898 0.2002 -0.0723 -0.0409 -0.0335 418 LYS A CD  
+3156 C  CE  . LYS A 396 ? 0.6127 0.3930 0.2216 -0.0822 -0.0448 -0.0365 418 LYS A CE  
+3157 N  NZ  . LYS A 396 ? 0.6410 0.4380 0.2263 -0.0524 -0.0354 -0.0441 418 LYS A NZ  
+3158 N  N   . ILE A 397 ? 0.4850 0.1604 0.1755 -0.0717 0.0067  -0.0169 419 ILE A N   
+3159 C  CA  . ILE A 397 ? 0.4375 0.1694 0.1851 -0.1154 0.0354  0.0069  419 ILE A CA  
+3160 C  C   . ILE A 397 ? 0.4257 0.1565 0.1726 -0.1065 0.0353  0.0008  419 ILE A C   
+3161 O  O   . ILE A 397 ? 0.5059 0.1645 0.1692 -0.0338 0.0504  0.0179  419 ILE A O   
+3162 C  CB  . ILE A 397 ? 0.4506 0.2547 0.1957 -0.1134 0.0503  0.0029  419 ILE A CB  
+3163 C  CG1 . ILE A 397 ? 0.4134 0.2438 0.1936 -0.1451 0.0342  -0.0154 419 ILE A CG1 
+3164 C  CG2 . ILE A 397 ? 0.5029 0.2011 0.2158 -0.1219 0.0383  0.0040  419 ILE A CG2 
+3165 C  CD1 . ILE A 397 ? 0.4115 0.2106 0.1968 -0.1562 0.0278  -0.0190 419 ILE A CD1 
+3166 N  N   . THR A 398 ? 0.4326 0.1492 0.1619 -0.0968 0.0142  -0.0172 420 THR A N   
+3167 C  CA  . THR A 398 ? 0.4312 0.2072 0.1588 -0.1547 0.0264  -0.0133 420 THR A CA  
+3168 C  C   . THR A 398 ? 0.4705 0.2449 0.1554 -0.1610 0.0273  -0.0001 420 THR A C   
+3169 O  O   . THR A 398 ? 0.4541 0.2205 0.1549 -0.1410 0.0382  0.0069  420 THR A O   
+3170 C  CB  . THR A 398 ? 0.5220 0.1921 0.1699 -0.1144 0.0338  -0.0110 420 THR A CB  
+3171 O  OG1 . THR A 398 ? 0.5479 0.2414 0.1921 -0.1622 0.0093  -0.0067 420 THR A OG1 
+3172 C  CG2 . THR A 398 ? 0.5975 0.2030 0.1726 -0.0766 0.0337  -0.0179 420 THR A CG2 
+3173 N  N   . VAL A 399 ? 0.4716 0.2377 0.1661 -0.1580 0.0263  0.0130  421 VAL A N   
+3174 C  CA  . VAL A 399 ? 0.4928 0.1934 0.1758 -0.1331 0.0378  0.0016  421 VAL A CA  
+3175 C  C   . VAL A 399 ? 0.5105 0.1883 0.1732 -0.1291 0.0509  -0.0096 421 VAL A C   
+3176 O  O   . VAL A 399 ? 0.5393 0.2533 0.1808 -0.1104 0.0691  -0.0007 421 VAL A O   
+3177 C  CB  . VAL A 399 ? 0.4996 0.1811 0.1854 -0.1057 0.0534  0.0108  421 VAL A CB  
+3178 C  CG1 . VAL A 399 ? 0.5530 0.2403 0.1844 -0.1750 0.0415  -0.0095 421 VAL A CG1 
+3179 C  CG2 . VAL A 399 ? 0.5478 0.2190 0.1825 -0.0753 0.0609  -0.0025 421 VAL A CG2 
+3180 N  N   . TYR A 400 ? 0.4995 0.2036 0.1597 -0.1412 0.0636  -0.0312 422 TYR A N   
+3181 C  CA  . TYR A 400 ? 0.4642 0.2238 0.1532 -0.1653 0.0537  -0.0285 422 TYR A CA  
+3182 C  C   . TYR A 400 ? 0.4860 0.2403 0.1708 -0.1741 0.0528  -0.0357 422 TYR A C   
+3183 O  O   . TYR A 400 ? 0.5191 0.2527 0.1754 -0.1847 0.0681  -0.0312 422 TYR A O   
+3184 C  CB  . TYR A 400 ? 0.4113 0.2544 0.1619 -0.1788 0.0601  -0.0320 422 TYR A CB  
+3185 C  CG  . TYR A 400 ? 0.4530 0.2543 0.1583 -0.1357 0.0844  -0.0347 422 TYR A CG  
+3186 C  CD1 . TYR A 400 ? 0.4150 0.2209 0.1542 -0.1596 0.0737  -0.0403 422 TYR A CD1 
+3187 C  CD2 . TYR A 400 ? 0.4882 0.1898 0.1581 -0.0755 0.0805  -0.0357 422 TYR A CD2 
+3188 C  CE1 . TYR A 400 ? 0.4351 0.2141 0.1647 -0.1558 0.0618  -0.0255 422 TYR A CE1 
+3189 C  CE2 . TYR A 400 ? 0.4589 0.1989 0.1529 -0.1121 0.0713  -0.0348 422 TYR A CE2 
+3190 C  CZ  . TYR A 400 ? 0.4338 0.2202 0.1675 -0.1484 0.0505  -0.0467 422 TYR A CZ  
+3191 O  OH  . TYR A 400 ? 0.4279 0.2587 0.1827 -0.1839 0.0518  -0.0415 422 TYR A OH  
+3192 N  N   . GLU A 401 ? 0.5309 0.2523 0.1765 -0.1646 0.0704  -0.0446 423 GLU A N   
+3193 C  CA  . GLU A 401 ? 0.5868 0.2041 0.2017 -0.1336 0.0716  -0.0145 423 GLU A CA  
+3194 C  C   . GLU A 401 ? 0.5407 0.2314 0.2004 -0.1661 0.0657  -0.0289 423 GLU A C   
+3195 O  O   . GLU A 401 ? 0.5489 0.2624 0.2208 -0.1537 0.0667  -0.0412 423 GLU A O   
+3196 C  CB  . GLU A 401 ? 0.7089 0.2526 0.2540 -0.0972 0.0827  0.0374  423 GLU A CB  
+3197 C  CG  . GLU A 401 ? 0.8741 0.3063 0.2913 -0.0293 0.0467  0.0743  423 GLU A CG  
+3198 C  CD  . GLU A 401 ? 1.0344 0.4404 0.3187 -0.0156 -0.0218 0.0667  423 GLU A CD  
+3199 O  OE1 . GLU A 401 ? 1.1104 0.6043 0.3338 0.0461  -0.0418 0.0102  423 GLU A OE1 
+3200 O  OE2 . GLU A 401 ? 1.0389 0.4085 0.3402 -0.0572 -0.0683 0.1052  423 GLU A OE2 
+3201 N  N   . ILE A 402 ? 0.4887 0.2323 0.1862 -0.1639 0.0677  -0.0373 424 ILE A N   
+3202 C  CA  . ILE A 402 ? 0.4834 0.2745 0.1804 -0.1563 0.0597  0.0044  424 ILE A CA  
+3203 C  C   . ILE A 402 ? 0.4751 0.2955 0.1613 -0.1655 0.0494  0.0008  424 ILE A C   
+3204 O  O   . ILE A 402 ? 0.4657 0.2862 0.1592 -0.1960 0.0318  -0.0084 424 ILE A O   
+3205 C  CB  . ILE A 402 ? 0.4298 0.3081 0.2049 -0.1815 0.0548  0.0190  424 ILE A CB  
+3206 C  CG1 . ILE A 402 ? 0.4163 0.3027 0.2083 -0.1895 0.0497  0.0098  424 ILE A CG1 
+3207 C  CG2 . ILE A 402 ? 0.4655 0.3850 0.2041 -0.0839 0.0598  0.0318  424 ILE A CG2 
+3208 C  CD1 . ILE A 402 ? 0.3553 0.2652 0.1940 -0.1663 0.0397  0.0133  424 ILE A CD1 
+3209 N  N   . LEU A 403 ? 0.4662 0.2816 0.1676 -0.1899 0.0424  -0.0076 425 LEU A N   
+3210 C  CA  . LEU A 403 ? 0.4388 0.3144 0.1556 -0.2170 0.0136  -0.0095 425 LEU A CA  
+3211 C  C   . LEU A 403 ? 0.4356 0.2427 0.1531 -0.1763 0.0263  -0.0079 425 LEU A C   
+3212 O  O   . LEU A 403 ? 0.4459 0.2199 0.1707 -0.1383 0.0244  0.0254  425 LEU A O   
+3213 C  CB  . LEU A 403 ? 0.4704 0.3262 0.1725 -0.2197 -0.0052 -0.0111 425 LEU A CB  
+3214 C  CG  . LEU A 403 ? 0.5117 0.3439 0.1970 -0.1881 -0.0073 0.0134  425 LEU A CG  
+3215 C  CD1 . LEU A 403 ? 0.5151 0.3326 0.2160 -0.1984 -0.0115 0.0453  425 LEU A CD1 
+3216 C  CD2 . LEU A 403 ? 0.5061 0.4066 0.1976 -0.1186 -0.0143 -0.0076 425 LEU A CD2 
+3217 N  N   . PRO A 404 ? 0.4454 0.2508 0.1528 -0.1715 0.0230  -0.0147 426 PRO A N   
+3218 C  CA  . PRO A 404 ? 0.4313 0.2514 0.1523 -0.1807 0.0318  -0.0124 426 PRO A CA  
+3219 C  C   . PRO A 404 ? 0.4427 0.2938 0.1543 -0.1534 0.0253  -0.0176 426 PRO A C   
+3220 O  O   . PRO A 404 ? 0.4470 0.2594 0.1601 -0.1664 0.0402  -0.0068 426 PRO A O   
+3221 C  CB  . PRO A 404 ? 0.4395 0.2687 0.1598 -0.1800 0.0431  -0.0085 426 PRO A CB  
+3222 C  CG  . PRO A 404 ? 0.4274 0.2642 0.1570 -0.1891 0.0308  -0.0151 426 PRO A CG  
+3223 C  CD  . PRO A 404 ? 0.4073 0.2586 0.1653 -0.1843 0.0317  -0.0168 426 PRO A CD  
+3224 N  N   . ALA A 405 ? 0.4463 0.2747 0.1556 -0.1863 0.0070  -0.0034 427 ALA A N   
+3225 C  CA  . ALA A 405 ? 0.4397 0.3199 0.1658 -0.1529 0.0237  -0.0068 427 ALA A CA  
+3226 C  C   . ALA A 405 ? 0.4579 0.2651 0.1570 -0.1471 0.0090  -0.0119 427 ALA A C   
+3227 O  O   . ALA A 405 ? 0.5222 0.3206 0.1519 -0.1242 0.0149  -0.0097 427 ALA A O   
+3228 C  CB  . ALA A 405 ? 0.4825 0.3560 0.1895 -0.1500 0.0574  0.0129  427 ALA A CB  
+3229 N  N   . PHE A 406 ? 0.4802 0.2573 0.1648 -0.1061 -0.0174 -0.0477 428 PHE A N   
+3230 C  CA  . PHE A 406 ? 0.4743 0.2523 0.1657 -0.1407 -0.0154 0.0052  428 PHE A CA  
+3231 C  C   . PHE A 406 ? 0.4944 0.2890 0.1856 -0.1731 -0.0038 0.0174  428 PHE A C   
+3232 O  O   . PHE A 406 ? 0.4925 0.2850 0.2275 -0.1181 0.0020  0.0326  428 PHE A O   
+3233 C  CB  . PHE A 406 ? 0.4922 0.2708 0.1638 -0.1391 -0.0071 -0.0001 428 PHE A CB  
+3234 C  CG  . PHE A 406 ? 0.4939 0.2416 0.1693 -0.1233 -0.0047 0.0006  428 PHE A CG  
+3235 C  CD1 . PHE A 406 ? 0.4971 0.2658 0.1810 -0.1103 -0.0329 -0.0138 428 PHE A CD1 
+3236 C  CD2 . PHE A 406 ? 0.5263 0.2235 0.1732 -0.1181 -0.0221 -0.0302 428 PHE A CD2 
+3237 C  CE1 . PHE A 406 ? 0.5261 0.2154 0.1759 -0.0943 -0.0086 -0.0174 428 PHE A CE1 
+3238 C  CE2 . PHE A 406 ? 0.5267 0.2007 0.1838 -0.0942 -0.0262 -0.0354 428 PHE A CE2 
+3239 C  CZ  . PHE A 406 ? 0.5205 0.1907 0.1756 -0.1155 -0.0202 -0.0179 428 PHE A CZ  
+3240 N  N   . THR A 407 ? 0.4883 0.3072 0.1721 -0.2031 -0.0095 0.0207  429 THR A N   
+3241 C  CA  . THR A 407 ? 0.5384 0.3384 0.1763 -0.1583 -0.0104 0.0441  429 THR A CA  
+3242 C  C   . THR A 407 ? 0.5513 0.2829 0.1692 -0.1717 0.0158  0.0150  429 THR A C   
+3243 O  O   . THR A 407 ? 0.5795 0.2518 0.1607 -0.1533 0.0153  -0.0060 429 THR A O   
+3244 C  CB  . THR A 407 ? 0.5657 0.4815 0.1907 -0.0794 -0.0328 0.0569  429 THR A CB  
+3245 O  OG1 . THR A 407 ? 0.6168 0.6080 0.2174 0.0262  -0.0625 0.0337  429 THR A OG1 
+3246 C  CG2 . THR A 407 ? 0.5194 0.4560 0.1771 -0.0845 -0.0304 0.0939  429 THR A CG2 
+3247 N  N   . GLY A 408 ? 0.5718 0.2901 0.1684 -0.0958 0.0189  0.0088  430 GLY A N   
+3248 C  CA  . GLY A 408 ? 0.6077 0.3114 0.1631 -0.0544 0.0116  0.0130  430 GLY A CA  
+3249 C  C   . GLY A 408 ? 0.6426 0.2912 0.1648 -0.0651 0.0047  0.0055  430 GLY A C   
+3250 O  O   . GLY A 408 ? 0.6777 0.3598 0.1724 -0.0485 0.0197  -0.0078 430 GLY A O   
+3251 N  N   . ILE A 409 ? 0.6035 0.2517 0.1700 -0.1002 -0.0216 -0.0187 431 ILE A N   
+3252 C  CA  . ILE A 409 ? 0.6310 0.2707 0.2048 -0.1046 -0.0366 -0.0468 431 ILE A CA  
+3253 C  C   . ILE A 409 ? 0.6568 0.4025 0.2244 -0.0897 -0.0148 -0.0680 431 ILE A C   
+3254 O  O   . ILE A 409 ? 0.7521 0.4580 0.2515 -0.0089 -0.0213 -0.1076 431 ILE A O   
+3255 C  CB  . ILE A 409 ? 0.6754 0.2928 0.2037 -0.0793 -0.0848 -0.0105 431 ILE A CB  
+3256 C  CG1 . ILE A 409 ? 0.7356 0.4030 0.2059 0.0302  -0.0965 -0.0052 431 ILE A CG1 
+3257 C  CG2 . ILE A 409 ? 0.7075 0.3366 0.2105 -0.0073 -0.0598 0.0056  431 ILE A CG2 
+3258 C  CD1 . ILE A 409 ? 0.7694 0.4925 0.2125 0.0238  -0.0922 0.0154  431 ILE A CD1 
+3259 N  N   . THR A 410 ? 0.5770 0.3504 0.2060 -0.1202 0.0328  -0.0362 432 THR A N   
+3260 C  CA  . THR A 410 ? 0.5844 0.3199 0.1934 -0.0601 0.0390  0.0044  432 THR A CA  
+3261 C  C   . THR A 410 ? 0.5298 0.2692 0.1800 -0.1097 0.0179  0.0053  432 THR A C   
+3262 O  O   . THR A 410 ? 0.5119 0.2426 0.1753 -0.0937 -0.0126 -0.0005 432 THR A O   
+3263 C  CB  . THR A 410 ? 0.6792 0.4707 0.2045 0.0956  0.0632  0.0479  432 THR A CB  
+3264 O  OG1 . THR A 410 ? 0.7784 0.5815 0.2345 0.1628  0.0749  0.0555  432 THR A OG1 
+3265 C  CG2 . THR A 410 ? 0.7182 0.4678 0.2071 0.1572  0.0487  0.0382  432 THR A CG2 
+3266 N  N   . ASP A 411 ? 0.5165 0.2404 0.1740 -0.1527 0.0184  0.0127  433 ASP A N   
+3267 C  CA  . ASP A 411 ? 0.4711 0.2988 0.1817 -0.1446 0.0156  0.0187  433 ASP A CA  
+3268 C  C   . ASP A 411 ? 0.4221 0.2327 0.1843 -0.1545 0.0258  0.0231  433 ASP A C   
+3269 O  O   . ASP A 411 ? 0.4760 0.2053 0.1827 -0.0741 0.0511  0.0379  433 ASP A O   
+3270 C  CB  . ASP A 411 ? 0.4626 0.3345 0.2044 -0.1525 0.0017  -0.0074 433 ASP A CB  
+3271 C  CG  . ASP A 411 ? 0.4595 0.3684 0.2276 -0.1785 -0.0321 0.0103  433 ASP A CG  
+3272 O  OD1 . ASP A 411 ? 0.4099 0.3568 0.2154 -0.1785 0.0016  0.0633  433 ASP A OD1 
+3273 O  OD2 . ASP A 411 ? 0.4858 0.4100 0.2608 -0.1866 -0.0640 0.0131  433 ASP A OD2 
+3274 N  N   . THR A 412 ? 0.4143 0.2926 0.1751 -0.1470 0.0452  0.0158  434 THR A N   
+3275 C  CA  . THR A 412 ? 0.4751 0.3212 0.1883 -0.0769 0.0301  0.0489  434 THR A CA  
+3276 C  C   . THR A 412 ? 0.4469 0.2808 0.1855 -0.0546 0.0424  0.0345  434 THR A C   
+3277 O  O   . THR A 412 ? 0.4171 0.2723 0.1726 0.0024  0.0123  0.0192  434 THR A O   
+3278 C  CB  . THR A 412 ? 0.5547 0.4329 0.2155 -0.0179 0.0252  0.0304  434 THR A CB  
+3279 O  OG1 . THR A 412 ? 0.5885 0.5908 0.2385 0.0360  0.0136  -0.0003 434 THR A OG1 
+3280 C  CG2 . THR A 412 ? 0.5698 0.3650 0.2126 -0.1308 0.0300  0.0482  434 THR A CG2 
+3281 N  N   . THR A 413 ? 0.4650 0.2879 0.1979 -0.0252 0.0442  0.0408  435 THR A N   
+3282 C  CA  . THR A 413 ? 0.4722 0.2477 0.2128 0.0399  0.0353  0.0400  435 THR A CA  
+3283 C  C   . THR A 413 ? 0.4711 0.2396 0.2238 0.0213  0.0299  0.0652  435 THR A C   
+3284 O  O   . THR A 413 ? 0.4876 0.3618 0.2438 0.1337  0.0258  0.0937  435 THR A O   
+3285 C  CB  . THR A 413 ? 0.5399 0.2281 0.2321 -0.0372 0.0169  0.0042  435 THR A CB  
+3286 O  OG1 . THR A 413 ? 0.5867 0.2938 0.2453 -0.0707 -0.0017 -0.0162 435 THR A OG1 
+3287 C  CG2 . THR A 413 ? 0.5634 0.2381 0.2332 -0.0230 0.0154  -0.0173 435 THR A CG2 
+3288 N  N   . VAL A 414 ? 0.4389 0.2556 0.2238 0.0322  0.0312  0.0558  436 VAL A N   
+3289 C  CA  . VAL A 414 ? 0.4367 0.3015 0.2265 0.0644  0.0336  0.0213  436 VAL A CA  
+3290 C  C   . VAL A 414 ? 0.4414 0.3031 0.2209 0.0763  0.0069  0.0285  436 VAL A C   
+3291 O  O   . VAL A 414 ? 0.4757 0.3074 0.2156 0.0603  -0.0121 0.0283  436 VAL A O   
+3292 C  CB  . VAL A 414 ? 0.4343 0.2950 0.2361 0.0177  0.0381  0.0159  436 VAL A CB  
+3293 C  CG1 . VAL A 414 ? 0.4533 0.3706 0.2380 0.0827  0.0302  0.0165  436 VAL A CG1 
+3294 C  CG2 . VAL A 414 ? 0.4394 0.1576 0.2400 0.0017  0.0364  -0.0167 436 VAL A CG2 
+3295 N  N   . VAL A 415 ? 0.4914 0.3458 0.2261 0.0893  -0.0044 0.0338  437 VAL A N   
+3296 C  CA  A VAL A 415 ? 0.4628 0.3398 0.2298 0.1163  -0.0074 0.0284  437 VAL A CA  
+3297 C  CA  B VAL A 415 ? 0.4718 0.3267 0.2317 0.0886  -0.0036 0.0378  437 VAL A CA  
+3298 C  C   . VAL A 415 ? 0.4651 0.3284 0.2238 0.0972  -0.0006 0.0339  437 VAL A C   
+3299 O  O   . VAL A 415 ? 0.4206 0.3028 0.2142 0.0835  -0.0211 0.0312  437 VAL A O   
+3300 C  CB  A VAL A 415 ? 0.4624 0.4032 0.2398 0.1660  -0.0147 0.0104  437 VAL A CB  
+3301 C  CB  B VAL A 415 ? 0.4963 0.3945 0.2457 0.0911  -0.0025 0.0344  437 VAL A CB  
+3302 C  CG1 A VAL A 415 ? 0.4696 0.4560 0.2450 0.2050  -0.0242 -0.0013 437 VAL A CG1 
+3303 C  CG1 B VAL A 415 ? 0.4993 0.4181 0.2507 0.0784  -0.0007 0.0375  437 VAL A CG1 
+3304 C  CG2 A VAL A 415 ? 0.4565 0.4023 0.2438 0.1738  -0.0180 0.0008  437 VAL A CG2 
+3305 C  CG2 B VAL A 415 ? 0.5136 0.4300 0.2538 0.1029  -0.0099 0.0218  437 VAL A CG2 
+3306 N  N   . ILE A 416 ? 0.4763 0.3223 0.2170 0.0862  0.0002  0.0352  438 ILE A N   
+3307 C  CA  . ILE A 416 ? 0.4242 0.3700 0.2198 0.0748  0.0194  0.0164  438 ILE A CA  
+3308 C  C   . ILE A 416 ? 0.3672 0.3814 0.2285 0.0760  0.0244  0.0268  438 ILE A C   
+3309 O  O   . ILE A 416 ? 0.3561 0.3767 0.2358 0.0469  0.0157  0.0323  438 ILE A O   
+3310 C  CB  . ILE A 416 ? 0.4704 0.4030 0.2158 0.0588  0.0276  -0.0003 438 ILE A CB  
+3311 C  CG1 . ILE A 416 ? 0.5764 0.5057 0.2251 0.1333  0.0278  0.0025  438 ILE A CG1 
+3312 C  CG2 . ILE A 416 ? 0.5142 0.4423 0.2144 0.0237  0.0402  -0.0226 438 ILE A CG2 
+3313 C  CD1 . ILE A 416 ? 0.6259 0.5798 0.2287 0.1464  0.0333  0.0077  438 ILE A CD1 
+3314 N  N   . ASP A 417 ? 0.3407 0.3896 0.2340 0.0925  0.0178  0.0337  439 ASP A N   
+3315 C  CA  . ASP A 417 ? 0.3010 0.4322 0.2413 0.0998  0.0092  0.0476  439 ASP A CA  
+3316 C  C   . ASP A 417 ? 0.3137 0.4625 0.2432 0.0593  -0.0116 0.0432  439 ASP A C   
+3317 O  O   . ASP A 417 ? 0.3473 0.5456 0.2500 0.0610  -0.0120 0.0532  439 ASP A O   
+3318 C  CB  . ASP A 417 ? 0.3221 0.4605 0.2492 0.0914  0.0279  0.0493  439 ASP A CB  
+3319 C  CG  . ASP A 417 ? 0.3892 0.4569 0.2607 0.1165  0.0532  0.0607  439 ASP A CG  
+3320 O  OD1 . ASP A 417 ? 0.3816 0.3888 0.2717 0.0718  0.0621  0.0862  439 ASP A OD1 
+3321 O  OD2 . ASP A 417 ? 0.4197 0.5189 0.2634 0.1854  0.0645  0.0625  439 ASP A OD2 
+3322 N  N   . SER A 418 ? 0.3187 0.4268 0.2379 0.0256  -0.0146 0.0622  440 SER A N   
+3323 C  CA  . SER A 418 ? 0.3383 0.4733 0.2450 0.0217  -0.0318 0.0439  440 SER A CA  
+3324 C  C   . SER A 418 ? 0.2892 0.4311 0.2451 -0.0106 -0.0350 0.0220  440 SER A C   
+3325 O  O   . SER A 418 ? 0.3170 0.4058 0.2448 0.0801  -0.0239 0.0166  440 SER A O   
+3326 C  CB  . SER A 418 ? 0.3636 0.4809 0.2478 0.0108  -0.0356 0.0507  440 SER A CB  
+3327 O  OG  . SER A 418 ? 0.3717 0.4491 0.2524 -0.0135 -0.0111 0.0369  440 SER A OG  
+3328 N  N   . GLU A 419 ? 0.3320 0.4760 0.2490 -0.0064 -0.0429 0.0334  441 GLU A N   
+3329 C  CA  . GLU A 419 ? 0.3634 0.5232 0.2604 -0.0677 -0.0388 0.0310  441 GLU A CA  
+3330 C  C   . GLU A 419 ? 0.3735 0.5149 0.2454 -0.0474 -0.0192 0.0515  441 GLU A C   
+3331 O  O   . GLU A 419 ? 0.3919 0.5399 0.2469 -0.0482 -0.0034 0.0800  441 GLU A O   
+3332 C  CB  . GLU A 419 ? 0.4799 0.6843 0.2995 0.0033  -0.0229 0.0409  441 GLU A CB  
+3333 C  CG  . GLU A 419 ? 0.6316 0.8288 0.3278 0.0730  -0.0069 0.0458  441 GLU A CG  
+3334 C  CD  . GLU A 419 ? 0.7890 1.0012 0.3537 0.1494  0.0098  0.0527  441 GLU A CD  
+3335 O  OE1 . GLU A 419 ? 0.8686 1.0570 0.3645 0.1783  0.0095  0.0290  441 GLU A OE1 
+3336 O  OE2 . GLU A 419 ? 0.8367 1.0749 0.3669 0.1817  0.0117  0.0667  441 GLU A OE2 
+3337 N  N   . PHE A 420 ? 0.3333 0.4600 0.2293 -0.0217 0.0083  0.0440  442 PHE A N   
+3338 C  CA  . PHE A 420 ? 0.3297 0.3873 0.2092 -0.0968 0.0018  0.0459  442 PHE A CA  
+3339 C  C   . PHE A 420 ? 0.3761 0.4164 0.2129 -0.0464 0.0065  0.0207  442 PHE A C   
+3340 O  O   . PHE A 420 ? 0.4096 0.4390 0.2248 -0.0572 0.0196  0.0120  442 PHE A O   
+3341 C  CB  . PHE A 420 ? 0.3688 0.3954 0.1930 -0.0918 -0.0078 0.0058  442 PHE A CB  
+3342 C  CG  . PHE A 420 ? 0.4227 0.3561 0.1820 -0.0952 -0.0193 0.0141  442 PHE A CG  
+3343 C  CD1 . PHE A 420 ? 0.4996 0.3699 0.1905 0.0061  -0.0032 0.0152  442 PHE A CD1 
+3344 C  CD2 . PHE A 420 ? 0.3502 0.3648 0.1708 -0.1147 -0.0349 0.0010  442 PHE A CD2 
+3345 C  CE1 . PHE A 420 ? 0.4862 0.3605 0.1814 0.0325  -0.0019 0.0007  442 PHE A CE1 
+3346 C  CE2 . PHE A 420 ? 0.3656 0.3616 0.1774 -0.1129 -0.0437 -0.0243 442 PHE A CE2 
+3347 C  CZ  . PHE A 420 ? 0.4162 0.3577 0.1745 -0.0459 -0.0231 -0.0311 442 PHE A CZ  
+3348 N  N   . ASP A 421 ? 0.3357 0.4274 0.2074 -0.0902 0.0018  0.0116  443 ASP A N   
+3349 C  CA  . ASP A 421 ? 0.3581 0.4711 0.1979 -0.0950 -0.0140 -0.0163 443 ASP A CA  
+3350 C  C   . ASP A 421 ? 0.3329 0.3958 0.1843 -0.1156 0.0056  0.0026  443 ASP A C   
+3351 O  O   . ASP A 421 ? 0.3253 0.4531 0.1850 -0.0889 0.0216  0.0113  443 ASP A O   
+3352 C  CB  . ASP A 421 ? 0.4040 0.5936 0.2068 -0.0902 -0.0219 -0.0670 443 ASP A CB  
+3353 C  CG  . ASP A 421 ? 0.4406 0.6756 0.2153 -0.0754 -0.0197 -0.0683 443 ASP A CG  
+3354 O  OD1 . ASP A 421 ? 0.3775 0.6022 0.2093 -0.1382 0.0055  -0.0666 443 ASP A OD1 
+3355 O  OD2 . ASP A 421 ? 0.5009 0.7572 0.2339 -0.0482 -0.0338 -0.0695 443 ASP A OD2 
+3356 N  N   . PRO A 422 ? 0.3955 0.3739 0.1845 -0.1019 0.0028  0.0475  444 PRO A N   
+3357 C  CA  . PRO A 422 ? 0.3651 0.3036 0.1792 -0.1385 0.0203  0.0364  444 PRO A CA  
+3358 C  C   . PRO A 422 ? 0.3658 0.3497 0.1735 -0.1162 0.0209  0.0263  444 PRO A C   
+3359 O  O   . PRO A 422 ? 0.3285 0.3371 0.1729 -0.1051 0.0257  0.0253  444 PRO A O   
+3360 C  CB  . PRO A 422 ? 0.3904 0.3785 0.1837 0.0026  0.0316  0.0564  444 PRO A CB  
+3361 C  CG  . PRO A 422 ? 0.4636 0.4392 0.2085 0.0036  0.0100  0.0620  444 PRO A CG  
+3362 C  CD  . PRO A 422 ? 0.4461 0.4099 0.2060 -0.0521 -0.0219 0.0375  444 PRO A CD  
+3363 N  N   . MET A 423 ? 0.3770 0.4077 0.1741 -0.1110 0.0100  0.0180  445 MET A N   
+3364 C  CA  . MET A 423 ? 0.4089 0.3716 0.1761 -0.1119 -0.0161 0.0097  445 MET A CA  
+3365 C  C   . MET A 423 ? 0.4341 0.4682 0.1848 -0.0262 -0.0266 -0.0057 445 MET A C   
+3366 O  O   . MET A 423 ? 0.4348 0.4650 0.1884 0.0099  -0.0273 0.0231  445 MET A O   
+3367 C  CB  . MET A 423 ? 0.4415 0.4134 0.1853 -0.1263 -0.0012 0.0188  445 MET A CB  
+3368 C  CG  . MET A 423 ? 0.4575 0.3255 0.1894 -0.1819 -0.0006 0.0157  445 MET A CG  
+3369 S  SD  . MET A 423 ? 0.4774 0.3741 0.1922 -0.1340 0.0034  0.0013  445 MET A SD  
+3370 C  CE  . MET A 423 ? 0.4671 0.4423 0.1901 -0.0890 0.0261  0.0081  445 MET A CE  
+3371 N  N   . GLN A 424 ? 0.4698 0.5201 0.1859 -0.0046 -0.0291 -0.0067 446 GLN A N   
+3372 C  CA  A GLN A 424 ? 0.5052 0.5412 0.1950 0.0113  -0.0244 -0.0030 446 GLN A CA  
+3373 C  CA  B GLN A 424 ? 0.5174 0.5241 0.1898 0.0264  -0.0153 0.0008  446 GLN A CA  
+3374 C  C   . GLN A 424 ? 0.5174 0.5151 0.1868 0.0104  -0.0178 0.0053  446 GLN A C   
+3375 O  O   . GLN A 424 ? 0.4877 0.4370 0.1862 -0.0293 -0.0022 0.0155  446 GLN A O   
+3376 C  CB  A GLN A 424 ? 0.5332 0.6243 0.2152 0.0569  -0.0190 -0.0023 446 GLN A CB  
+3377 C  CB  B GLN A 424 ? 0.5661 0.5608 0.1987 0.0904  0.0052  0.0060  446 GLN A CB  
+3378 C  CG  A GLN A 424 ? 0.5742 0.7160 0.2360 0.1070  -0.0148 0.0006  446 GLN A CG  
+3379 C  CG  B GLN A 424 ? 0.6240 0.6080 0.2082 0.1572  0.0237  0.0130  446 GLN A CG  
+3380 C  CD  A GLN A 424 ? 0.6084 0.7846 0.2575 0.1318  -0.0110 0.0069  446 GLN A CD  
+3381 C  CD  B GLN A 424 ? 0.6811 0.6402 0.2214 0.2060  0.0407  0.0242  446 GLN A CD  
+3382 O  OE1 A GLN A 424 ? 0.6365 0.8429 0.2741 0.1329  -0.0129 -0.0074 446 GLN A OE1 
+3383 O  OE1 B GLN A 424 ? 0.7123 0.6596 0.2324 0.2204  0.0466  0.0229  446 GLN A OE1 
+3384 N  NE2 A GLN A 424 ? 0.6202 0.8173 0.2586 0.1687  -0.0079 0.0277  446 GLN A NE2 
+3385 N  NE2 B GLN A 424 ? 0.6988 0.6380 0.2346 0.2455  0.0466  0.0257  446 GLN A NE2 
+3386 N  N   . GLY A 425 ? 0.5792 0.5031 0.1866 0.0358  -0.0244 0.0479  447 GLY A N   
+3387 C  CA  . GLY A 425 ? 0.5809 0.4377 0.1808 0.0344  -0.0022 0.0561  447 GLY A CA  
+3388 C  C   . GLY A 425 ? 0.5287 0.3839 0.1786 0.0096  0.0128  0.0395  447 GLY A C   
+3389 O  O   . GLY A 425 ? 0.5687 0.3819 0.1978 0.0430  0.0201  0.0382  447 GLY A O   
+3390 N  N   . VAL A 426 ? 0.4783 0.3567 0.1610 0.0105  -0.0028 0.0249  448 VAL A N   
+3391 C  CA  . VAL A 426 ? 0.4369 0.3342 0.1659 -0.0722 -0.0018 0.0177  448 VAL A CA  
+3392 C  C   . VAL A 426 ? 0.4329 0.3389 0.1757 -0.0450 -0.0027 0.0069  448 VAL A C   
+3393 O  O   . VAL A 426 ? 0.4406 0.3745 0.1888 -0.0605 0.0010  -0.0119 448 VAL A O   
+3394 C  CB  . VAL A 426 ? 0.4455 0.3315 0.1594 -0.0477 0.0210  0.0148  448 VAL A CB  
+3395 C  CG1 . VAL A 426 ? 0.4397 0.2788 0.1627 -0.0495 0.0210  0.0290  448 VAL A CG1 
+3396 C  CG2 . VAL A 426 ? 0.4599 0.3707 0.1454 -0.0297 0.0112  0.0076  448 VAL A CG2 
+3397 N  N   . SER A 427 ? 0.4511 0.2731 0.1684 -0.1012 0.0055  0.0220  449 SER A N   
+3398 C  CA  . SER A 427 ? 0.4828 0.2691 0.1661 -0.0939 0.0086  0.0548  449 SER A CA  
+3399 C  C   . SER A 427 ? 0.4713 0.2836 0.1524 -0.1270 -0.0043 0.0197  449 SER A C   
+3400 O  O   . SER A 427 ? 0.4454 0.3240 0.1519 -0.1590 -0.0001 -0.0147 449 SER A O   
+3401 C  CB  . SER A 427 ? 0.5531 0.2832 0.1895 -0.1041 0.0004  0.0675  449 SER A CB  
+3402 O  OG  . SER A 427 ? 0.6132 0.4082 0.2123 -0.0882 -0.0263 0.0866  449 SER A OG  
+3403 N  N   . ALA A 428 ? 0.4723 0.2840 0.1449 -0.1691 0.0098  0.0044  450 ALA A N   
+3404 C  CA  . ALA A 428 ? 0.4386 0.2690 0.1473 -0.1814 -0.0034 0.0154  450 ALA A CA  
+3405 C  C   . ALA A 428 ? 0.4030 0.2606 0.1416 -0.1840 -0.0222 0.0193  450 ALA A C   
+3406 O  O   . ALA A 428 ? 0.4223 0.3396 0.1569 -0.2124 -0.0125 0.0225  450 ALA A O   
+3407 C  CB  . ALA A 428 ? 0.4876 0.2602 0.1341 -0.1108 0.0111  0.0037  450 ALA A CB  
+3408 N  N   . SER A 429 ? 0.4292 0.2798 0.1611 -0.1581 -0.0158 0.0492  451 SER A N   
+3409 C  CA  . SER A 429 ? 0.4427 0.2459 0.1661 -0.1551 -0.0038 0.0368  451 SER A CA  
+3410 C  C   . SER A 429 ? 0.4386 0.3377 0.1488 -0.1804 0.0006  0.0198  451 SER A C   
+3411 O  O   . SER A 429 ? 0.4205 0.3275 0.1472 -0.1507 -0.0182 -0.0004 451 SER A O   
+3412 C  CB  . SER A 429 ? 0.5290 0.2891 0.1861 -0.1640 -0.0056 0.0257  451 SER A CB  
+3413 O  OG  . SER A 429 ? 0.5345 0.3111 0.2078 -0.1416 0.0059  0.0669  451 SER A OG  
+3414 N  N   . HIS A 430 ? 0.4227 0.3430 0.1521 -0.2130 0.0096  -0.0005 452 HIS A N   
+3415 C  CA  . HIS A 430 ? 0.3872 0.3465 0.1510 -0.2148 0.0072  0.0007  452 HIS A CA  
+3416 C  C   . HIS A 430 ? 0.3992 0.3143 0.1503 -0.2086 0.0101  -0.0041 452 HIS A C   
+3417 O  O   . HIS A 430 ? 0.4046 0.3378 0.1560 -0.1614 -0.0023 0.0232  452 HIS A O   
+3418 C  CB  . HIS A 430 ? 0.4201 0.3323 0.1491 -0.1906 0.0029  -0.0207 452 HIS A CB  
+3419 C  CG  . HIS A 430 ? 0.4449 0.2501 0.1465 -0.1832 0.0250  -0.0127 452 HIS A CG  
+3420 N  ND1 . HIS A 430 ? 0.4685 0.2556 0.1457 -0.1462 0.0240  -0.0244 452 HIS A ND1 
+3421 C  CD2 . HIS A 430 ? 0.4132 0.3206 0.1636 -0.1962 0.0313  0.0024  452 HIS A CD2 
+3422 C  CE1 . HIS A 430 ? 0.4502 0.3325 0.1577 -0.2148 0.0282  -0.0158 452 HIS A CE1 
+3423 N  NE2 . HIS A 430 ? 0.4311 0.3291 0.1551 -0.2191 0.0253  -0.0175 452 HIS A NE2 
+3424 N  N   . PRO A 431 ? 0.4261 0.3410 0.1718 -0.2130 0.0071  0.0184  453 PRO A N   
+3425 C  CA  . PRO A 431 ? 0.4640 0.3540 0.1748 -0.2273 0.0132  0.0077  453 PRO A CA  
+3426 C  C   . PRO A 431 ? 0.4985 0.3359 0.1675 -0.2132 0.0145  0.0055  453 PRO A C   
+3427 O  O   . PRO A 431 ? 0.5752 0.3005 0.1747 -0.2205 0.0010  0.0006  453 PRO A O   
+3428 C  CB  . PRO A 431 ? 0.4680 0.3680 0.1877 -0.2351 0.0121  0.0125  453 PRO A CB  
+3429 C  CG  . PRO A 431 ? 0.5103 0.4541 0.1757 -0.1467 0.0258  0.0502  453 PRO A CG  
+3430 C  CD  . PRO A 431 ? 0.4606 0.3427 0.1749 -0.2172 0.0107  0.0158  453 PRO A CD  
+3431 N  N   . THR A 432 ? 0.4370 0.3385 0.1619 -0.2232 0.0119  -0.0016 454 THR A N   
+3432 C  CA  . THR A 432 ? 0.4835 0.3496 0.1669 -0.1962 -0.0193 -0.0157 454 THR A CA  
+3433 C  C   . THR A 432 ? 0.4944 0.3214 0.1781 -0.2079 -0.0175 -0.0147 454 THR A C   
+3434 O  O   . THR A 432 ? 0.5132 0.3536 0.1913 -0.2471 -0.0212 0.0133  454 THR A O   
+3435 C  CB  . THR A 432 ? 0.5438 0.3288 0.1748 -0.1727 -0.0197 -0.0267 454 THR A CB  
+3436 O  OG1 . THR A 432 ? 0.6229 0.2980 0.1895 -0.1646 -0.0046 -0.0310 454 THR A OG1 
+3437 C  CG2 . THR A 432 ? 0.5374 0.3652 0.1839 -0.1982 -0.0077 -0.0353 454 THR A CG2 
+3438 N  N   . GLN A 433 ? 0.4998 0.2882 0.1705 -0.2098 -0.0081 -0.0008 455 GLN A N   
+3439 C  CA  A GLN A 433 ? 0.4677 0.3237 0.1803 -0.2261 -0.0047 0.0008  455 GLN A CA  
+3440 C  CA  B GLN A 433 ? 0.4856 0.3372 0.1826 -0.2335 -0.0010 -0.0074 455 GLN A CA  
+3441 C  C   . GLN A 433 ? 0.5091 0.3774 0.1930 -0.2566 -0.0163 0.0074  455 GLN A C   
+3442 O  O   . GLN A 433 ? 0.5478 0.4349 0.2359 -0.2705 -0.0129 0.0186  455 GLN A O   
+3443 C  CB  A GLN A 433 ? 0.4310 0.2706 0.1913 -0.1914 0.0045  0.0135  455 GLN A CB  
+3444 C  CB  B GLN A 433 ? 0.5287 0.3330 0.1809 -0.2280 0.0046  -0.0171 455 GLN A CB  
+3445 C  CG  A GLN A 433 ? 0.4456 0.2637 0.2017 -0.1554 0.0121  0.0534  455 GLN A CG  
+3446 C  CG  B GLN A 433 ? 0.5323 0.3828 0.1748 -0.1631 0.0118  -0.0136 455 GLN A CG  
+3447 C  CD  A GLN A 433 ? 0.4065 0.2508 0.2061 -0.1390 0.0041  0.0685  455 GLN A CD  
+3448 C  CD  B GLN A 433 ? 0.5293 0.4279 0.1744 -0.1313 0.0195  -0.0174 455 GLN A CD  
+3449 O  OE1 A GLN A 433 ? 0.4218 0.2211 0.1983 -0.1181 -0.0115 0.0693  455 GLN A OE1 
+3450 O  OE1 B GLN A 433 ? 0.5337 0.4367 0.1804 -0.1423 0.0163  -0.0140 455 GLN A OE1 
+3451 N  NE2 A GLN A 433 ? 0.3835 0.2903 0.2119 -0.0821 0.0226  0.1177  455 GLN A NE2 
+3452 N  NE2 B GLN A 433 ? 0.5008 0.4511 0.1718 -0.1293 0.0155  -0.0237 455 GLN A NE2 
+3453 N  N   . GLY A 434 ? 0.4921 0.3524 0.1676 -0.2234 -0.0264 0.0122  456 GLY A N   
+3454 C  CA  . GLY A 434 ? 0.4683 0.3273 0.1600 -0.2062 -0.0297 0.0093  456 GLY A CA  
+3455 C  C   . GLY A 434 ? 0.4464 0.3577 0.1621 -0.2184 -0.0360 0.0234  456 GLY A C   
+3456 O  O   . GLY A 434 ? 0.4478 0.3393 0.1700 -0.2266 -0.0419 0.0277  456 GLY A O   
+3457 N  N   . ASP A 435 ? 0.4540 0.3371 0.1626 -0.1848 -0.0158 0.0420  457 ASP A N   
+3458 C  CA  . ASP A 435 ? 0.4631 0.3212 0.1610 -0.1493 -0.0187 0.0195  457 ASP A CA  
+3459 C  C   . ASP A 435 ? 0.4417 0.2403 0.1591 -0.1779 -0.0115 0.0051  457 ASP A C   
+3460 O  O   . ASP A 435 ? 0.5025 0.3107 0.1760 -0.2238 -0.0210 0.0158  457 ASP A O   
+3461 C  CB  . ASP A 435 ? 0.4472 0.3147 0.1798 -0.1354 -0.0422 0.0581  457 ASP A CB  
+3462 C  CG  . ASP A 435 ? 0.4215 0.4197 0.2011 -0.1976 -0.0279 0.0524  457 ASP A CG  
+3463 O  OD1 . ASP A 435 ? 0.4538 0.3902 0.1911 -0.2035 -0.0206 0.0394  457 ASP A OD1 
+3464 O  OD2 . ASP A 435 ? 0.4328 0.4751 0.2213 -0.1986 -0.0434 0.0634  457 ASP A OD2 
+3465 N  N   . LEU A 436 ? 0.4152 0.2770 0.1551 -0.1955 -0.0192 0.0147  458 LEU A N   
+3466 C  CA  . LEU A 436 ? 0.4229 0.2391 0.1518 -0.1645 0.0009  0.0163  458 LEU A CA  
+3467 C  C   . LEU A 436 ? 0.4531 0.2640 0.1496 -0.1797 0.0052  0.0106  458 LEU A C   
+3468 O  O   . LEU A 436 ? 0.4855 0.2673 0.1510 -0.1976 0.0021  -0.0015 458 LEU A O   
+3469 C  CB  . LEU A 436 ? 0.3966 0.1882 0.1513 -0.1368 0.0135  0.0069  458 LEU A CB  
+3470 C  CG  . LEU A 436 ? 0.4209 0.2171 0.1658 -0.1614 0.0188  -0.0055 458 LEU A CG  
+3471 C  CD1 . LEU A 436 ? 0.4463 0.2519 0.1553 -0.1743 0.0200  0.0000  458 LEU A CD1 
+3472 C  CD2 . LEU A 436 ? 0.4651 0.2482 0.1892 -0.1393 0.0289  -0.0190 458 LEU A CD2 
+3473 N  N   . THR A 437 ? 0.4493 0.2613 0.1513 -0.1726 -0.0019 0.0202  459 THR A N   
+3474 C  CA  . THR A 437 ? 0.4173 0.2846 0.1650 -0.1622 0.0193  0.0264  459 THR A CA  
+3475 C  C   . THR A 437 ? 0.4078 0.2656 0.1649 -0.1877 0.0116  0.0005  459 THR A C   
+3476 O  O   . THR A 437 ? 0.4202 0.3067 0.1619 -0.1773 0.0071  -0.0278 459 THR A O   
+3477 C  CB  . THR A 437 ? 0.3969 0.2922 0.1887 -0.1484 -0.0097 0.0308  459 THR A CB  
+3478 O  OG1 . THR A 437 ? 0.4347 0.2836 0.2135 -0.1320 -0.0232 0.0213  459 THR A OG1 
+3479 C  CG2 . THR A 437 ? 0.3845 0.3159 0.1927 -0.0905 0.0025  0.0224  459 THR A CG2 
+3480 N  N   . ALA A 438 ? 0.4104 0.3127 0.1693 -0.2109 -0.0027 0.0067  460 ALA A N   
+3481 C  CA  . ALA A 438 ? 0.4209 0.3000 0.1665 -0.2063 -0.0006 -0.0071 460 ALA A CA  
+3482 C  C   . ALA A 438 ? 0.4357 0.2558 0.1550 -0.1864 0.0014  0.0027  460 ALA A C   
+3483 O  O   . ALA A 438 ? 0.5053 0.2496 0.1757 -0.1737 0.0147  0.0140  460 ALA A O   
+3484 C  CB  . ALA A 438 ? 0.4352 0.3615 0.1820 -0.1953 -0.0300 -0.0278 460 ALA A CB  
+3485 N  N   . ASN A 439 ? 0.4343 0.2738 0.1423 -0.1953 -0.0082 0.0067  461 ASN A N   
+3486 C  CA  . ASN A 439 ? 0.4026 0.2774 0.1300 -0.1488 0.0116  0.0087  461 ASN A CA  
+3487 C  C   . ASN A 439 ? 0.3937 0.2637 0.1341 -0.1692 0.0103  0.0068  461 ASN A C   
+3488 O  O   . ASN A 439 ? 0.4060 0.2377 0.1339 -0.1720 0.0030  0.0021  461 ASN A O   
+3489 C  CB  . ASN A 439 ? 0.4143 0.2390 0.1267 -0.1514 -0.0085 -0.0015 461 ASN A CB  
+3490 C  CG  . ASN A 439 ? 0.4364 0.2659 0.1576 -0.1723 -0.0119 -0.0190 461 ASN A CG  
+3491 O  OD1 . ASN A 439 ? 0.4557 0.2943 0.1725 -0.1455 -0.0209 0.0010  461 ASN A OD1 
+3492 N  ND2 . ASN A 439 ? 0.4565 0.2853 0.1436 -0.1810 0.0103  -0.0019 461 ASN A ND2 
+3493 N  N   . ILE A 440 ? 0.3893 0.2183 0.1310 -0.1599 0.0252  -0.0172 462 ILE A N   
+3494 C  CA  . ILE A 440 ? 0.3671 0.2102 0.1379 -0.1534 0.0128  -0.0129 462 ILE A CA  
+3495 C  C   . ILE A 440 ? 0.4108 0.2490 0.1391 -0.1170 0.0325  0.0109  462 ILE A C   
+3496 O  O   . ILE A 440 ? 0.4374 0.2921 0.1505 -0.1329 0.0371  0.0260  462 ILE A O   
+3497 C  CB  . ILE A 440 ? 0.3599 0.1904 0.1496 -0.1411 0.0131  -0.0023 462 ILE A CB  
+3498 C  CG1 . ILE A 440 ? 0.4202 0.1817 0.1642 -0.1273 0.0212  0.0107  462 ILE A CG1 
+3499 C  CG2 . ILE A 440 ? 0.3966 0.2464 0.1507 -0.1209 0.0127  -0.0134 462 ILE A CG2 
+3500 C  CD1 . ILE A 440 ? 0.4256 0.1940 0.1649 -0.1447 0.0193  -0.0051 462 ILE A CD1 
+3501 N  N   . THR A 441 ? 0.3885 0.2227 0.1302 -0.0956 0.0228  -0.0003 463 THR A N   
+3502 C  CA  . THR A 441 ? 0.4237 0.2389 0.1351 -0.1251 0.0163  0.0024  463 THR A CA  
+3503 C  C   . THR A 441 ? 0.3856 0.2623 0.1295 -0.1237 0.0160  0.0079  463 THR A C   
+3504 O  O   . THR A 441 ? 0.3400 0.2639 0.1320 -0.1117 0.0281  -0.0039 463 THR A O   
+3505 C  CB  . THR A 441 ? 0.4694 0.2386 0.1454 -0.1296 0.0069  0.0096  463 THR A CB  
+3506 O  OG1 . THR A 441 ? 0.4581 0.3149 0.1440 -0.1309 0.0216  0.0081  463 THR A OG1 
+3507 C  CG2 . THR A 441 ? 0.5148 0.3094 0.1618 -0.0688 -0.0190 -0.0250 463 THR A CG2 
+3508 N  N   . VAL A 442 ? 0.3877 0.2588 0.1342 -0.1312 0.0336  0.0146  464 VAL A N   
+3509 C  CA  . VAL A 442 ? 0.4206 0.2499 0.1262 -0.0857 0.0318  0.0218  464 VAL A CA  
+3510 C  C   . VAL A 442 ? 0.4577 0.2696 0.1405 -0.0734 0.0387  0.0360  464 VAL A C   
+3511 O  O   . VAL A 442 ? 0.4878 0.2538 0.1639 -0.0960 0.0339  0.0385  464 VAL A O   
+3512 C  CB  . VAL A 442 ? 0.4424 0.2954 0.1210 -0.0872 0.0008  0.0056  464 VAL A CB  
+3513 C  CG1 . VAL A 442 ? 0.4636 0.3545 0.1279 -0.0178 -0.0062 -0.0277 464 VAL A CG1 
+3514 C  CG2 . VAL A 442 ? 0.4566 0.3501 0.1301 -0.0839 -0.0136 0.0296  464 VAL A CG2 
+3515 N  N   . THR A 443 ? 0.4289 0.2293 0.1256 -0.0457 0.0366  0.0299  465 THR A N   
+3516 C  CA  . THR A 443 ? 0.4522 0.2151 0.1221 0.0035  0.0472  0.0089  465 THR A CA  
+3517 C  C   . THR A 443 ? 0.4594 0.2130 0.1192 -0.0246 0.0306  0.0032  465 THR A C   
+3518 O  O   . THR A 443 ? 0.4936 0.2189 0.1355 -0.0952 0.0286  0.0036  465 THR A O   
+3519 C  CB  . THR A 443 ? 0.4848 0.3181 0.1274 0.0517  0.0270  0.0012  465 THR A CB  
+3520 O  OG1 . THR A 443 ? 0.5504 0.3295 0.1459 0.0568  0.0250  -0.0079 465 THR A OG1 
+3521 C  CG2 . THR A 443 ? 0.4663 0.3442 0.1276 -0.0169 0.0447  0.0260  465 THR A CG2 
+3522 N  N   . GLY A 444 ? 0.4429 0.2742 0.1199 0.0120  0.0469  0.0113  466 GLY A N   
+3523 C  CA  . GLY A 444 ? 0.4256 0.2500 0.1230 -0.0204 0.0401  0.0348  466 GLY A CA  
+3524 C  C   . GLY A 444 ? 0.4436 0.2035 0.1235 -0.1004 0.0046  -0.0147 466 GLY A C   
+3525 O  O   . GLY A 444 ? 0.4957 0.3007 0.1287 -0.0227 -0.0249 -0.0176 466 GLY A O   
+3526 N  N   . GLU A 445 ? 0.4500 0.2590 0.1454 -0.1184 0.0271  -0.0171 467 GLU A N   
+3527 C  CA  . GLU A 445 ? 0.4194 0.2775 0.1747 -0.1608 0.0174  -0.0376 467 GLU A CA  
+3528 C  C   . GLU A 445 ? 0.3585 0.2323 0.1603 -0.1181 0.0084  -0.0341 467 GLU A C   
+3529 O  O   . GLU A 445 ? 0.3869 0.1969 0.1534 -0.0995 -0.0016 -0.0054 467 GLU A O   
+3530 C  CB  . GLU A 445 ? 0.4943 0.4023 0.2545 -0.2381 0.0249  -0.0801 467 GLU A CB  
+3531 C  CG  . GLU A 445 ? 0.5997 0.6504 0.3018 -0.2732 -0.0080 -0.1221 467 GLU A CG  
+3532 C  CD  . GLU A 445 ? 0.7472 0.8890 0.3246 -0.1256 -0.0053 -0.1391 467 GLU A CD  
+3533 O  OE1 . GLU A 445 ? 0.8107 0.9727 0.3440 -0.0889 -0.0152 -0.1312 467 GLU A OE1 
+3534 O  OE2 . GLU A 445 ? 0.8064 0.9998 0.3345 -0.0630 0.0078  -0.1188 467 GLU A OE2 
+3535 N  N   . VAL A 446 ? 0.3478 0.3040 0.1534 -0.0635 0.0153  -0.0135 468 VAL A N   
+3536 C  CA  . VAL A 446 ? 0.2829 0.3070 0.1557 -0.0912 -0.0032 0.0013  468 VAL A CA  
+3537 C  C   . VAL A 446 ? 0.2485 0.3580 0.1336 -0.0880 -0.0009 0.0150  468 VAL A C   
+3538 O  O   . VAL A 446 ? 0.2630 0.4428 0.1362 -0.0976 0.0072  -0.0037 468 VAL A O   
+3539 C  CB  . VAL A 446 ? 0.2648 0.2919 0.1708 -0.0268 0.0010  0.0143  468 VAL A CB  
+3540 C  CG1 . VAL A 446 ? 0.2497 0.2462 0.1889 -0.0196 0.0052  0.0374  468 VAL A CG1 
+3541 C  CG2 . VAL A 446 ? 0.3261 0.2816 0.1776 -0.0463 0.0252  0.0187  468 VAL A CG2 
+3542 N  N   . ASP A 447 ? 0.2607 0.2848 0.1214 -0.0867 0.0288  0.0292  469 ASP A N   
+3543 C  CA  . ASP A 447 ? 0.2472 0.2804 0.1221 -0.0250 0.0270  0.0395  469 ASP A CA  
+3544 C  C   . ASP A 447 ? 0.2975 0.3055 0.1281 0.0043  0.0149  0.0348  469 ASP A C   
+3545 O  O   . ASP A 447 ? 0.3033 0.2932 0.1295 -0.0138 0.0327  0.0317  469 ASP A O   
+3546 C  CB  . ASP A 447 ? 0.2294 0.2633 0.1424 -0.0455 0.0360  0.0505  469 ASP A CB  
+3547 C  CG  . ASP A 447 ? 0.2351 0.3009 0.1461 -0.0199 0.0237  0.0324  469 ASP A CG  
+3548 O  OD1 . ASP A 447 ? 0.2554 0.3178 0.1531 -0.0196 0.0119  0.0241  469 ASP A OD1 
+3549 O  OD2 . ASP A 447 ? 0.2425 0.2707 0.1528 -0.0420 0.0076  -0.0025 469 ASP A OD2 
+3550 N  N   . THR A 448 ? 0.2701 0.2868 0.1376 -0.0025 -0.0089 0.0210  470 THR A N   
+3551 C  CA  . THR A 448 ? 0.2564 0.3156 0.1535 0.0201  0.0034  0.0365  470 THR A CA  
+3552 C  C   . THR A 448 ? 0.2642 0.2641 0.1683 0.0129  0.0299  0.0195  470 THR A C   
+3553 O  O   . THR A 448 ? 0.3162 0.2585 0.1829 0.0553  0.0415  0.0208  470 THR A O   
+3554 C  CB  . THR A 448 ? 0.2950 0.3378 0.1604 0.0189  0.0076  0.0549  470 THR A CB  
+3555 O  OG1 . THR A 448 ? 0.2719 0.4366 0.1602 0.0260  -0.0019 0.0607  470 THR A OG1 
+3556 C  CG2 . THR A 448 ? 0.3420 0.3467 0.1749 0.0576  0.0126  0.0620  470 THR A CG2 
+3557 N  N   . ASN A 449 ? 0.2647 0.3108 0.1616 0.0069  0.0066  0.0348  471 ASN A N   
+3558 C  CA  . ASN A 449 ? 0.2166 0.2534 0.1712 -0.0043 0.0064  0.0123  471 ASN A CA  
+3559 C  C   . ASN A 449 ? 0.2225 0.2958 0.1588 -0.0140 0.0011  0.0113  471 ASN A C   
+3560 O  O   . ASN A 449 ? 0.2673 0.2876 0.1639 -0.0220 0.0130  0.0310  471 ASN A O   
+3561 C  CB  . ASN A 449 ? 0.2200 0.2788 0.1803 -0.0200 0.0059  0.0230  471 ASN A CB  
+3562 C  CG  . ASN A 449 ? 0.2638 0.3947 0.1887 -0.0083 0.0108  0.0311  471 ASN A CG  
+3563 O  OD1 . ASN A 449 ? 0.2863 0.4383 0.1812 -0.0346 0.0152  0.0387  471 ASN A OD1 
+3564 N  ND2 . ASN A 449 ? 0.3138 0.4591 0.1982 0.0251  0.0175  0.0501  471 ASN A ND2 
+3565 N  N   . VAL A 450 ? 0.2045 0.3034 0.1478 0.0164  0.0129  0.0145  472 VAL A N   
+3566 C  CA  . VAL A 450 ? 0.2167 0.2641 0.1403 -0.0225 0.0308  0.0153  472 VAL A CA  
+3567 C  C   . VAL A 450 ? 0.2540 0.2324 0.1459 -0.0152 0.0248  0.0179  472 VAL A C   
+3568 O  O   . VAL A 450 ? 0.2860 0.2372 0.1410 -0.0583 0.0259  0.0128  472 VAL A O   
+3569 C  CB  . VAL A 450 ? 0.2350 0.2684 0.1252 -0.0273 0.0380  0.0361  472 VAL A CB  
+3570 C  CG1 . VAL A 450 ? 0.2345 0.3002 0.1200 -0.0049 0.0416  0.0103  472 VAL A CG1 
+3571 C  CG2 . VAL A 450 ? 0.2254 0.2445 0.1301 -0.0116 0.0289  0.0287  472 VAL A CG2 
+3572 N  N   . VAL A 451 ? 0.2725 0.2267 0.1617 0.0233  0.0146  0.0123  473 VAL A N   
+3573 C  CA  . VAL A 451 ? 0.2392 0.2281 0.1595 -0.0488 0.0168  0.0107  473 VAL A CA  
+3574 C  C   . VAL A 451 ? 0.3108 0.2092 0.1379 -0.0388 0.0089  0.0092  473 VAL A C   
+3575 O  O   . VAL A 451 ? 0.3150 0.1501 0.1396 -0.0201 0.0317  0.0238  473 VAL A O   
+3576 C  CB  . VAL A 451 ? 0.3289 0.2609 0.2003 0.0240  0.0234  -0.0021 473 VAL A CB  
+3577 C  CG1 . VAL A 451 ? 0.4202 0.2930 0.1950 0.0388  0.0216  -0.0107 473 VAL A CG1 
+3578 C  CG2 . VAL A 451 ? 0.3349 0.1819 0.2202 -0.0170 0.0408  0.0042  473 VAL A CG2 
+3579 N  N   . GLY A 452 ? 0.3251 0.2366 0.1116 0.0143  0.0132  0.0146  474 GLY A N   
+3580 C  CA  . GLY A 452 ? 0.3089 0.2906 0.1066 -0.0368 0.0434  0.0239  474 GLY A CA  
+3581 C  C   . GLY A 452 ? 0.3245 0.2295 0.1196 -0.0739 0.0297  0.0320  474 GLY A C   
+3582 O  O   . GLY A 452 ? 0.3427 0.2285 0.1234 -0.0147 0.0329  0.0392  474 GLY A O   
+3583 N  N   . VAL A 453 ? 0.3296 0.2353 0.1319 -0.0668 0.0366  0.0117  475 VAL A N   
+3584 C  CA  . VAL A 453 ? 0.3265 0.2324 0.1454 -0.0442 0.0141  0.0119  475 VAL A CA  
+3585 C  C   . VAL A 453 ? 0.3232 0.2515 0.1358 -0.0009 0.0069  0.0016  475 VAL A C   
+3586 O  O   . VAL A 453 ? 0.3675 0.2868 0.1346 0.0180  0.0035  -0.0043 475 VAL A O   
+3587 C  CB  . VAL A 453 ? 0.3394 0.2884 0.1605 -0.0996 0.0035  -0.0138 475 VAL A CB  
+3588 C  CG1 . VAL A 453 ? 0.3953 0.4293 0.1640 -0.0250 0.0304  0.0104  475 VAL A CG1 
+3589 C  CG2 . VAL A 453 ? 0.2878 0.3237 0.1819 -0.0614 -0.0163 0.0209  475 VAL A CG2 
+3590 N  N   . TYR A 454 ? 0.2788 0.2015 0.1217 -0.0536 -0.0140 -0.0049 476 TYR A N   
+3591 C  CA  . TYR A 454 ? 0.2604 0.2307 0.1176 -0.1029 0.0058  0.0120  476 TYR A CA  
+3592 C  C   . TYR A 454 ? 0.2937 0.2460 0.1283 -0.0634 0.0307  0.0179  476 TYR A C   
+3593 O  O   . TYR A 454 ? 0.3476 0.2572 0.1590 -0.0094 0.0669  0.0335  476 TYR A O   
+3594 C  CB  . TYR A 454 ? 0.2592 0.2120 0.1079 -0.0863 -0.0055 0.0164  476 TYR A CB  
+3595 C  CG  . TYR A 454 ? 0.2662 0.2071 0.1127 -0.0739 -0.0095 0.0194  476 TYR A CG  
+3596 C  CD1 . TYR A 454 ? 0.3204 0.1955 0.1173 -0.0564 0.0143  0.0134  476 TYR A CD1 
+3597 C  CD2 . TYR A 454 ? 0.3096 0.2166 0.1215 -0.0278 -0.0117 0.0465  476 TYR A CD2 
+3598 C  CE1 . TYR A 454 ? 0.3037 0.2283 0.1153 -0.0124 0.0076  0.0011  476 TYR A CE1 
+3599 C  CE2 . TYR A 454 ? 0.2591 0.1791 0.1287 -0.0448 0.0169  0.0176  476 TYR A CE2 
+3600 C  CZ  . TYR A 454 ? 0.2326 0.2185 0.1191 -0.0995 0.0174  0.0325  476 TYR A CZ  
+3601 O  OH  . TYR A 454 ? 0.2245 0.2737 0.1074 -0.0394 0.0117  0.0254  476 TYR A OH  
+3602 N  N   . GLU A 455 ? 0.3182 0.2606 0.1221 -0.0500 0.0261  -0.0453 477 GLU A N   
+3603 C  CA  . GLU A 455 ? 0.3621 0.3032 0.1288 -0.0459 0.0264  -0.0406 477 GLU A CA  
+3604 C  C   . GLU A 455 ? 0.3430 0.2562 0.1297 -0.0518 0.0309  0.0096  477 GLU A C   
+3605 O  O   . GLU A 455 ? 0.3759 0.2558 0.1277 -0.0755 0.0174  0.0083  477 GLU A O   
+3606 C  CB  . GLU A 455 ? 0.3736 0.3682 0.1542 -0.1108 0.0297  -0.0795 477 GLU A CB  
+3607 C  CG  . GLU A 455 ? 0.4633 0.5130 0.1931 -0.0530 0.0291  -0.0435 477 GLU A CG  
+3608 C  CD  . GLU A 455 ? 0.6355 0.7831 0.2413 0.0024  0.0263  0.0224  477 GLU A CD  
+3609 O  OE1 . GLU A 455 ? 0.7053 0.8970 0.2604 0.0628  -0.0024 0.0344  477 GLU A OE1 
+3610 O  OE2 . GLU A 455 ? 0.6878 0.8899 0.2647 -0.0039 0.0352  0.0277  477 GLU A OE2 
+3611 N  N   . LEU A 456 ? 0.3386 0.2469 0.1219 -0.0596 0.0179  0.0150  478 LEU A N   
+3612 C  CA  . LEU A 456 ? 0.3674 0.2007 0.1275 -0.0601 0.0310  0.0323  478 LEU A CA  
+3613 C  C   . LEU A 456 ? 0.3712 0.2414 0.1418 -0.1257 0.0463  0.0149  478 LEU A C   
+3614 O  O   . LEU A 456 ? 0.5004 0.2345 0.1519 -0.0715 0.0765  0.0008  478 LEU A O   
+3615 C  CB  . LEU A 456 ? 0.4221 0.2561 0.1534 -0.0634 0.0140  0.0226  478 LEU A CB  
+3616 C  CG  . LEU A 456 ? 0.4083 0.2317 0.1622 -0.0756 -0.0184 -0.0035 478 LEU A CG  
+3617 C  CD1 . LEU A 456 ? 0.4083 0.3033 0.1702 -0.0659 -0.0369 -0.0007 478 LEU A CD1 
+3618 C  CD2 . LEU A 456 ? 0.4207 0.2275 0.1820 -0.1101 0.0013  0.0070  478 LEU A CD2 
+3619 N  N   . THR A 457 ? 0.4073 0.2179 0.1380 -0.0363 0.0198  -0.0024 479 THR A N   
+3620 C  CA  . THR A 457 ? 0.4049 0.2517 0.1396 -0.0460 -0.0058 -0.0018 479 THR A CA  
+3621 C  C   . THR A 457 ? 0.4064 0.2653 0.1248 -0.0630 0.0056  -0.0135 479 THR A C   
+3622 O  O   . THR A 457 ? 0.4405 0.2253 0.1261 -0.1007 0.0319  0.0028  479 THR A O   
+3623 C  CB  . THR A 457 ? 0.5213 0.3642 0.1668 0.0630  -0.0470 -0.0498 479 THR A CB  
+3624 O  OG1 . THR A 457 ? 0.5675 0.4518 0.2038 0.1856  -0.0854 -0.0656 479 THR A OG1 
+3625 C  CG2 . THR A 457 ? 0.5452 0.3702 0.1767 0.0448  -0.0564 -0.0476 479 THR A CG2 
+3626 N  N   . TYR A 458 ? 0.3823 0.2488 0.1071 -0.0838 0.0049  -0.0134 480 TYR A N   
+3627 C  CA  . TYR A 458 ? 0.3992 0.2201 0.1194 -0.1363 0.0140  -0.0101 480 TYR A CA  
+3628 C  C   . TYR A 458 ? 0.3704 0.1840 0.1244 -0.1359 0.0348  -0.0154 480 TYR A C   
+3629 O  O   . TYR A 458 ? 0.4043 0.2123 0.1369 -0.1230 0.0341  -0.0308 480 TYR A O   
+3630 C  CB  . TYR A 458 ? 0.4216 0.2172 0.1261 -0.1125 0.0120  -0.0063 480 TYR A CB  
+3631 C  CG  . TYR A 458 ? 0.3822 0.2334 0.1210 -0.1108 0.0459  -0.0124 480 TYR A CG  
+3632 C  CD1 . TYR A 458 ? 0.3597 0.2593 0.1266 -0.1342 0.0489  -0.0155 480 TYR A CD1 
+3633 C  CD2 . TYR A 458 ? 0.3662 0.2535 0.1267 -0.0891 0.0416  0.0003  480 TYR A CD2 
+3634 C  CE1 . TYR A 458 ? 0.3383 0.2499 0.1235 -0.0992 0.0260  -0.0252 480 TYR A CE1 
+3635 C  CE2 . TYR A 458 ? 0.3627 0.2210 0.1265 -0.1159 0.0302  0.0007  480 TYR A CE2 
+3636 C  CZ  . TYR A 458 ? 0.3485 0.2150 0.1295 -0.1047 0.0421  -0.0136 480 TYR A CZ  
+3637 O  OH  . TYR A 458 ? 0.3526 0.2687 0.1347 -0.1038 0.0547  0.0202  480 TYR A OH  
+3638 N  N   . GLN A 459 ? 0.3817 0.1998 0.1267 -0.0947 0.0346  -0.0011 481 GLN A N   
+3639 C  CA  . GLN A 459 ? 0.3472 0.2760 0.1392 -0.1237 0.0124  -0.0279 481 GLN A CA  
+3640 C  C   . GLN A 459 ? 0.3034 0.2796 0.1428 -0.1651 0.0077  -0.0304 481 GLN A C   
+3641 O  O   . GLN A 459 ? 0.3256 0.3308 0.1377 -0.1712 0.0105  -0.0163 481 GLN A O   
+3642 C  CB  . GLN A 459 ? 0.4049 0.3510 0.1547 -0.0245 0.0082  -0.0021 481 GLN A CB  
+3643 C  CG  . GLN A 459 ? 0.5565 0.4832 0.1919 0.0401  0.0111  0.0117  481 GLN A CG  
+3644 C  CD  . GLN A 459 ? 0.6968 0.6349 0.2315 0.0494  -0.0081 0.0739  481 GLN A CD  
+3645 O  OE1 . GLN A 459 ? 0.7675 0.6742 0.2498 0.0647  0.0147  0.1103  481 GLN A OE1 
+3646 N  NE2 . GLN A 459 ? 0.7388 0.6521 0.2380 0.0451  -0.0346 0.1094  481 GLN A NE2 
+3647 N  N   . LEU A 460 ? 0.3594 0.2679 0.1256 -0.1532 0.0091  -0.0242 482 LEU A N   
+3648 C  CA  . LEU A 460 ? 0.3805 0.2607 0.1310 -0.1052 -0.0007 -0.0186 482 LEU A CA  
+3649 C  C   . LEU A 460 ? 0.3393 0.2181 0.1490 -0.1549 0.0174  -0.0173 482 LEU A C   
+3650 O  O   . LEU A 460 ? 0.3226 0.3008 0.1747 -0.1025 0.0155  -0.0237 482 LEU A O   
+3651 C  CB  . LEU A 460 ? 0.3630 0.2507 0.1297 -0.1426 -0.0120 -0.0049 482 LEU A CB  
+3652 C  CG  . LEU A 460 ? 0.3647 0.2541 0.1508 -0.1628 0.0263  0.0087  482 LEU A CG  
+3653 C  CD1 . LEU A 460 ? 0.4148 0.2910 0.1532 -0.1123 0.0231  0.0054  482 LEU A CD1 
+3654 C  CD2 . LEU A 460 ? 0.3299 0.3194 0.1824 -0.1855 0.0010  0.0330  482 LEU A CD2 
+3655 N  N   . PHE A 461 ? 0.3799 0.2583 0.1464 -0.1732 0.0193  -0.0290 483 PHE A N   
+3656 C  CA  . PHE A 461 ? 0.4043 0.2420 0.1391 -0.1100 0.0312  -0.0287 483 PHE A CA  
+3657 C  C   . PHE A 461 ? 0.4139 0.3226 0.1446 -0.1037 0.0309  -0.0178 483 PHE A C   
+3658 O  O   . PHE A 461 ? 0.4183 0.3025 0.1463 -0.1636 0.0089  -0.0351 483 PHE A O   
+3659 C  CB  . PHE A 461 ? 0.4395 0.2225 0.1442 -0.1645 0.0402  -0.0205 483 PHE A CB  
+3660 C  CG  . PHE A 461 ? 0.4738 0.2064 0.1534 -0.1278 0.0409  -0.0352 483 PHE A CG  
+3661 C  CD1 . PHE A 461 ? 0.5109 0.2953 0.1581 -0.1143 0.0383  -0.0493 483 PHE A CD1 
+3662 C  CD2 . PHE A 461 ? 0.5225 0.2065 0.1535 -0.1172 0.0378  -0.0271 483 PHE A CD2 
+3663 C  CE1 . PHE A 461 ? 0.5187 0.2471 0.1639 -0.1227 0.0376  -0.0453 483 PHE A CE1 
+3664 C  CE2 . PHE A 461 ? 0.5107 0.2126 0.1568 -0.1555 0.0425  -0.0203 483 PHE A CE2 
+3665 C  CZ  . PHE A 461 ? 0.5117 0.2104 0.1563 -0.1480 0.0434  -0.0239 483 PHE A CZ  
+3666 N  N   . TYR A 462 ? 0.4004 0.2587 0.1409 -0.0931 0.0542  -0.0077 484 TYR A N   
+3667 C  CA  . TYR A 462 ? 0.4442 0.2728 0.1565 -0.1440 0.0657  -0.0099 484 TYR A CA  
+3668 C  C   . TYR A 462 ? 0.4807 0.2742 0.1570 -0.1531 0.0603  -0.0159 484 TYR A C   
+3669 O  O   . TYR A 462 ? 0.4894 0.2592 0.1620 -0.1524 0.0699  -0.0178 484 TYR A O   
+3670 C  CB  . TYR A 462 ? 0.4875 0.2550 0.1869 -0.1503 0.0856  -0.0067 484 TYR A CB  
+3671 C  CG  . TYR A 462 ? 0.5018 0.2436 0.2291 -0.1655 0.0964  -0.0192 484 TYR A CG  
+3672 C  CD1 . TYR A 462 ? 0.5684 0.2341 0.2560 -0.1289 0.0986  -0.0411 484 TYR A CD1 
+3673 C  CD2 . TYR A 462 ? 0.5191 0.2551 0.2513 -0.1857 0.0788  -0.0315 484 TYR A CD2 
+3674 C  CE1 . TYR A 462 ? 0.5276 0.2414 0.2759 -0.1599 0.1229  -0.0237 484 TYR A CE1 
+3675 C  CE2 . TYR A 462 ? 0.5029 0.3098 0.2718 -0.2165 0.0861  -0.0364 484 TYR A CE2 
+3676 C  CZ  . TYR A 462 ? 0.5186 0.2967 0.2965 -0.1983 0.1053  -0.0548 484 TYR A CZ  
+3677 O  OH  . TYR A 462 ? 0.5453 0.3693 0.3281 -0.1677 0.1133  -0.0768 484 TYR A OH  
+3678 N  N   . GLY A 463 ? 0.5304 0.2868 0.1627 -0.1503 0.0605  -0.0257 485 GLY A N   
+3679 C  CA  . GLY A 463 ? 0.5618 0.2904 0.1768 -0.1572 0.0731  -0.0166 485 GLY A CA  
+3680 C  C   . GLY A 463 ? 0.5981 0.3017 0.1910 -0.0810 0.0964  -0.0186 485 GLY A C   
+3681 O  O   . GLY A 463 ? 0.5777 0.2514 0.1826 -0.1321 0.0935  -0.0250 485 GLY A O   
+3682 N  N   . GLN A 464 ? 0.5367 0.2641 0.2219 -0.1570 0.1119  -0.0121 486 GLN A N   
+3683 C  CA  . GLN A 464 ? 0.5777 0.2600 0.2418 -0.1764 0.1137  -0.0281 486 GLN A CA  
+3684 C  C   . GLN A 464 ? 0.5548 0.2746 0.2309 -0.1722 0.0906  -0.0399 486 GLN A C   
+3685 O  O   . GLN A 464 ? 0.5744 0.2854 0.2400 -0.1606 0.0933  -0.0461 486 GLN A O   
+3686 C  CB  . GLN A 464 ? 0.6858 0.2747 0.2689 -0.1440 0.1372  -0.0457 486 GLN A CB  
+3687 C  CG  . GLN A 464 ? 0.7742 0.3911 0.2950 -0.1122 0.1630  -0.0607 486 GLN A CG  
+3688 C  CD  . GLN A 464 ? 0.8560 0.4137 0.3183 -0.1330 0.1892  -0.0344 486 GLN A CD  
+3689 O  OE1 . GLN A 464 ? 0.8850 0.4142 0.3282 -0.1473 0.1989  -0.0263 486 GLN A OE1 
+3690 N  NE2 . GLN A 464 ? 0.8923 0.4828 0.3332 -0.1454 0.1873  -0.0236 486 GLN A NE2 
+3691 N  N   . ASP A 465 ? 0.5274 0.2521 0.2196 -0.1849 0.0744  -0.0373 487 ASP A N   
+3692 C  CA  . ASP A 465 ? 0.4984 0.2249 0.2023 -0.1631 0.0789  -0.0399 487 ASP A CA  
+3693 C  C   . ASP A 465 ? 0.4905 0.2087 0.1901 -0.1452 0.0446  -0.0378 487 ASP A C   
+3694 O  O   . ASP A 465 ? 0.4723 0.2265 0.1718 -0.1444 0.0226  -0.0014 487 ASP A O   
+3695 C  CB  . ASP A 465 ? 0.5098 0.2610 0.2132 -0.1462 0.0918  -0.0511 487 ASP A CB  
+3696 C  CG  . ASP A 465 ? 0.5259 0.2668 0.2364 -0.1260 0.0929  -0.0308 487 ASP A CG  
+3697 O  OD1 . ASP A 465 ? 0.5458 0.2765 0.2461 -0.1227 0.0545  -0.0692 487 ASP A OD1 
+3698 O  OD2 . ASP A 465 ? 0.5155 0.3547 0.2530 -0.1084 0.1069  -0.0200 487 ASP A OD2 
+3699 N  N   . ASN A 466 ? 0.4673 0.2378 0.1938 -0.1632 0.0533  -0.0519 488 ASN A N   
+3700 C  CA  . ASN A 466 ? 0.4389 0.2204 0.1909 -0.1428 0.0691  -0.0616 488 ASN A CA  
+3701 C  C   . ASN A 466 ? 0.4296 0.2567 0.2063 -0.1056 0.0696  -0.0591 488 ASN A C   
+3702 O  O   . ASN A 466 ? 0.4479 0.2486 0.1923 -0.1718 0.0593  -0.0322 488 ASN A O   
+3703 C  CB  . ASN A 466 ? 0.4255 0.2558 0.1840 -0.1254 0.0698  -0.0420 488 ASN A CB  
+3704 C  CG  . ASN A 466 ? 0.4668 0.2722 0.1981 -0.1549 0.0566  -0.0062 488 ASN A CG  
+3705 O  OD1 . ASN A 466 ? 0.4937 0.2314 0.2028 -0.1583 0.0341  0.0038  488 ASN A OD1 
+3706 N  ND2 . ASN A 466 ? 0.4582 0.2613 0.2109 -0.1764 0.0415  0.0013  488 ASN A ND2 
+3707 N  N   . GLN A 467 ? 0.4579 0.2599 0.2389 -0.1331 0.0691  -0.0326 489 GLN A N   
+3708 C  CA  . GLN A 467 ? 0.5132 0.3158 0.2747 -0.1364 0.0251  -0.0610 489 GLN A CA  
+3709 C  C   . GLN A 467 ? 0.5229 0.3487 0.2823 -0.1377 0.0074  -0.0661 489 GLN A C   
+3710 O  O   . GLN A 467 ? 0.5738 0.3581 0.3006 -0.1427 -0.0224 -0.0688 489 GLN A O   
+3711 C  CB  . GLN A 467 ? 0.5860 0.3140 0.3043 -0.1448 -0.0122 -0.0541 489 GLN A CB  
+3712 C  CG  . GLN A 467 ? 0.6648 0.2633 0.3264 -0.1527 -0.0411 -0.0589 489 GLN A CG  
+3713 C  CD  . GLN A 467 ? 0.7477 0.3014 0.3306 -0.1157 -0.0796 -0.0411 489 GLN A CD  
+3714 O  OE1 . GLN A 467 ? 0.7838 0.3538 0.3494 -0.0816 -0.0891 -0.0148 489 GLN A OE1 
+3715 N  NE2 . GLN A 467 ? 0.7671 0.3491 0.3245 -0.0694 -0.0830 -0.0140 489 GLN A NE2 
+3716 N  N   . GLN A 468 ? 0.4756 0.3255 0.2715 -0.1578 0.0267  -0.0669 490 GLN A N   
+3717 C  CA  A GLN A 468 ? 0.4674 0.3159 0.2674 -0.1502 0.0470  -0.0510 490 GLN A CA  
+3718 C  CA  B GLN A 468 ? 0.4638 0.2714 0.2685 -0.1840 0.0494  -0.0512 490 GLN A CA  
+3719 C  C   . GLN A 468 ? 0.4436 0.2954 0.2582 -0.1622 0.0422  -0.0635 490 GLN A C   
+3720 O  O   . GLN A 468 ? 0.4021 0.2910 0.2532 -0.1729 0.0386  -0.0666 490 GLN A O   
+3721 C  CB  A GLN A 468 ? 0.4767 0.3704 0.2709 -0.1266 0.0605  -0.0417 490 GLN A CB  
+3722 C  CB  B GLN A 468 ? 0.4647 0.2855 0.2732 -0.2018 0.0587  -0.0505 490 GLN A CB  
+3723 C  CG  A GLN A 468 ? 0.4978 0.4368 0.2772 -0.0752 0.0648  -0.0379 490 GLN A CG  
+3724 C  CG  B GLN A 468 ? 0.4894 0.3409 0.2826 -0.1953 0.0609  -0.0622 490 GLN A CG  
+3725 C  CD  A GLN A 468 ? 0.5065 0.5066 0.2858 -0.0048 0.0718  -0.0251 490 GLN A CD  
+3726 C  CD  B GLN A 468 ? 0.5157 0.3971 0.2975 -0.1446 0.0684  -0.0575 490 GLN A CD  
+3727 O  OE1 A GLN A 468 ? 0.5156 0.5502 0.2943 0.0042  0.0702  -0.0178 490 GLN A OE1 
+3728 O  OE1 B GLN A 468 ? 0.5207 0.4569 0.3027 -0.1297 0.0680  -0.0607 490 GLN A OE1 
+3729 N  NE2 A GLN A 468 ? 0.5271 0.5403 0.2928 0.0617  0.0717  -0.0283 490 GLN A NE2 
+3730 N  NE2 B GLN A 468 ? 0.5288 0.4800 0.3059 -0.1140 0.0775  -0.0284 490 GLN A NE2 
+3731 N  N   . ASN A 469 ? 0.4399 0.2764 0.2490 -0.1479 0.0730  -0.0681 491 ASN A N   
+3732 C  CA  A ASN A 469 ? 0.4392 0.2938 0.2423 -0.1855 0.0921  -0.0380 491 ASN A CA  
+3733 C  CA  B ASN A 469 ? 0.4342 0.2961 0.2357 -0.1839 0.0810  -0.0464 491 ASN A CA  
+3734 C  C   . ASN A 469 ? 0.4120 0.2628 0.2314 -0.1748 0.0806  -0.0183 491 ASN A C   
+3735 O  O   . ASN A 469 ? 0.4476 0.3165 0.2445 -0.1802 0.0595  -0.0324 491 ASN A O   
+3736 C  CB  A ASN A 469 ? 0.4813 0.3668 0.2477 -0.1532 0.1128  -0.0180 491 ASN A CB  
+3737 C  CB  B ASN A 469 ? 0.4615 0.3738 0.2269 -0.1508 0.0801  -0.0411 491 ASN A CB  
+3738 C  CG  A ASN A 469 ? 0.4954 0.4468 0.2589 -0.1375 0.1114  -0.0114 491 ASN A CG  
+3739 C  CG  B ASN A 469 ? 0.4598 0.4266 0.2238 -0.1679 0.0604  -0.0437 491 ASN A CG  
+3740 O  OD1 A ASN A 469 ? 0.5185 0.5457 0.2684 -0.1433 0.1114  0.0223  491 ASN A OD1 
+3741 O  OD1 B ASN A 469 ? 0.4941 0.5485 0.2298 -0.1114 0.0557  0.0007  491 ASN A OD1 
+3742 N  ND2 A ASN A 469 ? 0.5014 0.4466 0.2592 -0.1223 0.1175  -0.0164 491 ASN A ND2 
+3743 N  ND2 B ASN A 469 ? 0.3993 0.4021 0.2169 -0.2091 0.0610  -0.0775 491 ASN A ND2 
+3744 N  N   . MET A 470 ? 0.4483 0.2365 0.2038 -0.1436 0.0641  -0.0305 492 MET A N   
+3745 C  CA  . MET A 470 ? 0.4044 0.2495 0.1897 -0.1772 0.0583  -0.0350 492 MET A CA  
+3746 C  C   . MET A 470 ? 0.3669 0.2901 0.1761 -0.1884 0.0598  -0.0375 492 MET A C   
+3747 O  O   . MET A 470 ? 0.4034 0.3001 0.1608 -0.1826 0.0378  -0.0314 492 MET A O   
+3748 C  CB  . MET A 470 ? 0.4386 0.2724 0.1952 -0.1680 0.0404  -0.0308 492 MET A CB  
+3749 C  CG  . MET A 470 ? 0.4754 0.3159 0.1914 -0.1548 0.0018  -0.0153 492 MET A CG  
+3750 S  SD  . MET A 470 ? 0.5108 0.3799 0.2010 -0.2196 0.0141  0.0195  492 MET A SD  
+3751 C  CE  . MET A 470 ? 0.5456 0.3550 0.2150 -0.1728 0.0122  0.0019  492 MET A CE  
+3752 N  N   . THR A 471 ? 0.3373 0.2983 0.1775 -0.1525 0.0485  -0.0701 493 THR A N   
+3753 C  CA  . THR A 471 ? 0.3422 0.2726 0.1915 -0.1677 0.0406  -0.0424 493 THR A CA  
+3754 C  C   . THR A 471 ? 0.3772 0.2794 0.1894 -0.1484 0.0439  -0.0454 493 THR A C   
+3755 O  O   . THR A 471 ? 0.4037 0.3181 0.2052 -0.1581 0.0332  -0.0863 493 THR A O   
+3756 C  CB  . THR A 471 ? 0.4399 0.3542 0.2252 -0.0036 0.0270  -0.0480 493 THR A CB  
+3757 O  OG1 . THR A 471 ? 0.4726 0.4205 0.2478 -0.0138 -0.0130 -0.0582 493 THR A OG1 
+3758 C  CG2 . THR A 471 ? 0.4634 0.2635 0.2412 -0.1028 0.0634  -0.0217 493 THR A CG2 
+3759 N  N   . ASP A 472 ? 0.3775 0.2438 0.1701 -0.1394 0.0481  -0.0660 494 ASP A N   
+3760 C  CA  . ASP A 472 ? 0.4608 0.2764 0.1755 -0.1634 0.0666  -0.0369 494 ASP A CA  
+3761 C  C   . ASP A 472 ? 0.4309 0.3485 0.1580 -0.1502 0.0586  -0.0336 494 ASP A C   
+3762 O  O   . ASP A 472 ? 0.4612 0.3918 0.1626 -0.1685 0.0469  -0.0480 494 ASP A O   
+3763 C  CB  . ASP A 472 ? 0.6350 0.3065 0.2120 -0.1213 0.0729  -0.0385 494 ASP A CB  
+3764 C  CG  . ASP A 472 ? 0.8060 0.4747 0.2490 -0.0910 0.0721  0.0132  494 ASP A CG  
+3765 O  OD1 . ASP A 472 ? 0.8158 0.3972 0.2730 -0.2105 0.1020  0.0063  494 ASP A OD1 
+3766 O  OD2 . ASP A 472 ? 0.9506 0.5688 0.2711 0.0680  0.0621  0.0442  494 ASP A OD2 
+3767 N  N   . LYS A 473 ? 0.3510 0.2931 0.1590 -0.1458 0.0503  -0.0454 495 LYS A N   
+3768 C  CA  . LYS A 473 ? 0.3607 0.3171 0.1720 -0.1340 0.0507  -0.0131 495 LYS A CA  
+3769 C  C   . LYS A 473 ? 0.3660 0.3546 0.1708 -0.0895 0.0434  -0.0074 495 LYS A C   
+3770 O  O   . LYS A 473 ? 0.3758 0.3845 0.1896 -0.0905 0.0658  0.0009  495 LYS A O   
+3771 C  CB  . LYS A 473 ? 0.4508 0.4441 0.1957 -0.0084 0.0536  -0.0158 495 LYS A CB  
+3772 C  CG  . LYS A 473 ? 0.5789 0.5215 0.2277 0.0553  0.0259  -0.0115 495 LYS A CG  
+3773 C  CD  . LYS A 473 ? 0.6851 0.6528 0.2512 0.1543  0.0083  -0.0124 495 LYS A CD  
+3774 C  CE  . LYS A 473 ? 0.7380 0.7578 0.2691 0.1790  -0.0025 -0.0053 495 LYS A CE  
+3775 N  NZ  . LYS A 473 ? 0.7538 0.8309 0.2844 0.1753  -0.0183 0.0001  495 LYS A NZ  
+3776 N  N   . ARG A 474 ? 0.3519 0.2601 0.1559 -0.1045 0.0197  -0.0168 496 ARG A N   
+3777 C  CA  . ARG A 474 ? 0.3619 0.2681 0.1489 -0.0707 0.0301  0.0101  496 ARG A CA  
+3778 C  C   . ARG A 474 ? 0.3564 0.2816 0.1440 -0.0405 0.0286  0.0172  496 ARG A C   
+3779 O  O   . ARG A 474 ? 0.4024 0.2221 0.1356 -0.0682 0.0477  0.0156  496 ARG A O   
+3780 C  CB  . ARG A 474 ? 0.4046 0.2921 0.1648 -0.0469 0.0307  0.0263  496 ARG A CB  
+3781 C  CG  . ARG A 474 ? 0.4176 0.3277 0.1786 -0.0261 0.0154  0.0241  496 ARG A CG  
+3782 C  CD  . ARG A 474 ? 0.3901 0.2829 0.1763 -0.0561 0.0050  0.0344  496 ARG A CD  
+3783 N  NE  . ARG A 474 ? 0.3876 0.2647 0.1886 -0.1218 0.0065  0.0468  496 ARG A NE  
+3784 C  CZ  . ARG A 474 ? 0.3583 0.2917 0.2137 -0.0742 -0.0101 0.0363  496 ARG A CZ  
+3785 N  NH1 . ARG A 474 ? 0.3433 0.2406 0.2092 -0.0966 -0.0242 0.0530  496 ARG A NH1 
+3786 N  NH2 . ARG A 474 ? 0.3766 0.3760 0.2352 -0.0220 -0.0052 0.0184  496 ARG A NH2 
+3787 N  N   . ILE A 475 ? 0.3647 0.2416 0.1449 -0.0838 0.0176  0.0106  497 ILE A N   
+3788 C  CA  . ILE A 475 ? 0.3556 0.2703 0.1585 -0.0809 -0.0190 -0.0213 497 ILE A CA  
+3789 C  C   . ILE A 475 ? 0.3524 0.2490 0.1525 -0.0925 0.0104  -0.0048 497 ILE A C   
+3790 O  O   . ILE A 475 ? 0.3628 0.2796 0.1649 -0.0687 0.0414  0.0232  497 ILE A O   
+3791 C  CB  . ILE A 475 ? 0.3538 0.3454 0.1804 -0.1210 -0.0483 -0.0337 497 ILE A CB  
+3792 C  CG1 . ILE A 475 ? 0.4343 0.4127 0.2077 -0.0903 -0.0753 -0.0155 497 ILE A CG1 
+3793 C  CG2 . ILE A 475 ? 0.3823 0.3375 0.1810 -0.0851 -0.0440 -0.0095 497 ILE A CG2 
+3794 C  CD1 . ILE A 475 ? 0.5052 0.5538 0.2299 0.0212  -0.0756 -0.0185 497 ILE A CD1 
+3795 N  N   . VAL A 476 ? 0.2973 0.2203 0.1395 -0.1085 0.0166  0.0110  498 VAL A N   
+3796 C  CA  . VAL A 476 ? 0.3259 0.2920 0.1416 -0.1408 0.0071  0.0118  498 VAL A CA  
+3797 C  C   . VAL A 476 ? 0.3710 0.2766 0.1389 -0.0863 0.0000  0.0042  498 VAL A C   
+3798 O  O   . VAL A 476 ? 0.3541 0.1985 0.1488 -0.0477 0.0148  -0.0057 498 VAL A O   
+3799 C  CB  . VAL A 476 ? 0.2937 0.3420 0.1444 -0.1242 0.0072  0.0060  498 VAL A CB  
+3800 C  CG1 . VAL A 476 ? 0.3446 0.3068 0.1528 -0.1028 0.0179  0.0307  498 VAL A CG1 
+3801 C  CG2 . VAL A 476 ? 0.2810 0.3842 0.1396 -0.1543 -0.0093 0.0081  498 VAL A CG2 
+3802 N  N   . THR A 477 ? 0.3925 0.2572 0.1304 -0.0948 -0.0191 -0.0117 499 THR A N   
+3803 C  CA  . THR A 477 ? 0.4010 0.2420 0.1432 -0.0540 -0.0064 -0.0016 499 THR A CA  
+3804 C  C   . THR A 477 ? 0.3990 0.2231 0.1527 -0.0411 -0.0138 0.0111  499 THR A C   
+3805 O  O   . THR A 477 ? 0.4426 0.2892 0.1662 0.0015  0.0053  0.0595  499 THR A O   
+3806 C  CB  . THR A 477 ? 0.3598 0.2597 0.1545 -0.0838 0.0066  -0.0309 499 THR A CB  
+3807 O  OG1 . THR A 477 ? 0.3466 0.2766 0.1614 -0.0567 0.0246  -0.0229 499 THR A OG1 
+3808 C  CG2 . THR A 477 ? 0.4122 0.2889 0.1569 -0.0534 0.0191  -0.0242 499 THR A CG2 
+3809 N  N   . VAL A 478 ? 0.3498 0.2147 0.1583 0.0068  0.0001  0.0307  500 VAL A N   
+3810 C  CA  . VAL A 478 ? 0.3532 0.2263 0.1687 -0.0040 0.0080  -0.0178 500 VAL A CA  
+3811 C  C   . VAL A 478 ? 0.3721 0.2605 0.1845 0.0190  0.0081  -0.0152 500 VAL A C   
+3812 O  O   . VAL A 478 ? 0.3423 0.2051 0.1676 0.0175  0.0160  0.0129  500 VAL A O   
+3813 C  CB  . VAL A 478 ? 0.3393 0.2190 0.1716 0.0055  0.0152  -0.0063 500 VAL A CB  
+3814 C  CG1 . VAL A 478 ? 0.3524 0.2368 0.1802 0.0091  0.0180  -0.0138 500 VAL A CG1 
+3815 C  CG2 . VAL A 478 ? 0.3003 0.2146 0.1780 -0.0222 -0.0015 -0.0058 500 VAL A CG2 
+3816 N  N   . VAL A 479 ? 0.4270 0.2592 0.2086 0.0617  0.0223  -0.0058 501 VAL A N   
+3817 C  CA  . VAL A 479 ? 0.4653 0.2394 0.2334 -0.0147 0.0142  -0.0144 501 VAL A CA  
+3818 C  C   . VAL A 479 ? 0.4546 0.2602 0.2439 0.0249  0.0236  -0.0336 501 VAL A C   
+3819 O  O   . VAL A 479 ? 0.4243 0.3489 0.2465 0.0324  0.0439  -0.0319 501 VAL A O   
+3820 C  CB  . VAL A 479 ? 0.5481 0.3032 0.2546 0.0142  0.0070  -0.0110 501 VAL A CB  
+3821 C  CG1 . VAL A 479 ? 0.5703 0.3492 0.2629 -0.0103 0.0130  -0.0202 501 VAL A CG1 
+3822 C  CG2 . VAL A 479 ? 0.5635 0.2099 0.2659 0.0355  0.0065  0.0090  501 VAL A CG2 
+3823 N  N   . THR A 480 ? 0.4655 0.2957 0.2577 0.0103  0.0403  -0.0453 502 THR A N   
+3824 C  CA  . THR A 480 ? 0.5897 0.4101 0.2892 0.0633  0.0680  -0.0744 502 THR A CA  
+3825 C  C   . THR A 480 ? 0.6310 0.4949 0.3369 0.1035  0.0616  -0.0822 502 THR A C   
+3826 O  O   . THR A 480 ? 0.6011 0.4556 0.3425 0.0972  0.0788  -0.0589 502 THR A O   
+3827 C  CB  . THR A 480 ? 0.6525 0.5491 0.2869 0.1014  0.1164  -0.0722 502 THR A CB  
+3828 O  OG1 . THR A 480 ? 0.7054 0.6371 0.2931 0.1599  0.1365  -0.0537 502 THR A OG1 
+3829 C  CG2 . THR A 480 ? 0.6683 0.5477 0.2824 0.0796  0.1162  -0.0833 502 THR A CG2 
+3830 N  N   . ASP A 481 ? 0.7217 0.6025 0.3836 0.1436  0.0370  -0.1046 503 ASP A N   
+3831 C  CA  . ASP A 481 ? 0.7950 0.7009 0.4254 0.1661  0.0162  -0.1237 503 ASP A CA  
+3832 C  C   . ASP A 481 ? 0.8353 0.6915 0.4497 0.1936  0.0086  -0.1396 503 ASP A C   
+3833 O  O   . ASP A 481 ? 0.8280 0.7564 0.4631 0.2174  -0.0039 -0.1209 503 ASP A O   
+3834 C  CB  . ASP A 481 ? 0.8413 0.7986 0.4394 0.1837  0.0001  -0.1314 503 ASP A CB  
+3835 C  CG  . ASP A 481 ? 0.8939 0.8855 0.4523 0.1786  -0.0183 -0.1369 503 ASP A CG  
+3836 O  OD1 . ASP A 481 ? 0.9154 0.9030 0.4552 0.1697  -0.0129 -0.1217 503 ASP A OD1 
+3837 O  OD2 . ASP A 481 ? 0.9246 0.9345 0.4619 0.1950  -0.0269 -0.1454 503 ASP A OD2 
+3838 N  N   . ALA A 482 ? 0.8715 0.6397 0.4588 0.1859  0.0177  -0.1662 504 ALA A N   
+3839 C  CA  . ALA A 482 ? 0.8961 0.6406 0.4707 0.1889  0.0250  -0.1713 504 ALA A CA  
+3840 C  C   . ALA A 482 ? 0.9319 0.6087 0.4812 0.2202  0.0293  -0.1834 504 ALA A C   
+3841 O  O   . ALA A 482 ? 0.9466 0.5506 0.4816 0.2053  0.0315  -0.1966 504 ALA A O   
+3842 C  CB  . ALA A 482 ? 0.8919 0.6689 0.4690 0.1732  0.0293  -0.1662 504 ALA A CB  
+3843 N  N   . VAL A 483 ? 0.9459 0.6195 0.4920 0.2655  0.0212  -0.1623 505 VAL A N   
+3844 C  CA  . VAL A 483 ? 0.9593 0.6285 0.5007 0.2832  0.0162  -0.1363 505 VAL A CA  
+3845 C  C   . VAL A 483 ? 0.9542 0.6091 0.5053 0.2432  0.0247  -0.0996 505 VAL A C   
+3846 O  O   . VAL A 483 ? 0.9774 0.6690 0.5028 0.2287  0.0150  -0.1084 505 VAL A O   
+3847 C  CB  . VAL A 483 ? 0.9889 0.6892 0.5064 0.3395  0.0103  -0.1352 505 VAL A CB  
+3848 C  CG1 . VAL A 483 ? 0.9971 0.6943 0.5101 0.3619  -0.0024 -0.1352 505 VAL A CG1 
+3849 C  CG2 . VAL A 483 ? 1.0175 0.7319 0.5109 0.3336  0.0039  -0.1309 505 VAL A CG2 
+3850 N  N   . SER A 484 ? 0.9250 0.5444 0.5090 0.2051  0.0381  -0.0550 506 SER A N   
+3851 C  CA  . SER A 484 ? 0.8815 0.5313 0.5063 0.1645  0.0515  -0.0116 506 SER A CA  
+3852 C  C   . SER A 484 ? 0.8138 0.4404 0.4940 0.1113  0.0678  0.0046  506 SER A C   
+3853 O  O   . SER A 484 ? 0.8120 0.3523 0.4914 0.1231  0.0516  0.0067  506 SER A O   
+3854 C  CB  . SER A 484 ? 0.8970 0.6196 0.5161 0.1641  0.0448  -0.0042 506 SER A CB  
+3855 O  OG  . SER A 484 ? 0.9056 0.7040 0.5238 0.1440  0.0379  -0.0005 506 SER A OG  
+3856 N  N   . ASP A 485 ? 0.7606 0.4401 0.4829 0.0997  0.0962  0.0318  507 ASP A N   
+3857 C  CA  . ASP A 485 ? 0.7284 0.4711 0.4783 0.1223  0.1187  0.0508  507 ASP A CA  
+3858 C  C   . ASP A 485 ? 0.6740 0.4197 0.4667 0.1263  0.1381  0.0498  507 ASP A C   
+3859 O  O   . ASP A 485 ? 0.6473 0.4390 0.4661 0.1538  0.1399  0.0592  507 ASP A O   
+3860 C  CB  . ASP A 485 ? 0.7324 0.5654 0.4889 0.1189  0.1192  0.0553  507 ASP A CB  
+3861 C  CG  . ASP A 485 ? 0.7601 0.6604 0.5005 0.0999  0.1155  0.0565  507 ASP A CG  
+3862 O  OD1 . ASP A 485 ? 0.7510 0.7098 0.5076 0.0822  0.1191  0.0597  507 ASP A OD1 
+3863 O  OD2 . ASP A 485 ? 0.7773 0.6702 0.5039 0.0606  0.1107  0.0664  507 ASP A OD2 
+3864 N  N   . ASP A 486 ? 0.6613 0.3552 0.4525 0.1112  0.1505  0.0377  508 ASP A N   
+3865 C  CA  . ASP A 486 ? 0.7043 0.3289 0.4408 0.0916  0.1426  0.0437  508 ASP A CA  
+3866 C  C   . ASP A 486 ? 0.6367 0.2553 0.4134 0.0243  0.1475  0.0555  508 ASP A C   
+3867 O  O   . ASP A 486 ? 0.5777 0.2512 0.4020 0.0043  0.1626  0.0573  508 ASP A O   
+3868 C  CB  . ASP A 486 ? 0.8078 0.4433 0.4504 0.0599  0.1366  0.0349  508 ASP A CB  
+3869 C  CG  . ASP A 486 ? 0.8605 0.5717 0.4554 0.0248  0.1265  0.0121  508 ASP A CG  
+3870 O  OD1 . ASP A 486 ? 0.9459 0.7123 0.4609 0.0873  0.0899  -0.0095 508 ASP A OD1 
+3871 O  OD2 . ASP A 486 ? 0.8233 0.5206 0.4559 -0.1609 0.1468  0.0298  508 ASP A OD2 
+3872 N  N   . ASP A 487 ? 0.6097 0.2460 0.3929 0.0264  0.1452  0.0809  509 ASP A N   
+3873 C  CA  . ASP A 487 ? 0.5992 0.2642 0.3717 -0.0404 0.1396  0.0776  509 ASP A CA  
+3874 C  C   . ASP A 487 ? 0.5808 0.2018 0.3554 -0.0167 0.1349  0.0428  509 ASP A C   
+3875 O  O   . ASP A 487 ? 0.5756 0.2077 0.3551 -0.0186 0.1374  0.0483  509 ASP A O   
+3876 C  CB  . ASP A 487 ? 0.6499 0.3391 0.3700 -0.0476 0.1161  0.0522  509 ASP A CB  
+3877 C  CG  . ASP A 487 ? 0.7518 0.4322 0.3806 0.0135  0.1026  0.0496  509 ASP A CG  
+3878 O  OD1 . ASP A 487 ? 0.7814 0.4462 0.3873 0.0236  0.0831  0.0197  509 ASP A OD1 
+3879 O  OD2 . ASP A 487 ? 0.8308 0.5642 0.3915 0.0735  0.0850  0.0009  509 ASP A OD2 
+3880 N  N   . TRP A 488 ? 0.5860 0.1611 0.3396 0.0058  0.1168  0.0220  510 TRP A N   
+3881 C  CA  . TRP A 488 ? 0.5691 0.1789 0.3321 -0.0752 0.1149  0.0148  510 TRP A CA  
+3882 C  C   . TRP A 488 ? 0.5588 0.1990 0.3344 -0.0905 0.1279  0.0251  510 TRP A C   
+3883 O  O   . TRP A 488 ? 0.6113 0.2552 0.3201 0.0199  0.1342  0.0417  510 TRP A O   
+3884 C  CB  . TRP A 488 ? 0.5563 0.2146 0.3230 -0.0719 0.1129  0.0029  510 TRP A CB  
+3885 C  CG  . TRP A 488 ? 0.5760 0.1870 0.3202 -0.0723 0.1221  0.0074  510 TRP A CG  
+3886 C  CD1 . TRP A 488 ? 0.5735 0.2091 0.3157 -0.0962 0.1388  0.0018  510 TRP A CD1 
+3887 C  CD2 . TRP A 488 ? 0.5498 0.2161 0.3225 -0.1158 0.1230  0.0186  510 TRP A CD2 
+3888 N  NE1 . TRP A 488 ? 0.5817 0.1949 0.3146 -0.0591 0.1412  -0.0070 510 TRP A NE1 
+3889 C  CE2 . TRP A 488 ? 0.5512 0.2029 0.3230 -0.1014 0.1116  0.0285  510 TRP A CE2 
+3890 C  CE3 . TRP A 488 ? 0.5432 0.2137 0.3322 -0.1360 0.0988  0.0058  510 TRP A CE3 
+3891 C  CZ2 . TRP A 488 ? 0.5054 0.2267 0.3265 -0.1388 0.0953  0.0267  510 TRP A CZ2 
+3892 C  CZ3 . TRP A 488 ? 0.5118 0.2157 0.3326 -0.1459 0.0853  0.0026  510 TRP A CZ3 
+3893 C  CH2 . TRP A 488 ? 0.5530 0.2393 0.3301 -0.1181 0.0922  0.0223  510 TRP A CH2 
+3894 N  N   . GLN A 489 ? 0.6005 0.2040 0.3487 -0.0522 0.1410  0.0485  511 GLN A N   
+3895 C  CA  . GLN A 489 ? 0.6645 0.2279 0.3684 -0.0679 0.1151  0.0665  511 GLN A CA  
+3896 C  C   . GLN A 489 ? 0.6847 0.2265 0.3541 -0.0649 0.1145  0.0590  511 GLN A C   
+3897 O  O   . GLN A 489 ? 0.7148 0.2225 0.3444 -0.0666 0.1419  0.0319  511 GLN A O   
+3898 C  CB  . GLN A 489 ? 0.7683 0.3086 0.3956 -0.0027 0.0924  0.0812  511 GLN A CB  
+3899 C  CG  . GLN A 489 ? 0.8673 0.4008 0.4198 0.0192  0.0591  0.0958  511 GLN A CG  
+3900 C  CD  . GLN A 489 ? 0.9700 0.5227 0.4409 0.0801  0.0253  0.0940  511 GLN A CD  
+3901 O  OE1 . GLN A 489 ? 1.0252 0.5644 0.4531 0.0943  0.0139  0.0994  511 GLN A OE1 
+3902 N  NE2 . GLN A 489 ? 1.0186 0.5594 0.4482 0.1307  0.0150  0.0859  511 GLN A NE2 
+3903 N  N   . VAL A 490 ? 0.6282 0.2491 0.3530 -0.1061 0.1047  0.0693  512 VAL A N   
+3904 C  CA  . VAL A 490 ? 0.6810 0.2482 0.3648 -0.1282 0.0980  0.0461  512 VAL A CA  
+3905 C  C   . VAL A 490 ? 0.7480 0.2494 0.3812 -0.1006 0.0908  0.0218  512 VAL A C   
+3906 O  O   . VAL A 490 ? 0.7697 0.2162 0.3709 -0.0853 0.0698  0.0053  512 VAL A O   
+3907 C  CB  . VAL A 490 ? 0.6569 0.2689 0.3552 -0.1347 0.1002  0.0615  512 VAL A CB  
+3908 C  CG1 . VAL A 490 ? 0.6437 0.2668 0.3566 -0.1447 0.0926  0.0567  512 VAL A CG1 
+3909 C  CG2 . VAL A 490 ? 0.6736 0.2348 0.3475 -0.1008 0.0860  0.0579  512 VAL A CG2 
+3910 N  N   . GLY A 491 ? 0.7600 0.2141 0.4050 -0.0868 0.0971  0.0018  513 GLY A N   
+3911 C  CA  . GLY A 491 ? 0.7866 0.2122 0.4251 -0.0620 0.1066  -0.0105 513 GLY A CA  
+3912 C  C   . GLY A 491 ? 0.7933 0.2213 0.4406 -0.0802 0.1202  -0.0173 513 GLY A C   
+3913 O  O   . GLY A 491 ? 0.8390 0.2198 0.4527 -0.0206 0.1228  0.0041  513 GLY A O   
+3914 N  N   . SER A 492 ? 0.8891 0.2945 0.4491 -0.0092 0.1761  0.0024  514 SER A N   
+3915 C  CA  . SER A 492 ? 0.9140 0.2957 0.4512 0.0219  0.1979  -0.0199 514 SER A CA  
+3916 C  C   . SER A 492 ? 0.9032 0.2621 0.4532 -0.0147 0.2023  -0.0531 514 SER A C   
+3917 O  O   . SER A 492 ? 0.8979 0.2812 0.4524 -0.0525 0.1967  -0.0842 514 SER A O   
+3918 C  CB  . SER A 492 ? 0.9338 0.3126 0.4506 0.0463  0.2042  -0.0155 514 SER A CB  
+3919 O  OG  . SER A 492 ? 0.9586 0.3754 0.4532 0.1028  0.2167  0.0027  514 SER A OG  
+3920 N  N   . THR A 493 ? 0.9156 0.3328 0.4633 -0.0161 0.2185  -0.0607 515 THR A N   
+3921 C  CA  . THR A 493 ? 0.9003 0.2657 0.4720 -0.0319 0.2179  -0.0586 515 THR A CA  
+3922 C  C   . THR A 493 ? 0.9466 0.3086 0.4668 0.0047  0.2257  -0.0542 515 THR A C   
+3923 O  O   . THR A 493 ? 0.9738 0.3037 0.4691 0.0392  0.2314  -0.0544 515 THR A O   
+3924 C  CB  . THR A 493 ? 0.8945 0.2761 0.4915 -0.0575 0.2184  -0.0787 515 THR A CB  
+3925 O  OG1 . THR A 493 ? 0.8723 0.2584 0.4987 -0.0648 0.2184  -0.0556 515 THR A OG1 
+3926 C  CG2 . THR A 493 ? 0.8624 0.2747 0.4933 -0.0689 0.1826  -0.0966 515 THR A CG2 
+3927 N  N   . TYR A 494 ? 0.8991 0.2549 0.4456 -0.0632 0.2190  -0.0274 516 TYR A N   
+3928 C  CA  . TYR A 494 ? 0.9080 0.2636 0.4390 -0.0249 0.2279  -0.0449 516 TYR A CA  
+3929 C  C   . TYR A 494 ? 0.9443 0.3160 0.4454 0.0050  0.2425  -0.0719 516 TYR A C   
+3930 O  O   . TYR A 494 ? 0.9263 0.3211 0.4469 0.0005  0.2159  -0.0923 516 TYR A O   
+3931 C  CB  . TYR A 494 ? 0.8809 0.2749 0.4286 0.0027  0.2240  -0.0569 516 TYR A CB  
+3932 C  CG  . TYR A 494 ? 0.8234 0.2513 0.4175 -0.0581 0.2205  -0.0565 516 TYR A CG  
+3933 C  CD1 . TYR A 494 ? 0.7338 0.2424 0.4004 -0.1198 0.1991  -0.0304 516 TYR A CD1 
+3934 C  CD2 . TYR A 494 ? 0.7704 0.2516 0.4049 -0.1212 0.2176  -0.0413 516 TYR A CD2 
+3935 C  CE1 . TYR A 494 ? 0.7912 0.2813 0.4030 -0.0519 0.2398  -0.0169 516 TYR A CE1 
+3936 C  CE2 . TYR A 494 ? 0.7719 0.2304 0.3993 -0.0824 0.1927  -0.0413 516 TYR A CE2 
+3937 C  CZ  . TYR A 494 ? 0.8124 0.2610 0.4024 -0.0066 0.2202  -0.0194 516 TYR A CZ  
+3938 O  OH  . TYR A 494 ? 0.8305 0.2385 0.3918 0.0567  0.2174  0.0076  516 TYR A OH  
+3939 N  N   . VAL A 495 ? 0.9876 0.3752 0.4524 0.0265  0.2660  -0.0789 517 VAL A N   
+3940 C  CA  . VAL A 495 ? 0.9993 0.3853 0.4575 0.0160  0.2827  -0.0771 517 VAL A CA  
+3941 C  C   . VAL A 495 ? 0.9603 0.4116 0.4614 -0.0334 0.2959  -0.1017 517 VAL A C   
+3942 O  O   . VAL A 495 ? 0.9470 0.4561 0.4614 -0.0225 0.3170  -0.0885 517 VAL A O   
+3943 C  CB  . VAL A 495 ? 1.0574 0.4435 0.4558 0.0320  0.2888  -0.0603 517 VAL A CB  
+3944 C  CG1 . VAL A 495 ? 1.0761 0.4553 0.4589 -0.0042 0.2865  -0.0561 517 VAL A CG1 
+3945 C  CG2 . VAL A 495 ? 1.0643 0.4956 0.4552 0.0772  0.2873  -0.0587 517 VAL A CG2 
+3946 N  N   . LYS A 496 ? 0.9553 0.4821 0.4693 -0.0044 0.2771  -0.1357 518 LYS A N   
+3947 C  CA  . LYS A 496 ? 0.9192 0.5775 0.4724 -0.0257 0.2910  -0.1597 518 LYS A CA  
+3948 C  C   . LYS A 496 ? 0.8938 0.6003 0.4749 -0.0295 0.3201  -0.1293 518 LYS A C   
+3949 O  O   . LYS A 496 ? 0.8792 0.5883 0.4773 -0.0272 0.3270  -0.1173 518 LYS A O   
+3950 C  CB  . LYS A 496 ? 0.9291 0.6775 0.4819 0.0402  0.2728  -0.1894 518 LYS A CB  
+3951 C  CG  . LYS A 496 ? 0.9482 0.7411 0.4902 0.0754  0.2557  -0.2165 518 LYS A CG  
+3952 C  CD  . LYS A 496 ? 0.9765 0.8362 0.5013 0.1250  0.2401  -0.2428 518 LYS A CD  
+3953 C  CE  . LYS A 496 ? 1.0195 0.9015 0.5071 0.1534  0.2248  -0.2556 518 LYS A CE  
+3954 N  NZ  . LYS A 496 ? 1.0387 0.9377 0.5121 0.1773  0.2121  -0.2585 518 LYS A NZ  
+3955 N  N   . ASP A 497 ? 0.8798 0.5809 0.4800 -0.0345 0.3260  -0.1238 519 ASP A N   
+3956 C  CA  . ASP A 497 ? 0.8908 0.5865 0.4827 -0.0090 0.3347  -0.1028 519 ASP A CA  
+3957 C  C   . ASP A 497 ? 0.8660 0.4429 0.4810 -0.0216 0.3370  -0.0781 519 ASP A C   
+3958 O  O   . ASP A 497 ? 0.8930 0.5078 0.4804 0.0181  0.3426  -0.0583 519 ASP A O   
+3959 C  CB  . ASP A 497 ? 0.9194 0.7015 0.4908 0.0221  0.3370  -0.1138 519 ASP A CB  
+3960 C  CG  . ASP A 497 ? 0.9683 0.8371 0.5038 0.0889  0.3312  -0.1336 519 ASP A CG  
+3961 O  OD1 . ASP A 497 ? 0.9731 0.8885 0.5067 0.0934  0.3346  -0.1361 519 ASP A OD1 
+3962 O  OD2 . ASP A 497 ? 1.0318 0.8938 0.5103 0.1267  0.3202  -0.1478 519 ASP A OD2 
+3963 N  N   . ASP A 498 ? 0.7993 0.3101 0.4792 -0.0749 0.3437  -0.0593 520 ASP A N   
+3964 C  CA  . ASP A 498 ? 0.8557 0.3110 0.4691 -0.0639 0.3378  -0.0568 520 ASP A CA  
+3965 C  C   . ASP A 498 ? 0.8627 0.3307 0.4527 -0.0015 0.3098  -0.0525 520 ASP A C   
+3966 O  O   . ASP A 498 ? 0.8493 0.3484 0.4621 0.0460  0.2986  -0.0509 520 ASP A O   
+3967 C  CB  . ASP A 498 ? 0.8947 0.3134 0.4812 -0.0969 0.3421  -0.0719 520 ASP A CB  
+3968 C  CG  . ASP A 498 ? 0.9469 0.3533 0.4972 -0.0867 0.3291  -0.0832 520 ASP A CG  
+3969 O  OD1 . ASP A 498 ? 0.9545 0.3349 0.5101 -0.0762 0.3179  -0.0927 520 ASP A OD1 
+3970 O  OD2 . ASP A 498 ? 0.9199 0.3292 0.4913 -0.1700 0.3181  -0.0875 520 ASP A OD2 
+3971 N  N   . LYS A 499 ? 0.8667 0.3043 0.4333 0.0258  0.2894  -0.0274 521 LYS A N   
+3972 C  CA  . LYS A 499 ? 0.8566 0.2694 0.4170 0.0525  0.2578  -0.0139 521 LYS A CA  
+3973 C  C   . LYS A 499 ? 0.7889 0.2341 0.3905 0.0397  0.2453  0.0016  521 LYS A C   
+3974 O  O   . LYS A 499 ? 0.7900 0.2689 0.3918 -0.0220 0.2534  0.0167  521 LYS A O   
+3975 C  CB  . LYS A 499 ? 0.9209 0.3542 0.4276 0.1037  0.2635  0.0002  521 LYS A CB  
+3976 C  CG  . LYS A 499 ? 0.9810 0.4356 0.4374 0.1214  0.2638  -0.0076 521 LYS A CG  
+3977 C  CD  . LYS A 499 ? 1.0286 0.5801 0.4530 0.1551  0.2499  -0.0158 521 LYS A CD  
+3978 C  CE  . LYS A 499 ? 1.0624 0.6821 0.4635 0.1558  0.2390  -0.0075 521 LYS A CE  
+3979 N  NZ  . LYS A 499 ? 1.0848 0.7719 0.4677 0.1656  0.2330  -0.0027 521 LYS A NZ  
+3980 N  N   . VAL A 500 ? 0.7216 0.2170 0.3596 0.0467  0.1960  -0.0117 522 VAL A N   
+3981 C  CA  . VAL A 500 ? 0.6854 0.2058 0.3393 0.0116  0.1829  -0.0213 522 VAL A CA  
+3982 C  C   . VAL A 500 ? 0.6644 0.2058 0.3135 0.0141  0.1431  -0.0011 522 VAL A C   
+3983 O  O   . VAL A 500 ? 0.6707 0.2190 0.3007 0.0322  0.1311  0.0167  522 VAL A O   
+3984 C  CB  . VAL A 500 ? 0.6700 0.2012 0.3404 -0.0231 0.1825  -0.0183 522 VAL A CB  
+3985 C  CG1 . VAL A 500 ? 0.6804 0.2537 0.3480 -0.0583 0.1733  -0.0221 522 VAL A CG1 
+3986 C  CG2 . VAL A 500 ? 0.6999 0.1934 0.3362 0.0034  0.1792  -0.0001 522 VAL A CG2 
+3987 N  N   . THR A 501 ? 0.5596 0.2070 0.2948 -0.0352 0.1386  0.0150  523 THR A N   
+3988 C  CA  . THR A 501 ? 0.5365 0.2309 0.2896 -0.0765 0.0917  0.0079  523 THR A CA  
+3989 C  C   . THR A 501 ? 0.5223 0.1931 0.2684 -0.0845 0.0837  -0.0029 523 THR A C   
+3990 O  O   . THR A 501 ? 0.5480 0.1853 0.2765 -0.0142 0.0741  0.0041  523 THR A O   
+3991 C  CB  . THR A 501 ? 0.5325 0.3114 0.3053 -0.0893 0.0425  0.0078  523 THR A CB  
+3992 O  OG1 . THR A 501 ? 0.5683 0.5008 0.3228 -0.0507 -0.0003 -0.0169 523 THR A OG1 
+3993 C  CG2 . THR A 501 ? 0.4915 0.2587 0.3048 -0.0356 0.0385  -0.0197 523 THR A CG2 
+3994 N  N   . HIS A 502 ? 0.4818 0.2100 0.2441 -0.1169 0.0721  -0.0118 524 HIS A N   
+3995 C  CA  . HIS A 502 ? 0.4618 0.1748 0.2214 -0.0955 0.0434  -0.0165 524 HIS A CA  
+3996 C  C   . HIS A 502 ? 0.4346 0.1645 0.1876 -0.1109 0.0317  -0.0230 524 HIS A C   
+3997 O  O   . HIS A 502 ? 0.4408 0.1880 0.1698 -0.0689 0.0282  0.0006  524 HIS A O   
+3998 C  CB  . HIS A 502 ? 0.5070 0.2008 0.2278 -0.0539 0.0406  0.0067  524 HIS A CB  
+3999 C  CG  . HIS A 502 ? 0.4903 0.2018 0.2256 -0.0523 0.0438  0.0127  524 HIS A CG  
+4000 N  ND1 . HIS A 502 ? 0.5309 0.2063 0.2372 -0.0332 0.0239  0.0279  524 HIS A ND1 
+4001 C  CD2 . HIS A 502 ? 0.5172 0.2707 0.2296 -0.0589 0.0465  0.0030  524 HIS A CD2 
+4002 C  CE1 . HIS A 502 ? 0.5010 0.2096 0.2376 -0.0698 0.0338  0.0079  524 HIS A CE1 
+4003 N  NE2 . HIS A 502 ? 0.5088 0.2362 0.2381 -0.0962 0.0290  -0.0132 524 HIS A NE2 
+4004 N  N   . ASN A 503 ? 0.4036 0.2266 0.1695 -0.0560 0.0400  -0.0344 525 ASN A N   
+4005 C  CA  . ASN A 503 ? 0.3802 0.2254 0.1590 -0.0702 0.0238  -0.0452 525 ASN A CA  
+4006 C  C   . ASN A 503 ? 0.3439 0.1920 0.1644 -0.0689 0.0051  -0.0357 525 ASN A C   
+4007 O  O   . ASN A 503 ? 0.3291 0.2023 0.1755 -0.0456 0.0079  -0.0085 525 ASN A O   
+4008 C  CB  . ASN A 503 ? 0.3877 0.2164 0.1641 -0.0764 0.0291  -0.0389 525 ASN A CB  
+4009 C  CG  . ASN A 503 ? 0.4541 0.2582 0.1695 -0.0700 0.0149  -0.0126 525 ASN A CG  
+4010 O  OD1 . ASN A 503 ? 0.4915 0.3119 0.1650 -0.1190 -0.0065 0.0073  525 ASN A OD1 
+4011 N  ND2 . ASN A 503 ? 0.4479 0.2307 0.1929 -0.0960 0.0411  -0.0011 525 ASN A ND2 
+4012 N  N   . GLY A 504 ? 0.3223 0.2388 0.1702 -0.0328 0.0235  -0.0038 526 GLY A N   
+4013 C  CA  . GLY A 504 ? 0.3534 0.2482 0.1830 -0.0268 0.0015  -0.0028 526 GLY A CA  
+4014 C  C   . GLY A 504 ? 0.4208 0.1904 0.2026 -0.0661 0.0156  0.0219  526 GLY A C   
+4015 O  O   . GLY A 504 ? 0.4786 0.2674 0.2218 -0.0564 0.0018  0.0262  526 GLY A O   
+4016 N  N   . ALA A 505 ? 0.4225 0.2069 0.1992 -0.0482 0.0097  0.0088  527 ALA A N   
+4017 C  CA  . ALA A 505 ? 0.4152 0.1982 0.2158 -0.0726 0.0351  0.0069  527 ALA A CA  
+4018 C  C   . ALA A 505 ? 0.4560 0.2061 0.2299 -0.0735 0.0531  0.0123  527 ALA A C   
+4019 O  O   . ALA A 505 ? 0.5010 0.2023 0.2338 0.0107  0.0535  0.0260  527 ALA A O   
+4020 C  CB  . ALA A 505 ? 0.3631 0.1661 0.2100 -0.0719 0.0244  -0.0028 527 ALA A CB  
+4021 N  N   . THR A 506 ? 0.4896 0.2356 0.2506 -0.0779 0.0803  0.0233  528 THR A N   
+4022 C  CA  . THR A 506 ? 0.5515 0.2797 0.2654 -0.0163 0.1015  -0.0013 528 THR A CA  
+4023 C  C   . THR A 506 ? 0.5697 0.2483 0.2580 0.0053  0.1272  -0.0081 528 THR A C   
+4024 O  O   . THR A 506 ? 0.6162 0.2867 0.2399 -0.0007 0.1341  0.0099  528 THR A O   
+4025 C  CB  . THR A 506 ? 0.5651 0.3639 0.2940 0.0163  0.0922  -0.0169 528 THR A CB  
+4026 O  OG1 . THR A 506 ? 0.5507 0.4915 0.3177 -0.0098 0.0855  -0.0037 528 THR A OG1 
+4027 C  CG2 . THR A 506 ? 0.6207 0.4105 0.3031 -0.0091 0.0897  -0.0178 528 THR A CG2 
+4028 N  N   . TRP A 507 ? 0.5178 0.2441 0.2660 -0.0624 0.1448  -0.0066 529 TRP A N   
+4029 C  CA  . TRP A 507 ? 0.5693 0.2237 0.2644 -0.0321 0.1652  -0.0257 529 TRP A CA  
+4030 C  C   . TRP A 507 ? 0.6330 0.2362 0.2938 -0.0267 0.1715  -0.0130 529 TRP A C   
+4031 O  O   . TRP A 507 ? 0.6691 0.2290 0.3021 0.0291  0.1502  -0.0112 529 TRP A O   
+4032 C  CB  . TRP A 507 ? 0.5364 0.1948 0.2411 -0.0687 0.1337  -0.0436 529 TRP A CB  
+4033 C  CG  . TRP A 507 ? 0.5186 0.2129 0.2209 -0.0924 0.0919  -0.0412 529 TRP A CG  
+4034 C  CD1 . TRP A 507 ? 0.5217 0.2168 0.2122 -0.1226 0.0682  -0.0628 529 TRP A CD1 
+4035 C  CD2 . TRP A 507 ? 0.5097 0.2165 0.2106 -0.0754 0.0808  -0.0319 529 TRP A CD2 
+4036 N  NE1 . TRP A 507 ? 0.5131 0.2071 0.1966 -0.0990 0.0806  -0.0387 529 TRP A NE1 
+4037 C  CE2 . TRP A 507 ? 0.4723 0.1876 0.2002 -0.1297 0.0599  -0.0372 529 TRP A CE2 
+4038 C  CE3 . TRP A 507 ? 0.4762 0.2604 0.2079 -0.0766 0.0841  -0.0282 529 TRP A CE3 
+4039 C  CZ2 . TRP A 507 ? 0.4732 0.2483 0.1968 -0.1245 0.0456  -0.0170 529 TRP A CZ2 
+4040 C  CZ3 . TRP A 507 ? 0.4827 0.2663 0.2025 -0.0591 0.0608  -0.0233 529 TRP A CZ3 
+4041 C  CH2 . TRP A 507 ? 0.4903 0.2696 0.1930 -0.0944 0.0468  -0.0361 529 TRP A CH2 
+4042 N  N   . THR A 508 ? 0.6755 0.3108 0.3056 0.0240  0.2047  -0.0467 530 THR A N   
+4043 C  CA  . THR A 508 ? 0.6837 0.3336 0.3213 -0.0121 0.2288  -0.0493 530 THR A CA  
+4044 C  C   . THR A 508 ? 0.7732 0.3336 0.3190 -0.0144 0.2188  -0.0506 530 THR A C   
+4045 O  O   . THR A 508 ? 0.8283 0.3353 0.3173 -0.0037 0.1975  -0.0575 530 THR A O   
+4046 C  CB  . THR A 508 ? 0.6752 0.4058 0.3322 0.0009  0.2394  -0.0490 530 THR A CB  
+4047 O  OG1 . THR A 508 ? 0.7172 0.4499 0.3206 -0.0139 0.2387  -0.0231 530 THR A OG1 
+4048 C  CG2 . THR A 508 ? 0.6461 0.4989 0.3468 0.0332  0.2425  -0.0616 530 THR A CG2 
+4049 N  N   . ALA A 509 ? 0.8213 0.3624 0.3253 -0.0127 0.2185  -0.0549 531 ALA A N   
+4050 C  CA  . ALA A 509 ? 0.8207 0.3898 0.3242 -0.0405 0.2224  -0.0600 531 ALA A CA  
+4051 C  C   . ALA A 509 ? 0.8215 0.4382 0.3331 -0.0268 0.2344  -0.0564 531 ALA A C   
+4052 O  O   . ALA A 509 ? 0.8416 0.4467 0.3451 0.0179  0.2346  -0.0595 531 ALA A O   
+4053 C  CB  . ALA A 509 ? 0.8050 0.3220 0.3290 -0.0733 0.2183  -0.0696 531 ALA A CB  
+4054 N  N   . GLN A 510 ? 0.8223 0.4347 0.3439 -0.0518 0.2193  -0.0992 532 GLN A N   
+4055 C  CA  . GLN A 510 ? 0.8101 0.4769 0.3539 -0.0538 0.2309  -0.1070 532 GLN A CA  
+4056 C  C   . GLN A 510 ? 0.8354 0.5076 0.3715 -0.0508 0.2182  -0.1404 532 GLN A C   
+4057 O  O   . GLN A 510 ? 0.8708 0.5606 0.3820 -0.0166 0.2009  -0.1644 532 GLN A O   
+4058 C  CB  . GLN A 510 ? 0.8267 0.5430 0.3566 -0.0116 0.2305  -0.1092 532 GLN A CB  
+4059 C  CG  . GLN A 510 ? 0.8370 0.5411 0.3571 -0.0031 0.2273  -0.1099 532 GLN A CG  
+4060 C  CD  . GLN A 510 ? 0.8823 0.5599 0.3491 0.0176  0.2151  -0.1033 532 GLN A CD  
+4061 O  OE1 . GLN A 510 ? 0.9062 0.5777 0.3452 0.0593  0.2142  -0.0807 532 GLN A OE1 
+4062 N  NE2 . GLN A 510 ? 0.9079 0.5456 0.3455 0.0170  0.2040  -0.1034 532 GLN A NE2 
+4063 N  N   . TRP A 511 ? 0.8643 0.5172 0.3897 -0.0334 0.1978  -0.1669 533 TRP A N   
+4064 C  CA  . TRP A 511 ? 0.9006 0.5229 0.3978 -0.0443 0.1772  -0.1820 533 TRP A CA  
+4065 C  C   . TRP A 511 ? 0.9051 0.4759 0.4167 -0.0512 0.1719  -0.1824 533 TRP A C   
+4066 O  O   . TRP A 511 ? 0.8696 0.4821 0.4223 -0.0238 0.1612  -0.1962 533 TRP A O   
+4067 C  CB  . TRP A 511 ? 0.9151 0.5541 0.3918 -0.0533 0.1604  -0.1922 533 TRP A CB  
+4068 C  CG  . TRP A 511 ? 0.9565 0.5841 0.3831 -0.0590 0.1534  -0.1875 533 TRP A CG  
+4069 C  CD1 . TRP A 511 ? 0.9581 0.5863 0.3817 -0.0603 0.1560  -0.1852 533 TRP A CD1 
+4070 C  CD2 . TRP A 511 ? 0.9790 0.5803 0.3804 -0.0547 0.1467  -0.1820 533 TRP A CD2 
+4071 N  NE1 . TRP A 511 ? 0.9775 0.5971 0.3768 -0.0770 0.1501  -0.1818 533 TRP A NE1 
+4072 C  CE2 . TRP A 511 ? 0.9794 0.5946 0.3729 -0.0795 0.1458  -0.1792 533 TRP A CE2 
+4073 C  CE3 . TRP A 511 ? 0.9728 0.5590 0.3789 -0.0866 0.1422  -0.1790 533 TRP A CE3 
+4074 C  CZ2 . TRP A 511 ? 0.9857 0.6254 0.3709 -0.0928 0.1370  -0.1854 533 TRP A CZ2 
+4075 C  CZ3 . TRP A 511 ? 0.9827 0.6152 0.3674 -0.0969 0.1415  -0.1786 533 TRP A CZ3 
+4076 C  CH2 . TRP A 511 ? 0.9893 0.6148 0.3661 -0.1137 0.1332  -0.1779 533 TRP A CH2 
+4077 N  N   . TRP A 512 ? 0.9462 0.4122 0.4341 -0.0761 0.1574  -0.1646 534 TRP A N   
+4078 C  CA  . TRP A 512 ? 0.9637 0.4089 0.4462 -0.0261 0.1449  -0.1652 534 TRP A CA  
+4079 C  C   . TRP A 512 ? 0.9291 0.4188 0.4317 -0.0642 0.1412  -0.1739 534 TRP A C   
+4080 O  O   . TRP A 512 ? 0.9527 0.4295 0.4272 -0.0535 0.1320  -0.1736 534 TRP A O   
+4081 C  CB  . TRP A 512 ? 1.0669 0.4631 0.4549 0.0362  0.1355  -0.1659 534 TRP A CB  
+4082 C  CG  . TRP A 512 ? 1.1318 0.5847 0.4686 0.0983  0.1303  -0.1461 534 TRP A CG  
+4083 C  CD1 . TRP A 512 ? 1.1471 0.6167 0.4748 0.1348  0.1264  -0.1364 534 TRP A CD1 
+4084 C  CD2 . TRP A 512 ? 1.1445 0.6635 0.4778 0.1253  0.1244  -0.1399 534 TRP A CD2 
+4085 N  NE1 . TRP A 512 ? 1.1628 0.6454 0.4787 0.1514  0.1258  -0.1310 534 TRP A NE1 
+4086 C  CE2 . TRP A 512 ? 1.1545 0.6685 0.4804 0.1411  0.1246  -0.1356 534 TRP A CE2 
+4087 C  CE3 . TRP A 512 ? 1.1392 0.7161 0.4816 0.1164  0.1168  -0.1322 534 TRP A CE3 
+4088 C  CZ2 . TRP A 512 ? 1.1467 0.6899 0.4816 0.1363  0.1254  -0.1419 534 TRP A CZ2 
+4089 C  CZ3 . TRP A 512 ? 1.1369 0.7283 0.4833 0.1208  0.1197  -0.1308 534 TRP A CZ3 
+4090 C  CH2 . TRP A 512 ? 1.1388 0.7224 0.4829 0.1188  0.1199  -0.1388 534 TRP A CH2 
+4091 N  N   . THR A 513 ? 0.8413 0.3561 0.4353 -0.1015 0.1374  -0.1603 535 THR A N   
+4092 C  CA  . THR A 513 ? 0.8470 0.3406 0.4190 -0.1244 0.1655  -0.1373 535 THR A CA  
+4093 C  C   . THR A 513 ? 0.8599 0.3355 0.4100 -0.1049 0.1733  -0.1286 535 THR A C   
+4094 O  O   . THR A 513 ? 0.8583 0.3097 0.4045 -0.0912 0.1895  -0.1078 535 THR A O   
+4095 C  CB  . THR A 513 ? 0.8322 0.3289 0.4213 -0.1395 0.1793  -0.1293 535 THR A CB  
+4096 O  OG1 . THR A 513 ? 0.8395 0.2945 0.4265 -0.1340 0.1711  -0.1028 535 THR A OG1 
+4097 C  CG2 . THR A 513 ? 0.8123 0.3284 0.4203 -0.1497 0.1741  -0.1313 535 THR A CG2 
+4098 N  N   . LYS A 514 ? 0.8100 0.2942 0.4112 -0.1292 0.1539  -0.1098 536 LYS A N   
+4099 C  CA  . LYS A 514 ? 0.8175 0.2660 0.4143 -0.1204 0.1179  -0.0844 536 LYS A CA  
+4100 C  C   . LYS A 514 ? 0.8332 0.2921 0.3991 -0.1410 0.1082  -0.0977 536 LYS A C   
+4101 O  O   . LYS A 514 ? 0.8508 0.2963 0.4108 -0.1624 0.1015  -0.0877 536 LYS A O   
+4102 C  CB  . LYS A 514 ? 0.7969 0.2335 0.4295 -0.0813 0.0985  -0.0653 536 LYS A CB  
+4103 C  CG  . LYS A 514 ? 0.8416 0.2310 0.4493 -0.0346 0.0936  -0.0575 536 LYS A CG  
+4104 C  CD  . LYS A 514 ? 0.8609 0.2482 0.4681 0.0513  0.0752  -0.0713 536 LYS A CD  
+4105 C  CE  . LYS A 514 ? 0.9130 0.3268 0.4821 0.1630  0.0751  -0.0867 536 LYS A CE  
+4106 N  NZ  . LYS A 514 ? 0.9311 0.3822 0.4998 0.2387  0.0588  -0.0800 536 LYS A NZ  
+4107 N  N   . GLY A 515 ? 0.8105 0.2844 0.3774 -0.1625 0.0920  -0.0780 537 GLY A N   
+4108 C  CA  . GLY A 515 ? 0.8050 0.2989 0.3548 -0.1385 0.0864  -0.0701 537 GLY A CA  
+4109 C  C   . GLY A 515 ? 0.7727 0.2727 0.3397 -0.1757 0.0804  -0.0525 537 GLY A C   
+4110 O  O   . GLY A 515 ? 0.7702 0.2760 0.3379 -0.1707 0.0995  -0.0442 537 GLY A O   
+4111 N  N   . GLU A 516 ? 0.7868 0.2651 0.3200 -0.1730 0.0790  -0.0242 538 GLU A N   
+4112 C  CA  . GLU A 516 ? 0.7563 0.2822 0.3074 -0.1973 0.0633  -0.0351 538 GLU A CA  
+4113 C  C   . GLU A 516 ? 0.7147 0.3059 0.2833 -0.1679 0.0533  -0.0374 538 GLU A C   
+4114 O  O   . GLU A 516 ? 0.7227 0.2978 0.2826 -0.1939 0.0517  -0.0351 538 GLU A O   
+4115 C  CB  . GLU A 516 ? 0.7519 0.3118 0.3215 -0.2195 0.0489  -0.0519 538 GLU A CB  
+4116 C  CG  . GLU A 516 ? 0.8495 0.3773 0.3290 -0.2350 0.0395  -0.0748 538 GLU A CG  
+4117 C  CD  . GLU A 516 ? 0.9176 0.4270 0.3408 -0.2137 0.0213  -0.0793 538 GLU A CD  
+4118 O  OE1 . GLU A 516 ? 0.9294 0.4468 0.3439 -0.2629 0.0103  -0.0426 538 GLU A OE1 
+4119 O  OE2 . GLU A 516 ? 0.9538 0.3916 0.3573 -0.1959 0.0185  -0.0968 538 GLU A OE2 
+4120 N  N   . GLU A 517 ? 0.6730 0.2846 0.2677 -0.1551 0.0358  -0.0367 539 GLU A N   
+4121 C  CA  . GLU A 517 ? 0.5703 0.2139 0.2459 -0.1497 0.0433  -0.0277 539 GLU A CA  
+4122 C  C   . GLU A 517 ? 0.5863 0.2198 0.2206 -0.1495 0.0585  -0.0358 539 GLU A C   
+4123 O  O   . GLU A 517 ? 0.5995 0.2759 0.2264 -0.1403 0.0196  -0.0703 539 GLU A O   
+4124 C  CB  . GLU A 517 ? 0.5745 0.2357 0.2442 -0.1448 0.0375  -0.0391 539 GLU A CB  
+4125 C  CG  . GLU A 517 ? 0.5476 0.2737 0.2476 -0.1246 0.0466  -0.0265 539 GLU A CG  
+4126 C  CD  . GLU A 517 ? 0.4896 0.2837 0.2530 -0.1942 0.0635  -0.0018 539 GLU A CD  
+4127 O  OE1 . GLU A 517 ? 0.5280 0.3261 0.2588 -0.1914 0.0509  0.0197  539 GLU A OE1 
+4128 O  OE2 . GLU A 517 ? 0.4671 0.3241 0.2579 -0.2011 0.0824  0.0032  539 GLU A OE2 
+4129 N  N   . PRO A 518 ? 0.5912 0.2147 0.2021 -0.1094 0.0799  -0.0322 540 PRO A N   
+4130 C  CA  . PRO A 518 ? 0.6055 0.2212 0.2038 -0.0900 0.0590  -0.0161 540 PRO A CA  
+4131 C  C   . PRO A 518 ? 0.5572 0.1981 0.2088 -0.1338 0.0605  -0.0261 540 PRO A C   
+4132 O  O   . PRO A 518 ? 0.5359 0.2131 0.2153 -0.1392 0.0743  -0.0013 540 PRO A O   
+4133 C  CB  . PRO A 518 ? 0.6224 0.2007 0.1938 -0.0933 0.0634  -0.0039 540 PRO A CB  
+4134 C  CG  . PRO A 518 ? 0.6395 0.2266 0.1949 -0.0699 0.0651  -0.0343 540 PRO A CG  
+4135 C  CD  . PRO A 518 ? 0.6042 0.2147 0.1963 -0.0859 0.0799  -0.0370 540 PRO A CD  
+4136 N  N   . GLY A 519 ? 0.5564 0.1827 0.2102 -0.0873 0.0592  -0.0024 541 GLY A N   
+4137 C  CA  . GLY A 519 ? 0.5416 0.2042 0.2123 -0.1332 0.0533  0.0064  541 GLY A CA  
+4138 C  C   . GLY A 519 ? 0.5524 0.2272 0.2034 -0.1624 0.0604  -0.0136 541 GLY A C   
+4139 O  O   . GLY A 519 ? 0.5735 0.2074 0.2052 -0.1399 0.0466  -0.0024 541 GLY A O   
+4140 N  N   . THR A 520 ? 0.5454 0.2327 0.1990 -0.1705 0.0572  -0.0287 542 THR A N   
+4141 C  CA  . THR A 520 ? 0.5537 0.2545 0.2125 -0.1845 0.0390  -0.0348 542 THR A CA  
+4142 C  C   . THR A 520 ? 0.6246 0.2872 0.2147 -0.2028 0.0242  -0.0208 542 THR A C   
+4143 O  O   . THR A 520 ? 0.6448 0.3099 0.2179 -0.1678 -0.0097 -0.0165 542 THR A O   
+4144 C  CB  . THR A 520 ? 0.5226 0.2364 0.2241 -0.1750 0.0457  -0.0261 542 THR A CB  
+4145 O  OG1 . THR A 520 ? 0.5413 0.2444 0.2232 -0.1515 0.0591  -0.0281 542 THR A OG1 
+4146 C  CG2 . THR A 520 ? 0.5220 0.2293 0.2367 -0.1259 0.0523  -0.0186 542 THR A CG2 
+4147 N  N   . THR A 521 ? 0.6392 0.2905 0.2223 -0.2027 0.0285  -0.0371 543 THR A N   
+4148 C  CA  . THR A 521 ? 0.6905 0.3138 0.2180 -0.1575 0.0507  -0.0348 543 THR A CA  
+4149 C  C   . THR A 521 ? 0.7091 0.3252 0.2065 -0.1734 0.0595  -0.0343 543 THR A C   
+4150 O  O   . THR A 521 ? 0.7162 0.3828 0.2157 -0.1440 0.0470  -0.0633 543 THR A O   
+4151 C  CB  . THR A 521 ? 0.6957 0.2660 0.2234 -0.1073 0.0771  -0.0500 543 THR A CB  
+4152 O  OG1 . THR A 521 ? 0.6655 0.3109 0.2244 -0.0893 0.1040  -0.0413 543 THR A OG1 
+4153 C  CG2 . THR A 521 ? 0.7350 0.2510 0.2342 -0.1074 0.0717  -0.0389 543 THR A CG2 
+4154 N  N   . GLY A 522 ? 0.7246 0.3260 0.2124 -0.2071 0.0531  -0.0110 544 GLY A N   
+4155 C  CA  . GLY A 522 ? 0.7303 0.2901 0.2222 -0.2009 0.0470  -0.0058 544 GLY A CA  
+4156 C  C   . GLY A 522 ? 0.7534 0.3393 0.2343 -0.1758 0.0602  -0.0115 544 GLY A C   
+4157 O  O   . GLY A 522 ? 0.7731 0.3213 0.2275 -0.1547 0.0625  0.0149  544 GLY A O   
+4158 N  N   . GLU A 523 ? 0.7451 0.3464 0.2500 -0.2546 0.0651  -0.0404 545 GLU A N   
+4159 C  CA  . GLU A 523 ? 0.8139 0.4091 0.2709 -0.2123 0.0925  -0.0520 545 GLU A CA  
+4160 C  C   . GLU A 523 ? 0.8925 0.4265 0.3083 -0.1795 0.0996  -0.0576 545 GLU A C   
+4161 O  O   . GLU A 523 ? 0.9359 0.4343 0.3348 -0.1829 0.1154  -0.0451 545 GLU A O   
+4162 C  CB  . GLU A 523 ? 0.8129 0.3935 0.2632 -0.2068 0.0857  -0.0590 545 GLU A CB  
+4163 C  CG  . GLU A 523 ? 0.8086 0.4392 0.2640 -0.2239 0.0800  -0.0800 545 GLU A CG  
+4164 C  CD  . GLU A 523 ? 0.8299 0.4602 0.2459 -0.1407 0.1088  -0.0440 545 GLU A CD  
+4165 O  OE1 . GLU A 523 ? 0.7936 0.5505 0.2383 -0.1251 0.1109  -0.0072 545 GLU A OE1 
+4166 O  OE2 . GLU A 523 ? 0.8588 0.4223 0.2540 -0.0823 0.1028  -0.0646 545 GLU A OE2 
+4167 N  N   . TRP A 524 ? 0.9232 0.3815 0.3009 -0.1411 0.0866  -0.0681 546 TRP A N   
+4168 C  CA  . TRP A 524 ? 0.9566 0.4464 0.3000 -0.0424 0.0798  -0.0848 546 TRP A CA  
+4169 C  C   . TRP A 524 ? 0.9015 0.4157 0.2939 -0.0864 0.0914  -0.1021 546 TRP A C   
+4170 O  O   . TRP A 524 ? 0.9036 0.4773 0.2941 -0.0524 0.0857  -0.1184 546 TRP A O   
+4171 C  CB  . TRP A 524 ? 1.0279 0.5159 0.3178 0.0149  0.0488  -0.0722 546 TRP A CB  
+4172 C  CG  . TRP A 524 ? 1.1030 0.6053 0.3377 0.0796  0.0087  -0.0893 546 TRP A CG  
+4173 C  CD1 . TRP A 524 ? 1.1270 0.6268 0.3448 0.1023  0.0040  -0.0910 546 TRP A CD1 
+4174 C  CD2 . TRP A 524 ? 1.1283 0.6425 0.3555 0.0621  -0.0118 -0.0957 546 TRP A CD2 
+4175 N  NE1 . TRP A 524 ? 1.1474 0.6665 0.3578 0.1228  -0.0039 -0.0825 546 TRP A NE1 
+4176 C  CE2 . TRP A 524 ? 1.1478 0.6796 0.3610 0.1003  -0.0135 -0.0881 546 TRP A CE2 
+4177 C  CE3 . TRP A 524 ? 1.1102 0.6412 0.3635 -0.0278 -0.0368 -0.1028 546 TRP A CE3 
+4178 C  CZ2 . TRP A 524 ? 1.1419 0.6940 0.3639 0.0505  -0.0362 -0.0849 546 TRP A CZ2 
+4179 C  CZ3 . TRP A 524 ? 1.1071 0.6702 0.3644 -0.0473 -0.0499 -0.0973 546 TRP A CZ3 
+4180 C  CH2 . TRP A 524 ? 1.1237 0.6790 0.3659 0.0007  -0.0556 -0.0896 546 TRP A CH2 
+4181 N  N   . GLY A 525 ? 0.8670 0.4001 0.2902 -0.1324 0.1038  -0.0794 547 GLY A N   
+4182 C  CA  . GLY A 525 ? 0.7914 0.3454 0.2985 -0.1728 0.1176  -0.0972 547 GLY A CA  
+4183 C  C   . GLY A 525 ? 0.7424 0.3749 0.2868 -0.1804 0.1433  -0.1037 547 GLY A C   
+4184 O  O   . GLY A 525 ? 0.7352 0.4766 0.2812 -0.1422 0.1674  -0.0969 547 GLY A O   
+4185 N  N   . VAL A 526 ? 0.7341 0.4056 0.2920 -0.1084 0.1453  -0.1200 548 VAL A N   
+4186 C  CA  . VAL A 526 ? 0.7067 0.3575 0.2910 -0.1013 0.1438  -0.1141 548 VAL A CA  
+4187 C  C   . VAL A 526 ? 0.7286 0.3641 0.2930 -0.0270 0.1469  -0.1052 548 VAL A C   
+4188 O  O   . VAL A 526 ? 0.7507 0.3437 0.3030 -0.0005 0.1334  -0.1038 548 VAL A O   
+4189 C  CB  . VAL A 526 ? 0.7014 0.4362 0.2909 -0.0960 0.1480  -0.1302 548 VAL A CB  
+4190 C  CG1 . VAL A 526 ? 0.6701 0.4047 0.2886 -0.2025 0.1558  -0.1186 548 VAL A CG1 
+4191 C  CG2 . VAL A 526 ? 0.7143 0.4376 0.2976 -0.0693 0.1394  -0.1385 548 VAL A CG2 
+4192 N  N   . TRP A 527 ? 0.7267 0.3119 0.2985 -0.0721 0.1312  -0.1040 549 TRP A N   
+4193 C  CA  . TRP A 527 ? 0.7104 0.2782 0.2835 -0.1073 0.1425  -0.0830 549 TRP A CA  
+4194 C  C   . TRP A 527 ? 0.7347 0.2957 0.2694 -0.1079 0.1353  -0.0778 549 TRP A C   
+4195 O  O   . TRP A 527 ? 0.7427 0.3660 0.2738 -0.0916 0.1224  -0.0704 549 TRP A O   
+4196 C  CB  . TRP A 527 ? 0.6934 0.2774 0.2808 -0.1013 0.1518  -0.0820 549 TRP A CB  
+4197 C  CG  . TRP A 527 ? 0.6995 0.2665 0.2934 -0.1135 0.1453  -0.0834 549 TRP A CG  
+4198 C  CD1 . TRP A 527 ? 0.7010 0.2652 0.2935 -0.1333 0.1466  -0.0798 549 TRP A CD1 
+4199 C  CD2 . TRP A 527 ? 0.7019 0.2539 0.3013 -0.1013 0.1458  -0.0796 549 TRP A CD2 
+4200 N  NE1 . TRP A 527 ? 0.7276 0.3005 0.3081 -0.0843 0.1347  -0.1036 549 TRP A NE1 
+4201 C  CE2 . TRP A 527 ? 0.7161 0.2762 0.3063 -0.0944 0.1456  -0.0912 549 TRP A CE2 
+4202 C  CE3 . TRP A 527 ? 0.7295 0.2743 0.3038 -0.0299 0.1577  -0.0765 549 TRP A CE3 
+4203 C  CZ2 . TRP A 527 ? 0.7138 0.2736 0.3015 -0.0696 0.1612  -0.0825 549 TRP A CZ2 
+4204 C  CZ3 . TRP A 527 ? 0.7354 0.2441 0.3017 -0.0128 0.1706  -0.0506 549 TRP A CZ3 
+4205 C  CH2 . TRP A 527 ? 0.7324 0.2441 0.3029 -0.0881 0.1595  -0.0655 549 TRP A CH2 
+4206 N  N   . ARG A 528 ? 0.7875 0.3349 0.2607 -0.0903 0.1464  -0.0591 550 ARG A N   
+4207 C  CA  . ARG A 528 ? 0.8028 0.3348 0.2630 -0.0645 0.1554  -0.0478 550 ARG A CA  
+4208 C  C   . ARG A 528 ? 0.7630 0.3451 0.2503 -0.0768 0.1486  -0.0484 550 ARG A C   
+4209 O  O   . ARG A 528 ? 0.7643 0.3573 0.2369 -0.1076 0.1275  -0.0423 550 ARG A O   
+4210 C  CB  . ARG A 528 ? 0.8858 0.4049 0.2742 -0.0348 0.1506  -0.0459 550 ARG A CB  
+4211 C  CG  . ARG A 528 ? 0.9548 0.4669 0.2885 -0.0176 0.1278  -0.0703 550 ARG A CG  
+4212 C  CD  . ARG A 528 ? 1.0372 0.5057 0.3023 0.0095  0.1054  -0.0764 550 ARG A CD  
+4213 N  NE  . ARG A 528 ? 1.1035 0.5406 0.3176 0.0229  0.0985  -0.0809 550 ARG A NE  
+4214 C  CZ  . ARG A 528 ? 1.1595 0.5682 0.3251 -0.0086 0.0899  -0.0813 550 ARG A CZ  
+4215 N  NH1 . ARG A 528 ? 1.1763 0.5681 0.3320 0.0017  0.0808  -0.0881 550 ARG A NH1 
+4216 N  NH2 . ARG A 528 ? 1.1704 0.5615 0.3287 -0.0573 0.0912  -0.0729 550 ARG A NH2 
+4217 O  OXT . ARG A 528 ? 0.7266 0.3072 0.2602 -0.0710 0.1628  -0.0562 550 ARG A OXT 
+4218 C  C1  A NAG B .   ? 0.3708 0.2279 0.1421 0.0527  0.0304  0.0106  1   NAG B C1  
+4219 C  C2  A NAG B .   ? 0.3136 0.2326 0.1527 0.0833  0.0388  -0.0251 1   NAG B C2  
+4220 C  C3  A NAG B .   ? 0.3209 0.2383 0.1495 0.0500  0.0077  -0.0426 1   NAG B C3  
+4221 C  C4  A NAG B .   ? 0.3247 0.2057 0.1417 0.0694  -0.0079 -0.0395 1   NAG B C4  
+4222 C  C5  A NAG B .   ? 0.3772 0.2154 0.1406 0.0357  -0.0140 -0.0279 1   NAG B C5  
+4223 C  C6  A NAG B .   ? 0.4215 0.2758 0.1565 -0.0004 -0.0662 -0.0605 1   NAG B C6  
+4224 C  C7  A NAG B .   ? 0.2925 0.2698 0.1905 0.0693  0.0148  -0.0489 1   NAG B C7  
+4225 C  C8  A NAG B .   ? 0.2662 0.3315 0.1956 0.0659  0.0066  -0.0353 1   NAG B C8  
+4226 N  N2  A NAG B .   ? 0.2769 0.2435 0.1614 0.0369  0.0322  -0.0241 1   NAG B N2  
+4227 O  O1  A NAG B .   ? 0.4469 0.3096 0.1449 0.0976  0.0304  0.0032  1   NAG B O1  
+4228 O  O3  A NAG B .   ? 0.3038 0.1954 0.1525 0.0439  0.0143  -0.0223 1   NAG B O3  
+4229 O  O4  A NAG B .   ? 0.3164 0.1863 0.1290 0.0358  -0.0102 -0.0432 1   NAG B O4  
+4230 O  O5  A NAG B .   ? 0.3856 0.2085 0.1395 0.0141  -0.0016 -0.0132 1   NAG B O5  
+4231 O  O6  A NAG B .   ? 0.4431 0.2242 0.1726 0.0311  -0.0562 -0.0758 1   NAG B O6  
+4232 O  O7  A NAG B .   ? 0.3162 0.3349 0.2122 0.0593  0.0318  -0.0624 1   NAG B O7  
+4233 C  C1  B NDG B .   ? 0.3455 0.2182 0.1338 0.0519  0.0523  -0.0045 1   NDG B C1  
+4234 C  C2  B NDG B .   ? 0.3100 0.2336 0.1476 0.0879  0.0546  -0.0366 1   NDG B C2  
+4235 C  C3  B NDG B .   ? 0.3182 0.2312 0.1471 0.0558  0.0190  -0.0528 1   NDG B C3  
+4236 C  C4  B NDG B .   ? 0.3230 0.2028 0.1450 0.0786  0.0177  -0.0398 1   NDG B C4  
+4237 C  C5  B NDG B .   ? 0.3820 0.2131 0.1467 0.0354  -0.0017 -0.0209 1   NDG B C5  
+4238 C  C6  B NDG B .   ? 0.4581 0.3204 0.1714 -0.0283 -0.0543 -0.0261 1   NDG B C6  
+4239 C  C7  B NDG B .   ? 0.2922 0.2695 0.1858 0.0697  0.0166  -0.0490 1   NDG B C7  
+4240 C  C8  B NDG B .   ? 0.2665 0.3317 0.1903 0.0659  0.0069  -0.0358 1   NDG B C8  
+4241 O  O5  B NDG B .   ? 0.3833 0.2002 0.1382 0.0104  0.0137  -0.0241 1   NDG B O5  
+4242 O  O3  B NDG B .   ? 0.2872 0.1567 0.1466 0.0730  0.0163  -0.0408 1   NDG B O3  
+4243 O  O4  B NDG B .   ? 0.3117 0.1944 0.1360 0.0437  0.0454  -0.0346 1   NDG B O4  
+4244 O  O6  B NDG B .   ? 0.5286 0.3137 0.1863 -0.0111 -0.0561 -0.0425 1   NDG B O6  
+4245 O  O7  B NDG B .   ? 0.3166 0.3348 0.2073 0.0595  0.0322  -0.0622 1   NDG B O7  
+4246 N  N2  B NDG B .   ? 0.2748 0.2425 0.1572 0.0356  0.0398  -0.0256 1   NDG B N2  
+4247 O  O1  B NDG B .   ? 0.3735 0.2180 0.1317 0.0517  0.0540  -0.0391 1   NDG B O1  
+4248 C  C1  . NAG B .   ? 0.3298 0.1662 0.1284 0.0465  -0.0332 -0.0562 2   NAG B C1  
+4249 C  C2  . NAG B .   ? 0.2705 0.1434 0.1321 0.0481  0.0063  -0.0438 2   NAG B C2  
+4250 C  C3  . NAG B .   ? 0.2732 0.1154 0.1302 0.0017  0.0132  -0.0115 2   NAG B C3  
+4251 C  C4  . NAG B .   ? 0.2749 0.1453 0.1222 0.0495  -0.0019 -0.0263 2   NAG B C4  
+4252 C  C5  . NAG B .   ? 0.2935 0.1756 0.1201 0.0013  -0.0073 -0.0455 2   NAG B C5  
+4253 C  C6  . NAG B .   ? 0.3465 0.1713 0.1080 0.0059  -0.0093 -0.0366 2   NAG B C6  
+4254 C  C7  . NAG B .   ? 0.2812 0.2370 0.1560 0.0349  0.0206  -0.0558 2   NAG B C7  
+4255 C  C8  . NAG B .   ? 0.3727 0.2356 0.1647 0.0542  0.0010  -0.0907 2   NAG B C8  
+4256 N  N2  . NAG B .   ? 0.2477 0.1732 0.1519 0.0326  0.0042  -0.0273 2   NAG B N2  
+4257 O  O3  . NAG B .   ? 0.3027 0.1614 0.1392 0.0222  0.0058  -0.0031 2   NAG B O3  
+4258 O  O4  . NAG B .   ? 0.2351 0.1644 0.1208 0.0420  -0.0222 -0.0300 2   NAG B O4  
+4259 O  O5  . NAG B .   ? 0.3247 0.1624 0.1225 0.0229  -0.0292 -0.0548 2   NAG B O5  
+4260 O  O6  . NAG B .   ? 0.3503 0.1453 0.0968 0.0124  -0.0042 -0.0228 2   NAG B O6  
+4261 O  O7  . NAG B .   ? 0.2734 0.1942 0.1650 0.0285  0.0167  -0.0448 2   NAG B O7  
+4262 C  C1  . NAG B .   ? 0.2255 0.1514 0.0981 0.0165  -0.0340 -0.0208 3   NAG B C1  
+4263 C  C2  . NAG B .   ? 0.2691 0.1883 0.0969 0.0941  -0.0199 -0.0345 3   NAG B C2  
+4264 C  C3  . NAG B .   ? 0.3069 0.1596 0.1060 0.1073  -0.0093 -0.0126 3   NAG B C3  
+4265 C  C4  . NAG B .   ? 0.2474 0.1402 0.0902 0.0324  -0.0049 0.0170  3   NAG B C4  
+4266 C  C5  . NAG B .   ? 0.2409 0.1708 0.0974 0.0282  -0.0163 -0.0050 3   NAG B C5  
+4267 C  C6  . NAG B .   ? 0.2722 0.2163 0.1163 0.0417  -0.0215 -0.0056 3   NAG B C6  
+4268 C  C7  . NAG B .   ? 0.2929 0.1665 0.1025 0.0745  -0.0012 0.0081  3   NAG B C7  
+4269 C  C8  . NAG B .   ? 0.2676 0.1799 0.1038 0.0951  -0.0084 -0.0046 3   NAG B C8  
+4270 N  N2  . NAG B .   ? 0.2721 0.1978 0.0975 0.0733  0.0010  -0.0080 3   NAG B N2  
+4271 O  O3  . NAG B .   ? 0.3146 0.1889 0.1037 0.0666  -0.0094 0.0018  3   NAG B O3  
+4272 O  O4  . NAG B .   ? 0.2698 0.1654 0.0998 0.0136  -0.0198 -0.0103 3   NAG B O4  
+4273 O  O5  . NAG B .   ? 0.2543 0.1394 0.0960 0.0039  -0.0194 -0.0047 3   NAG B O5  
+4274 O  O6  . NAG B .   ? 0.2688 0.2038 0.1180 0.0149  -0.0344 0.0113  3   NAG B O6  
+4275 O  O7  . NAG B .   ? 0.2698 0.1765 0.1028 0.0503  0.0038  -0.0016 3   NAG B O7  
+4276 C  C1  . NAG B .   ? 0.3072 0.2194 0.1237 0.0772  -0.0126 -0.0219 4   NAG B C1  
+4277 C  C2  . NAG B .   ? 0.3116 0.2019 0.1373 0.0371  0.0082  -0.0249 4   NAG B C2  
+4278 C  C3  . NAG B .   ? 0.3337 0.1520 0.1549 0.0860  0.0097  -0.0280 4   NAG B C3  
+4279 C  C4  . NAG B .   ? 0.3723 0.1921 0.1772 0.1265  0.0299  -0.0198 4   NAG B C4  
+4280 C  C5  . NAG B .   ? 0.3525 0.1797 0.1577 0.0768  -0.0037 -0.0289 4   NAG B C5  
+4281 C  C6  . NAG B .   ? 0.3113 0.2316 0.1641 0.0483  -0.0151 -0.0054 4   NAG B C6  
+4282 C  C7  . NAG B .   ? 0.3020 0.1310 0.1082 0.0902  -0.0076 0.0106  4   NAG B C7  
+4283 C  C8  . NAG B .   ? 0.2666 0.1457 0.0937 0.0079  -0.0250 -0.0175 4   NAG B C8  
+4284 N  N2  . NAG B .   ? 0.3193 0.1461 0.1343 0.0483  0.0204  -0.0160 4   NAG B N2  
+4285 O  O3  . NAG B .   ? 0.3465 0.1194 0.1462 0.0505  0.0156  -0.0143 4   NAG B O3  
+4286 O  O4  . NAG B .   ? 0.3803 0.1613 0.2117 0.1168  0.0229  0.0024  4   NAG B O4  
+4287 O  O5  . NAG B .   ? 0.3083 0.1679 0.1269 0.0568  -0.0032 -0.0287 4   NAG B O5  
+4288 O  O6  . NAG B .   ? 0.2789 0.2364 0.1628 0.0580  0.0079  0.0039  4   NAG B O6  
+4289 O  O7  . NAG B .   ? 0.3016 0.1532 0.0957 0.0402  0.0043  -0.0139 4   NAG B O7  
+4290 C  C1  . GOL C .   ? 0.4957 0.3294 0.1782 -0.0850 0.0463  -0.0080 601 GOL A C1  
+4291 O  O1  . GOL C .   ? 0.4798 0.2852 0.1862 -0.0804 0.0130  -0.0180 601 GOL A O1  
+4292 C  C2  . GOL C .   ? 0.4957 0.3421 0.1764 -0.0610 0.0355  -0.0174 601 GOL A C2  
+4293 O  O2  . GOL C .   ? 0.4683 0.3257 0.1765 -0.1695 0.0215  -0.0105 601 GOL A O2  
+4294 C  C3  . GOL C .   ? 0.5106 0.2887 0.1659 -0.0661 0.0265  -0.0227 601 GOL A C3  
+4295 O  O3  . GOL C .   ? 0.4474 0.2791 0.1403 -0.0753 0.0380  -0.0256 601 GOL A O3  
+4296 C  C1  . GOL D .   ? 0.5060 0.4079 0.1549 0.0688  0.0252  -0.0146 602 GOL A C1  
+4297 O  O1  . GOL D .   ? 0.5588 0.3600 0.1681 0.1032  -0.0005 -0.0137 602 GOL A O1  
+4298 C  C2  . GOL D .   ? 0.4203 0.4364 0.1506 0.0346  0.0163  -0.0322 602 GOL A C2  
+4299 O  O2  . GOL D .   ? 0.3783 0.3620 0.1419 -0.0580 0.0514  -0.0170 602 GOL A O2  
+4300 C  C3  . GOL D .   ? 0.3525 0.4529 0.1453 0.0407  0.0506  -0.0275 602 GOL A C3  
+4301 O  O3  . GOL D .   ? 0.4359 0.3943 0.1394 0.0850  0.0530  0.0002  602 GOL A O3  
+4302 C  C1  . GOL E .   ? 0.4833 0.9462 0.7028 0.0410  -0.0271 0.1373  603 GOL A C1  
+4303 O  O1  . GOL E .   ? 0.4347 0.9508 0.7065 -0.0045 -0.0294 0.1248  603 GOL A O1  
+4304 C  C2  . GOL E .   ? 0.4953 0.9453 0.6945 0.0714  -0.0334 0.1487  603 GOL A C2  
+4305 O  O2  . GOL E .   ? 0.4368 0.9247 0.6905 0.0143  -0.0433 0.1667  603 GOL A O2  
+4306 C  C3  . GOL E .   ? 0.5642 0.9611 0.6903 0.1470  -0.0296 0.1451  603 GOL A C3  
+4307 O  O3  . GOL E .   ? 0.6107 0.9656 0.6859 0.1921  -0.0326 0.1467  603 GOL A O3  
+4308 NA NA  . NA  F .   ? 0.3163 0.2423 0.1399 0.0746  -0.0454 -0.0046 604 NA  A NA  
+4309 S  S   . SO4 G .   ? 0.6749 0.3678 0.2925 0.1751  0.0046  -0.0555 605 SO4 A S   
+4310 O  O1  . SO4 G .   ? 0.5649 0.2132 0.2842 0.0291  -0.0031 -0.0994 605 SO4 A O1  
+4311 O  O2  . SO4 G .   ? 0.5793 0.3052 0.2760 0.0968  0.0153  -0.0353 605 SO4 A O2  
+4312 O  O3  . SO4 G .   ? 0.6170 0.3050 0.3105 0.2162  0.0004  -0.0442 605 SO4 A O3  
+4313 O  O4  . SO4 G .   ? 0.6723 0.4406 0.2887 0.2231  0.0070  -0.0719 605 SO4 A O4  
+4314 N  N   . GLY H .   ? 0.7556 0.7296 0.4756 -0.0427 0.0817  0.0547  606 GLY A N   
+4315 C  CA  . GLY H .   ? 0.7901 0.7128 0.4797 -0.0316 0.0839  0.0670  606 GLY A CA  
+4316 C  C   . GLY H .   ? 0.8088 0.7120 0.4800 -0.0227 0.0955  0.0802  606 GLY A C   
+4317 O  O   . GLY H .   ? 0.7994 0.7219 0.4808 -0.0075 0.1014  0.0721  606 GLY A O   
+4318 O  OXT . GLY H .   ? 0.8216 0.6880 0.4748 -0.0319 0.1077  0.1070  606 GLY A OXT 
+4319 N  N   . GLY I .   ? 0.6687 0.4853 0.9559 -0.0097 -0.0119 -0.1411 607 GLY A N   
+4320 C  CA  . GLY I .   ? 0.6951 0.4790 0.9591 0.0031  -0.0047 -0.1400 607 GLY A CA  
+4321 C  C   . GLY I .   ? 0.7040 0.4225 0.9642 0.0370  0.0083  -0.1372 607 GLY A C   
+4322 O  O   . GLY I .   ? 0.6825 0.3463 0.9651 0.0578  0.0168  -0.1400 607 GLY A O   
+4323 O  OXT . GLY I .   ? 0.7171 0.3788 0.9675 0.0326  0.0121  -0.1342 607 GLY A OXT 
+4324 N  N   . GLY J .   ? 0.6485 0.5919 0.6760 0.0067  -0.2090 0.0344  608 GLY A N   
+4325 C  CA  . GLY J .   ? 0.6699 0.6563 0.6778 0.0218  -0.2069 0.0866  608 GLY A CA  
+4326 C  C   . GLY J .   ? 0.6868 0.6236 0.6796 -0.0211 -0.2090 0.1258  608 GLY A C   
+4327 O  O   . GLY J .   ? 0.7044 0.6540 0.6785 0.0208  -0.2202 0.1358  608 GLY A O   
+4328 O  OXT . GLY J .   ? 0.6822 0.5454 0.6773 -0.0944 -0.2135 0.1481  608 GLY A OXT 
+# 


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [x] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #34 

---

<!-- Start the description of the PR here -->
문제 : 
data/mmcif/assembly.py에서 _map_branch에서  BranchLink에서 BranchLinkPartner에 해당하는 branch Scheme을 찾을 때, seq_id를 key로 하는 {seq_id: Scheme} dict를 사용함. 
근데, seq_id, 즉, entity_branch_list_num이 중복되는 pdb (4MB4) 에서는 key인 seq_id가 중복되는 Scheme들이 존재하게 되어서 {seq_id : Scheme} dict가 제대로 생성되지 않고, seq_id가 중복되는 마지막 Scheme이 나머지 Scheme들 대신 branch partner에 들어가게 됨

{seq_id: Scheme} 대신에 {seq_id, mon_id: Scheme}을 사용하여 해결. 
Scheme 비교 (eq, lt, hash) 시에 기존 asym_id, seq_id에 추가로 mon_id까지 사용.

추가로 
https://github.com/seoklab/gmol-base/blob/4953b452c5b931f442ab3530d6c7f23893029009/src/gmol/base/data/mmcif/assembly.py#L610-L628
의 Branch set 생성시 똑같이 overwrite 될 수도 있을 것 같아서, Scheme의 eq, lt, hash 에 mon_id를 추가로 사용하도록 변경하였습니다. 혹시 아니라면 다시 수정하겠습니다.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `Scheme` objects are keyed/compared, which can affect de-duplication and mmCIF output ordering across assemblies; scope is limited to mmCIF branch/scheme handling but could alter downstream parsing/serialization expectations.
> 
> **Overview**
> Fixes branch mapping for mmCIF entries where `_pdbx_branch_scheme.num`/`seq_id` is not unique by keying branch schemes by `(seq_id, mon_id)` when resolving `pdbx_entity_branch_link` partners, preventing the wrong residue type from being attached.
> 
> Updates `Scheme` equality/ordering/hashing to include `mon_id`, so `set`/`dict` de-duplication used during `Assembly.to_mmcif()` no longer collapses heterogeneous schemes that share `asym_id`+`seq_id`.
> 
> Adds a regression test using `4mb4.cif` plus a minimal CCD JSON to ensure altloc-discarded branch components don’t overwrite the retained ones and that emitted `_pdbx_branch_scheme` lines keep the correct `mon_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7a408babe1479be3bf1a39b2d4500d9882afbee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->