### PR TITLE
feat: extract ligand info from target mmCIF and write MOL2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/launch.json
 _autosummary/
+experimental/*
 
 # From Python.gitignore
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "networkx>=3.0,<4.0",
     "numpy",
+    "openbabel-wheel>=3.1.0",
     "nurikit>=0.1.0a16,<0.2.0",
     "pandas>=2.0,<3.0",
     "pydantic>=2.7,<3.0",

--- a/src/gmol/base/data/mmcif/__init__.py
+++ b/src/gmol/base/data/mmcif/__init__.py
@@ -1,3 +1,4 @@
 from .assembly import *
 from .filter import *
+from .ligand_mol2 import assembly_ligand_chains_mol2, mmcif_ligand_chains_mol2
 from .parse import *

--- a/src/gmol/base/data/mmcif/input.py
+++ b/src/gmol/base/data/mmcif/input.py
@@ -334,6 +334,16 @@ def _build_atom_data_from_ref(
     return coords, b_factors
 
 
+def build_ref_ligand_atom_coords(
+    assembly: Assembly,
+    residues: list[Residue],
+    atom_ids: list[str],
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Map assembly coordinates onto a reference ligand atom id ordering."""
+    ref_input = RefLigandInput(smiles="", atom_ids=atom_ids)
+    return _build_atom_data_from_ref(assembly, residues, ref_input)
+
+
 def _update_polymer_residue_coords(
     coords: NDArray[np.float64],
     b_factors: NDArray[np.float64],

--- a/src/gmol/base/data/mmcif/ligand_mol2.py
+++ b/src/gmol/base/data/mmcif/ligand_mol2.py
@@ -1,0 +1,73 @@
+"""Ligand chains as MOL2 (Open Babel), from mmCIF / assembly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rdkit import Chem
+from rdkit.Geometry import Point3D
+
+from gmol.base.wrapper.obabel import mol_block_to_mol2
+from .assembly import Assembly, MolType, mmcif_assemblies
+from .filter import filter_mmcif
+from .input import build_ref_ligand_atom_coords
+from .parse import ChemComp, load_mmcif_single
+from .smiles import mol_from_chem_comp, reference_from_mmcif
+
+
+def assembly_ligand_chains_mol2(assembly: Assembly) -> list[tuple[str, str]]:
+    """One MOL2 string per ligand chain (``label_asym_id`` / ``chain_id``).
+
+    Branched or multi-residue ligand chains use the same graph construction as
+    :func:`gmol.base.data.mmcif.input.process_ligand_chain`; coordinates come
+    from the assembly, bond orders and typing from RDKit then Open Babel.
+    """
+    entry = assembly.metadata.entry_id
+    out: list[tuple[str, str]] = []
+
+    for chain in assembly.chains_of_type(MolType.Ligand):
+        ccs = [
+            (residue.residue_id, residue.chem_comp)
+            for residue in assembly.residues_of_chain(chain)
+        ]
+        ref = reference_from_mmcif(ccs, chain.branches)
+        mol = mol_from_chem_comp(ref.atoms, ref.bonds)
+        atom_ids = [a.GetProp("atom_id") for a in mol.GetAtoms()]
+        residues = [assembly.residues[rid] for rid, _ in ccs]
+        coords, _ = build_ref_ligand_atom_coords(assembly, residues, atom_ids)
+
+        conf = Chem.Conformer(mol.GetNumAtoms())
+        for i in range(mol.GetNumAtoms()):
+            c = coords[i]
+            conf.SetAtomPosition(
+                i, Point3D(float(c[0]), float(c[1]), float(c[2]))
+            )
+        mol.RemoveAllConformers()
+        mol.AddConformer(conf)
+
+        mol_block = Chem.MolToMolBlock(mol, confId=0)
+        title = f"{entry}_{chain.chain_id}"
+        mol2 = mol_block_to_mol2(mol_block, title=title)
+        out.append((chain.chain_id, mol2))
+
+    return out
+
+
+def mmcif_ligand_chains_mol2(
+    mmcif_path: str | Path,
+    chem_comp_dict: dict[str, ChemComp],
+    *,
+    is_test: bool = False,
+) -> list[tuple[str, str]]:
+    """Load mmCIF, apply :func:`filter_mmcif`, return ligand-chain MOL2 strings.
+
+    If the structure fails the mmcif pre-filter, returns an empty list (same
+    idea as :func:`gmol.base.data.mmcif.input.build_input_from_mmcif`).
+    """
+    path = Path(mmcif_path)
+    metadata = load_mmcif_single(path)
+    assemblies = mmcif_assemblies(metadata, chem_comp_dict)
+    filtered = filter_mmcif(assemblies[0], chem_comp_dict, is_test=is_test)
+    if filtered is None:
+        return []
+    return assembly_ligand_chains_mol2(filtered)

--- a/src/gmol/base/wrapper/obabel.py
+++ b/src/gmol/base/wrapper/obabel.py
@@ -1,0 +1,11 @@
+"""Open Babel helpers for small-molecule file formats."""
+
+from openbabel import pybel
+
+
+def mol_block_to_mol2(mol_block: str, *, title: str | None = None) -> str:
+    """Convert an MDL mol block string to Tripos MOL2 via Open Babel."""
+    ob_mol = pybel.readstring("mol", mol_block)
+    if title is not None:
+        ob_mol.title = title
+    return ob_mol.write("mol2")

--- a/src/gmol/base/wrapper/obabel.py
+++ b/src/gmol/base/wrapper/obabel.py
@@ -6,6 +6,5 @@ from openbabel import pybel
 def mol_block_to_mol2(mol_block: str, *, title: str | None = None) -> str:
     """Convert an MDL mol block string to Tripos MOL2 via Open Babel."""
     ob_mol = pybel.readstring("mol", mol_block)
-    if title is not None:
-        ob_mol.title = title
+    ob_mol.title = title
     return ob_mol.write("mol2")

--- a/tests/data/mmcif/ligand_mol2_test.py
+++ b/tests/data/mmcif/ligand_mol2_test.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from pydantic import TypeAdapter
+
+from gmol.base.data.mmcif import (
+    ChemComp,
+    assembly_ligand_chains_mol2,
+    load_components,
+    load_mmcif_single,
+    mmcif_assemblies,
+    mmcif_ligand_chains_mol2,
+)
+
+
+def test_assembly_ligand_chains_mol2_branched_nag(test_data: Path):
+    """Branched NAG chain produces valid Open Babel MOL2 with expected title."""
+    ccd = load_components(test_data / "ccd" / "components_stdres.cif")
+    ccd.update(
+        TypeAdapter(dict[str, ChemComp]).validate_json(
+            (test_data / "ccd" / "components_4mb4.json").read_bytes()
+        )
+    )
+    data = load_mmcif_single(test_data / "mmcif" / "4mb4.cif")
+    assembly = mmcif_assemblies(data, ccd)[0]
+
+    items = assembly_ligand_chains_mol2(assembly)
+    by_id = dict(items)
+    assert "B" in by_id
+    mol2_b = by_id["B"]
+    assert "@<TRIPOS>MOLECULE" in mol2_b
+    assert "@<TRIPOS>ATOM" in mol2_b
+    assert "@<TRIPOS>BOND" in mol2_b
+    title_line = mol2_b.splitlines()[1]
+    assert title_line.endswith("_B")
+
+
+def test_mmcif_ligand_chains_mol2_filtered(test_data: Path):
+    """End-to-end mmCIF path returns one MOL2 per surviving ligand chain."""
+    ccd = load_components(test_data / "ccd" / "components_stdres.cif")
+    ccd.update(
+        TypeAdapter(dict[str, ChemComp]).validate_json(
+            (test_data / "ccd" / "components_4mb4.json").read_bytes()
+        )
+    )
+    path = test_data / "mmcif" / "4mb4.cif"
+    items = mmcif_ligand_chains_mol2(path, ccd, is_test=True)
+    assert len(items) >= 1
+    for chain_id, mol2 in items:
+        assert chain_id
+        assert mol2.startswith("@<TRIPOS>MOLECULE")

--- a/uv.lock
+++ b/uv.lock
@@ -458,6 +458,7 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'linux'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'linux'" },
     { name = "nurikit", marker = "sys_platform == 'linux'" },
+    { name = "openbabel-wheel", marker = "sys_platform == 'linux'" },
     { name = "pandas", marker = "sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'linux'" },
     { name = "rdkit", marker = "sys_platform == 'linux'" },
@@ -496,6 +497,7 @@ requires-dist = [
     { name = "networkx", specifier = ">=3.0,<4.0" },
     { name = "numpy" },
     { name = "nurikit", specifier = ">=0.1.0a16,<0.2.0" },
+    { name = "openbabel-wheel", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0,<3.0" },
     { name = "pydantic", specifier = ">=2.7,<3.0" },
     { name = "rdkit", specifier = ">=2024.3" },
@@ -1343,6 +1345,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/0a/12c3f78851c318a8b9a1fe03789e50b4eab6308774aefca7bedc1eeb383c/nurikit-0.1.0b1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b82288bf2cec9cd5b816850ccbb5657f2f4899572c182c92e8517846e1b71b", size = 3310168, upload-time = "2026-03-22T10:54:54.477Z" },
     { url = "https://files.pythonhosted.org/packages/1e/75/f16de3a9355940b3bcd0146be7b6d8054358a731af3a64800f2b5d6e70d5/nurikit-0.1.0b1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:252d4a9f8385d25a7c6ce84149aa5383ea26ccdee7514c4381a42176525661ea", size = 3310626, upload-time = "2026-03-22T10:54:59.464Z" },
     { url = "https://files.pythonhosted.org/packages/49/31/64dab486f3357d6ecdc6253972108761679d92d58701d5dd6242e2215683/nurikit-0.1.0b1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8ce17a99fbe35b7b797db53c9d9a7f25644556164f958099f66c831de761223", size = 3325633, upload-time = "2026-03-22T10:55:04.073Z" },
+]
+
+[[package]]
+name = "openbabel-wheel"
+version = "3.1.1.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/2d/720579ccff6247aa8fd2d397a7bd592dae72ef0f0133fe6cce2323ea13a2/openbabel_wheel-3.1.1.23.tar.gz", hash = "sha256:68fd86540ff0895d36b26f25721187399fb6073f874f6ae474a574e6acf8759d", size = 13256, upload-time = "2026-03-06T01:31:11.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/e6/f18330add6b58e3b1e21e8682fa85385090cb59b0ba355b8c7adf2834278/openbabel_wheel-3.1.1.23-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3dd18b2e3456792e497fcac505059317b8c0612538df1e31fa5db3165816e364", size = 15637569, upload-time = "2026-02-17T13:17:37.805Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/be/4ba14367b056b8eb71542903df00fa9e0b0e4425e633abce1424100e38d2/openbabel_wheel-3.1.1.23-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a0ce6d54af38a7380cf335acf349e9402935e3974e9b17a02400b34fe107c07a", size = 16083217, upload-time = "2026-02-17T13:17:40.462Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/2a/17ec36d9c0b90f9c7cffa2a8f79dfd2113a3ac3738742ab354360bcfadd5/openbabel_wheel-3.1.1.23-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d740d5b87e101054d2b9e2846c9d445e353ce7217b3088b2cb974c26eb40595f", size = 15637628, upload-time = "2026-02-17T13:17:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/33/69/af809769228ab7f052237ba56f4678a3e63f594c0d4f982c6293d4ad854c/openbabel_wheel-3.1.1.23-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:733ebba8a93786674d173e0651be894b2debd3cc68a2c4be62739207d51ba257", size = 16083095, upload-time = "2026-02-17T13:17:52.174Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d4/88625e94fa159c870c3ad7fb0a9a0c77be7b9ead68b2730c4b781243fe0e/openbabel_wheel-3.1.1.23-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7fa4edf22b616e6c71065bdb01f028ec6fb4821b7f788cef97edc33a916203cf", size = 15639446, upload-time = "2026-02-17T13:18:01.125Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/3e60dc173672ae40172a1f0c49fc42906d7587503f1f3acce4bd5b0cac7d/openbabel_wheel-3.1.1.23-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39340af4da11cafabb95542fd110e7ff120e3af085e4e48aa2b8e69cc49b807b", size = 16087232, upload-time = "2026-02-17T13:18:04.563Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c8/2ee60db27b572d20f2c9a4239df35f5230b1687d738b52c4b0671561f6b8/openbabel_wheel-3.1.1.23-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5395eb3fd4ce660a45c3693c65dd8155027a593c9f1fd192dccf69ed01c5295c", size = 15636511, upload-time = "2026-02-17T13:18:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/22/40/a885b253b15f95460d272a11be9aa039badbdc507dcd7f73256dca8cc339/openbabel_wheel-3.1.1.23-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b20aae66b907da10489bdee3912571d50b85986cfce8845d4f53f9c855bc2494", size = 16084796, upload-time = "2026-02-17T13:18:14.847Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d8/2cef68780788bc420b0a6c8b0f3d8bfb41cd14900cca43873c744f3d886e/openbabel_wheel-3.1.1.23-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3a9912e5b32ff3139e653db746a43ea4b7da0ce1b5b68b6e63f10f028c5d8a2d", size = 15641869, upload-time = "2026-02-17T13:18:22.976Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5c/875704cbbc314dd0c6ff0a2d689308a3d626cd64c7c6b48cf299874f484f/openbabel_wheel-3.1.1.23-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f56d0ae28e6bbbaaca483abe35dd21d4d2c7f3b1b6f602593f419b2b5f067ac", size = 16067368, upload-time = "2026-02-17T13:18:25.182Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
target mmCIF에서 ligand 정보를 추출해 mol2로 작성하는 기능 추가합니다 

## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [ ] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [ ] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes seoklab/casp-pipe#274 

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Open Babel as a new runtime dependency and introduces ligand-to-MOL2 export logic, which may affect environment setup and molecule conversion correctness (bond typing/coordinates) across platforms.
> 
> **Overview**
> Adds a new capability to export each ligand chain from an `Assembly` (or directly from an mmCIF path after `filter_mmcif`) as Tripos MOL2 strings via a new `mmcif/ligand_mol2.py` module.
> 
> Refactors ligand coordinate mapping by extracting `build_ref_ligand_atom_coords()` for reusing the existing reference-atom ordering logic, and adds a small Open Babel wrapper (`mol_block_to_mol2`) to convert RDKit mol blocks to MOL2. Includes new tests covering branched ligand chains and the end-to-end filtered mmCIF path, and updates packaging (`openbabel-wheel`) plus `.gitignore` to ignore `experimental/*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53609c644610b5f80a3e02e505931ac9cebd225a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->