### PR TITLE
feat(data/assembly): add b-factor to assembly writing functions

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -470,6 +470,12 @@ class Assembly(LooseModel):
 
         return data
 
+    @staticmethod
+    def _mmcif_float(value: float) -> str:
+        if not math.isfinite(value):
+            return "?"
+        return f"{value:.2f}"
+
     def count_polymer_chains(self) -> int:
         return len(self.chains) - sum(
             chain.type == MolType.Ligand for chain in self.chains.values()
@@ -719,6 +725,7 @@ class Assembly(LooseModel):
                     "Cartn_y",
                     "Cartn_z",
                     "occupancy",
+                    "B_iso_or_equiv",
                 ],
                 [
                     (
@@ -739,6 +746,7 @@ class Assembly(LooseModel):
                         f"{crd[1]:.3f}",
                         f"{crd[2]:.3f}",
                         f"{atom.occupancy:.2f}",
+                        self._mmcif_float(atom.b_factor),
                     )
                     for atom, crd in zip(self.atoms, self.coords)
                 ],
@@ -1038,6 +1046,8 @@ class Assembly(LooseModel):
                     "Cartn_x",
                     "Cartn_y",
                     "Cartn_z",
+                    "occupancy",
+                    "B_iso_or_equiv",
                 ],
                 [
                     (
@@ -1053,6 +1063,8 @@ class Assembly(LooseModel):
                         f"{crd[0]:.3f}",
                         f"{crd[1]:.3f}",
                         f"{crd[2]:.3f}",
+                        f"{atom.occupancy:.2f}",
+                        self._mmcif_float(atom.b_factor),
                     )
                     for atom, crd in zip(
                         self.atoms_of_chain(chain),

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -378,9 +378,11 @@ class _PdbAtom:
         assert len(self.res_name) <= 3
         assert len(self.element) <= 2
         assert len(self.alt_id) == 1
+        # Parser stores missing _atom_site.B_iso_or_equiv as NaN
+        self.b_factor = self.b_factor if math.isfinite(self.b_factor) else 0.0
+        assert len(f"{self.b_factor:>6.2f}") == 6
 
     def to_pdb_line(self, serial: int):
-        b = self.b_factor if math.isfinite(self.b_factor) else 0.0
         return (
             # 1-21
             f"{self.record}{serial:>5} {self.name}{self.alt_id}{self.res_name:>3} "
@@ -390,7 +392,7 @@ class _PdbAtom:
             f"   {self.coords[0]:>8.3f}{self.coords[1]:>8.3f}{self.coords[2]:>8.3f}"
             #                       6         7
             #                       12345678901234567
-            f"{self.occupancy:>6.2f}{b:>6.2f}          {self.element.upper():>2}  "
+            f"{self.occupancy:>6.2f}{self.b_factor:>6.2f}          {self.element.upper():>2}  "
         )
 
 

--- a/tests/data/mmcif/pdb_test.py
+++ b/tests/data/mmcif/pdb_test.py
@@ -1,4 +1,5 @@
 import nuri
+import pytest
 
 from gmol.base.data.mmcif import Assembly
 
@@ -11,3 +12,32 @@ def test_to_pdb(sample_assembly: Assembly):
 
     mol = mols[0]
     assert len(mol) == len(sample_assembly.atoms)
+
+
+def test_to_pdb_writes_b_factor(sample_assembly: Assembly):
+    result = sample_assembly.to_pdb()
+    atom_lines = [
+        line
+        for line in result.splitlines()
+        if line.startswith("ATOM  ") or line.startswith("HETATM")
+    ]
+    assert len(atom_lines) == len(sample_assembly.atoms)
+
+    atoms_sorted = sorted(
+        sample_assembly.atoms,
+        key=lambda atom: (atom.residue_id, atom.atom_idx),
+    )
+    expected = [f"{atom.b_factor:.2f}" for atom in atoms_sorted]
+    actual = [line[60:66].strip() for line in atom_lines]
+
+    assert actual == expected
+
+
+def test_to_pdb_raises_when_b_factor_exceeds_field_width(
+    sample_assembly: Assembly,
+):
+    assembly = sample_assembly.model_copy(deep=True)
+    assembly.atoms[0].b_factor = 1000.0
+
+    with pytest.raises(AssertionError):
+        assembly.to_pdb()

--- a/tests/data/mmcif/write_test.py
+++ b/tests/data/mmcif/write_test.py
@@ -1,10 +1,15 @@
+import math
 from collections.abc import Sequence
 from pathlib import Path
 
 import pytest
 from nuri.fmt import cif_ddl2_frame_as_dict, read_cif
 
-from gmol.base.data.mmcif import load_mmcif_single, mmcif_assemblies
+from gmol.base.data.mmcif import (
+    Assembly,
+    load_mmcif_single,
+    mmcif_assemblies,
+)
 from gmol.base.data.mmcif.write import mmcif_write_block
 
 
@@ -227,3 +232,49 @@ def test_assembly_operation_preserves_chain_auth_asym_id_mapping(
     }
 
     assert auth_by_label == {"A_1": "A", "A_2": "A"}
+
+
+def test_assembly_to_mmcif_writes_b_iso_or_equiv(sample_assembly: Assembly):
+    cif = sample_assembly.to_mmcif("1ubq")
+    rows = _parse_loop_rows(cif, "atom_site")
+    assert rows
+
+    expected = [
+        (f"{atom.b_factor:.2f}" if math.isfinite(atom.b_factor) else "?")
+        for atom in sample_assembly.atoms
+    ]
+    actual = [row["B_iso_or_equiv"] for row in rows]
+
+    assert actual == expected
+
+
+def test_assembly_to_mmcif_chain_writes_b_iso_or_equiv(
+    sample_assembly: Assembly,
+):
+    cid = next(iter(sample_assembly.chains))
+    chain = sample_assembly.chains[cid]
+
+    cif = sample_assembly.to_mmcif_chain("1ubq", cid)
+    rows = _parse_loop_rows(cif, "atom_site")
+    assert rows
+
+    atoms = list(sample_assembly.atoms_of_chain(chain))
+    expected = [
+        (f"{atom.b_factor:.2f}" if math.isfinite(atom.b_factor) else "?")
+        for atom in atoms
+    ]
+    actual = [row["B_iso_or_equiv"] for row in rows]
+
+    assert actual == expected
+
+
+def test_assembly_to_mmcif_writes_unknown_b_iso_or_equiv_as_question(
+    sample_assembly: Assembly,
+):
+    assembly = sample_assembly.model_copy(deep=True)
+    assembly.atoms[0].b_factor = float("nan")
+
+    cif = assembly.to_mmcif("1ubq")
+    rows = _parse_loop_rows(cif, "atom_site")
+    assert rows
+    assert rows[0]["B_iso_or_equiv"] == "?"


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [x] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [x] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes seoklab/casp-pipe#137

---

<!-- Start the description of the PR here -->