### PR TITLE
fix(assembly): fix ATOM/HETATM header prob.

### DIFF
--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -1198,7 +1198,7 @@ _pdbx_struct_oper_list.vector[3]           0.0"""
             if not is_standard:
                 return "HETATM"
 
-            if residue_chem_comp.mon_nstd_flag:
+            if not residue_chem_comp.mon_nstd_flag:
                 return "HETATM"
 
             return "ATOM  "

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -409,7 +409,8 @@ class _PdbAtom:
             f"{self.res_id.chain_id}{self.res_id.seq_id:4d}{self.res_id.ins_code:1}"
             # 28-54
             f"   {self.coords[0]:>8.3f}{self.coords[1]:>8.3f}{self.coords[2]:>8.3f}"
-            # 55-80
+            #                       6         7
+            #                       12345678901234567
             f"{self.occupancy:>6.2f}{self.b_factor:>6.2f}          {self.element.upper():>2}  "
         )
 
@@ -1235,7 +1236,8 @@ _pdbx_struct_oper_list.vector[3]           0.0"""
             res_id = last_atom.res_id
             lines.append(
                 (
-                    # 1-27
+                    #                  1
+                    #                  234567
                     f"TER   {serial:5d}      {res_name:>3} "
                     f"{res_id.chain_id}{res_id.seq_id:4d}{res_id.ins_code:1}"
                 )

--- a/src/gmol/base/data/mmcif/assembly.py
+++ b/src/gmol/base/data/mmcif/assembly.py
@@ -23,7 +23,7 @@ from pydantic import (
     model_validator,
 )
 
-from gmol.base.const import CCD_NAME_TO_ONE_LETTER, aa_restype_3to1
+from gmol.base.const import CCD_NAME_TO_ONE_LETTER
 from gmol.base.types import LooseModel
 from .parse import (
     AtomSite,
@@ -409,8 +409,7 @@ class _PdbAtom:
             f"{self.res_id.chain_id}{self.res_id.seq_id:4d}{self.res_id.ins_code:1}"
             # 28-54
             f"   {self.coords[0]:>8.3f}{self.coords[1]:>8.3f}{self.coords[2]:>8.3f}"
-            #                       6         7
-            #                       12345678901234567
+            # 55-80
             f"{self.occupancy:>6.2f}{self.b_factor:>6.2f}          {self.element.upper():>2}  "
         )
 
@@ -1183,32 +1182,19 @@ _pdbx_struct_oper_list.vector[3]           0.0"""
             for name, i in atom_names.items()
         }
 
-        def _record_name_for(
-            residue_chem_comp: ChemComp,
-            atom_chain_type: MolType,
-        ) -> str:
-            if atom_chain_type in (MolType.RNA, MolType.DNA):
+        def _record_name_for(group_pdb: str) -> str:
+            record = group_pdb.strip().upper()
+            if record == "ATOM":
                 return "ATOM  "
-
-            if residue_mol_type(residue_chem_comp) != MolType.Protein:
+            if record == "HETATM":
                 return "HETATM"
-
-            comp_id = residue_chem_comp.id
-            is_standard = comp_id in aa_restype_3to1
-            if not is_standard:
-                return "HETATM"
-
-            if not residue_chem_comp.mon_nstd_flag:
-                return "HETATM"
-
-            return "ATOM  "
+            raise ValueError(
+                f"Unsupported PDB atom record type: {group_pdb!r}"
+            )
 
         chain_atoms: dict[str, list[_PdbAtom]] = defaultdict(list)
         for atom in atoms:
-            record = _record_name_for(
-                self.residues[atom.residue_id].chem_comp,
-                self.chains[atom.chain_id].type,
-            )
+            record = _record_name_for(atom.group_PDB)
 
             ch = chain_map[atom.chain_id]
             rid = ResidueId(
@@ -1249,8 +1235,7 @@ _pdbx_struct_oper_list.vector[3]           0.0"""
             res_id = last_atom.res_id
             lines.append(
                 (
-                    #                  1
-                    #                  234567
+                    # 1-27
                     f"TER   {serial:5d}      {res_name:>3} "
                     f"{res_id.chain_id}{res_id.seq_id:4d}{res_id.ins_code:1}"
                 )

--- a/tests/data/mmcif/pdb_test.py
+++ b/tests/data/mmcif/pdb_test.py
@@ -1,10 +1,18 @@
 import nuri
 import pytest
 
-from gmol.base.data.mmcif import Assembly
+from gmol.base.data.mmcif import Assembly, ResidueId
 
 
-def test_to_pdb(sample_assembly: Assembly):
+def _atom_lines(pdb_str: str) -> list[str]:
+    return [
+        line
+        for line in pdb_str.splitlines()
+        if line.startswith("ATOM  ") or line.startswith("HETATM")
+    ]
+
+
+def test_to_pdb_roundtrips(sample_assembly: Assembly):
     result = sample_assembly.to_pdb()
 
     mols = list(nuri.readstring("pdb", result, sanitize=False))
@@ -14,13 +22,37 @@ def test_to_pdb(sample_assembly: Assembly):
     assert len(mol) == len(sample_assembly.atoms)
 
 
+def test_to_pdb_writes_group_pdb_from_atoms(sample_assembly: Assembly):
+    assembly = sample_assembly.model_copy(deep=True)
+    residue_id = assembly.atoms[0].residue_id
+    residue_atoms = [
+        atom for atom in assembly.atoms if atom.residue_id == residue_id
+    ]
+
+    for atom in assembly.atoms:
+        if atom.residue_id == residue_id:
+            atom.group_PDB = "HETATM"
+
+    result = assembly.to_pdb()
+    atom_lines = _atom_lines(result)
+
+    atoms_sorted = sorted(
+        assembly.atoms,
+        key=lambda atom: (atom.residue_id, atom.atom_idx),
+    )
+    actual = [line[:6] for line in atom_lines]
+    expected = [
+        "ATOM  " if atom.group_PDB == "ATOM" else "HETATM"
+        for atom in atoms_sorted
+    ]
+
+    assert actual == expected
+    assert actual[: len(residue_atoms)] == ["HETATM"] * len(residue_atoms)
+
+
 def test_to_pdb_writes_b_factor(sample_assembly: Assembly):
     result = sample_assembly.to_pdb()
-    atom_lines = [
-        line
-        for line in result.splitlines()
-        if line.startswith("ATOM  ") or line.startswith("HETATM")
-    ]
+    atom_lines = _atom_lines(result)
     assert len(atom_lines) == len(sample_assembly.atoms)
 
     atoms_sorted = sorted(
@@ -31,6 +63,38 @@ def test_to_pdb_writes_b_factor(sample_assembly: Assembly):
     actual = [line[60:66].strip() for line in atom_lines]
 
     assert actual == expected
+
+
+def test_to_pdb_writes_insertion_code(sample_assembly: Assembly):
+    assembly = sample_assembly.model_copy(deep=True)
+    residue_id = assembly.atoms[-1].residue_id
+    residue_id_with_ins = ResidueId(
+        residue_id.chain_id,
+        residue_id.seq_id,
+        "A",
+    )
+
+    for atom in assembly.atoms:
+        if atom.residue_id == residue_id:
+            atom.residue_id = residue_id_with_ins
+
+    result = assembly.to_pdb()
+    atom_lines = _atom_lines(result)
+
+    assert atom_lines[-1][26] == "A"
+
+    ter_line = next(
+        line for line in result.splitlines() if line.startswith("TER")
+    )
+    assert ter_line[26] == "A"
+
+
+def test_to_pdb_rejects_unknown_group_pdb(sample_assembly: Assembly):
+    assembly = sample_assembly.model_copy(deep=True)
+    assembly.atoms[0].group_PDB = "ANISOU"
+
+    with pytest.raises(ValueError, match="Unsupported PDB atom record type"):
+        assembly.to_pdb()
 
 
 def test_to_pdb_raises_when_b_factor_exceeds_field_width(


### PR DESCRIPTION
## Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you checked that there aren't other open [pull requests](http://github.com/seoklab/gmol-base/pulls) for the same issue?
- [x] Have you [linked the issue(s)](#linked-issues) you are working on (if any)?

If the change is related to the source code, tests, or build environments, please also check the following:

- [x] Does `pytest -vs` pass without any errors and warnings (at the project root)?
- [x] Does `mypy --pretty` pass without any errors and warnings (at the project root)?

If you added new feature(s), then also check the following:

- [ ] Did you also add corresponding tests?

## Linked Issues

Link the tracking issue(s) of this PR, with the [auto-close keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) here:

- Closes #68

---

<!-- Start the description of the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDB export behavior to rely on per-atom `group_PDB` and now errors on unsupported record types, which could affect downstream consumers expecting the previous ATOM/HETATM inference.
> 
> **Overview**
> **PDB export now uses each atom’s mmCIF `group_PDB` value** to choose between `ATOM  ` and `HETATM`, instead of inferring the record type from residue/chain chemistry.
> 
> Adds tests that validate round-tripping via `nuri`, correct propagation of `group_PDB`, correct writing of insertion codes (including on `TER` lines), and rejection of unknown record types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8934eda258b8f199e8482b5a8bce75f6f6145ef5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->